### PR TITLE
fix(release): retry prerelease consumer metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,12 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# Release evidence manifests reference immutable command logs.
+!release-evidence/
+!release-evidence/**/
+!release-evidence/**/logs/
+!release-evidence/**/logs/*.log
+
 # Environment
 .env
 .env.local

--- a/docs/releases/v1.0.0/readiness.md
+++ b/docs/releases/v1.0.0/readiness.md
@@ -35,6 +35,15 @@ alignment check from a clean source checkout of
 release governance and external validation; it is not an approved RC or a
 publication authorization.
 
+## Current clean pre-approval verification
+
+`v1.0.0-rc.0-preapproval-1` records successful `pnpm release:check`,
+`pnpm release:inventory`, candidate-manifest validation, and roadmap-alignment
+validation from clean commit `05a57d526cad64bad78526fededa9df567840fe1`. Its
+evidence manifest passes strict `--require-success` verification. This is the
+current local pre-approval evidence, not an approved RC artifact or a
+publication authorization.
+
 ## Remaining release blockers
 
 1. Approve the G0 package/subpath scope and target version map.

--- a/docs/releases/v1.0.0/status.md
+++ b/docs/releases/v1.0.0/status.md
@@ -14,12 +14,12 @@ command results and artifact hashes belong in
 | --- | --- | --- |
 | G0 Scope/versioning | `partial` | candidate scope/manifest and inventory are recorded; approve the target map |
 | G1 Public API | `partial` | contract candidates and candidate legacy outcomes exist; public-contract approval remains |
-| G2 Core execution | `partial` | clean pre-RC evidence records the full verification suite; certify an approved RC artifact |
-| G3 Lifecycle/metrics | `partial` | a clean lifecycle report is recorded; certify the approved RC artifact |
-| G4 React contract | `partial` | React 18.3.1/19.2.8 packed SSR checks and full clean verification are recorded; external consumer certification remains |
-| G5 Tool adapters | `partial` | clean evidence covers isolation and Tool Protocol/AI SDK/WebMCP checks; external consumer certification remains |
-| G6 Consumer packages | `partial` | clean evidence covers 10 tarball contracts and local tool-consumer smoke; certify the approved RC package matrix |
-| G7 Docs/migration | `partial` | canonical scope, migration, readiness documents, packed fixture, and clean pre-RC verification exist; approval remains |
+| G2 Core execution | `partial` | clean pre-approval evidence records the full verification suite; certify an approved RC artifact |
+| G3 Lifecycle/metrics | `partial` | a current clean lifecycle report is recorded; certify the approved RC artifact |
+| G4 React contract | `partial` | React 18.3.1/19.2.8 packed SSR checks and current clean verification are recorded; external consumer certification remains |
+| G5 Tool adapters | `partial` | current clean evidence covers isolation and Tool Protocol/AI SDK/WebMCP checks; external consumer certification remains |
+| G6 Consumer packages | `partial` | current clean evidence covers 10 tarball contracts and local tool-consumer smoke; certify the approved RC package matrix |
+| G7 Docs/migration | `partial` | canonical scope, migration, readiness documents, packed fixture, and current clean pre-approval verification exist; approval remains |
 | G8 Independent audit | `not-started` | audit protocol/template are prepared; fresh-context adversarial audit is required |
 | G9 Security/supply chain | `partial` | a clean local supply-chain report is recorded; registry provenance remains |
 
@@ -60,3 +60,13 @@ tree. Its `verify-all` and roadmap-alignment commands passed, and
 `pnpm release:evidence:verify -- --require-success` passed. It proves local
 reproducibility of the pre-RC candidate only; it does not approve the candidate
 manifest or authorize publication.
+
+## Current clean pre-approval evidence
+
+`release-evidence/v1.0.0-rc.0-preapproval-1/manifest.json` was generated from
+the clean RC-preparation commit `05a57d526cad64bad78526fededa9df567840fe1`.
+It records successful `pnpm release:check`, `pnpm release:inventory`, candidate
+manifest validation, and roadmap-alignment validation, and it passes
+`pnpm release:evidence:verify -- --require-success`. It supersedes the older
+precheck as current local evidence only; the candidate manifest is still
+unapproved and this bundle does not authorize publication.

--- a/release-evidence/v1.0.0-clean-precheck-1/logs/roadmap.log
+++ b/release-evidence/v1.0.0-clean-precheck-1/logs/roadmap.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 release:roadmap:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-roadmap-alignment.mjs
+
+v1 release roadmaps aligned (6 invariants).

--- a/release-evidence/v1.0.0-clean-precheck-1/logs/verify-all.log
+++ b/release-evidence/v1.0.0-clean-precheck-1/logs/verify-all.log
@@ -1,0 +1,6120 @@
+
+> context-action-monorepo@1.0.1 verify:all /Users/junwoobang/workflow/context-action
+> pnpm build:live-code-editor && pnpm build && pnpm test:ai-sdk-integration && pnpm verify:doc-snippets && pnpm verify:core-artifact-parity && pnpm verify:react-artifact-boundary && pnpm verify:package-exports && pnpm verify:package-tarballs && pnpm package-boundary:check && pnpm package-boundary:test && pnpm verify:local-tool-consumers && pnpm verify:v1-lifecycle && pnpm verify:v1-release-manifest && pnpm verify:v1-supply-chain && pnpm tool-durable:test:evidence && pnpm lint && pnpm convention:check && pnpm docs:management && pnpm llms:check && pnpm type-check && pnpm test && pnpm --filter example check && pnpm --filter example build && pnpm docs:build && pnpm verify:private-tools
+
+
+> context-action-monorepo@1.0.1 build:live-code-editor /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/live-code-editor build
+
+
+> @context-action/live-code-editor@0.0.0 build /Users/junwoobang/workflow/context-action/packages/live-code-editor
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/live-code-editor/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24.11.0
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+
+ WARN  We recommend using the ESM format instead of CommonJS.
+The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+
+ℹ Cleaning 8 files
+ℹ [CJS] dist/index.cjs       72.86 kB │ gzip: 16.05 kB
+ℹ [CJS] dist/index.cjs.map  144.26 kB │ gzip: 30.79 kB
+ℹ [CJS] 2 files, total: 217.12 kB
+ℹ [CJS] dist/index.d.cts.map   3.01 kB │ gzip: 1.21 kB
+ℹ [CJS] dist/index.d.cts      13.00 kB │ gzip: 2.98 kB
+ℹ [CJS] 2 files, total: 16.02 kB
+ℹ [ESM] dist/index.js         72.01 kB │ gzip: 15.91 kB
+ℹ [ESM] dist/index.js.map    144.26 kB │ gzip: 30.78 kB
+ℹ [ESM] dist/index.d.ts.map    3.01 kB │ gzip:  1.21 kB
+ℹ [ESM] dist/index.d.ts       13.00 kB │ gzip:  2.98 kB
+ℹ [ESM] 4 files, total: 232.28 kB
+✔ Build complete in 521ms
+✔ Build complete in 521ms
+
+> context-action-monorepo@1.0.1 build /Users/junwoobang/workflow/context-action
+> lerna run build
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target build for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:build
+
+
+> @context-action/mutative-core:build
+
+
+> @context-action/tool-durable-operations:build
+
+
+> @context-action/typedoc-vitepress-sync:build
+
+@context-action/tool-protocol: (node:43297) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:43300) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:43298) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:43299) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:43325) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:43323) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:43327) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:43328) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 build /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > tsdown
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 build /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > tsdown
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 build /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsdown
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 build /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsdown
+@context-action/tool-durable-operations: (node:43428) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:43382) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:43356) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:43426) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/tool-durable-operations: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/tool-protocol: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/mutative-core: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/mutative-core/tsdown.config.ts[24m 
+@context-action/tool-durable-operations: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/tool-durable-operations/tsdown.config.ts[24m 
+@context-action/mutative-core: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/tool-durable-operations: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/tool-durable-operations: [34mℹ[39m target: [34mes2020[39m
+@context-action/tool-durable-operations: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/mutative-core: [34mℹ[39m target: [34mnode14.0.0[39m
+@context-action/mutative-core: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/tool-durable-operations: [34mℹ[39m Build start
+@context-action/mutative-core: [34mℹ[39m Build start
+@context-action/tool-protocol: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/tool-protocol/tsdown.config.ts[24m 
+@context-action/typedoc-vitepress-sync: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync/tsdown.config.ts[24m 
+@context-action/tool-durable-operations: [34mℹ[39m Cleaning 7 files
+@context-action/mutative-core: [34mℹ[39m Cleaning 8 files
+@context-action/tool-protocol: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/tool-protocol: [34mℹ[39m target: [34mes2020[39m
+@context-action/tool-protocol: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/tool-protocol: [34mℹ[39m Build start
+@context-action/typedoc-vitepress-sync: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m target: [34mnode24[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m Build start
+@context-action/typedoc-vitepress-sync: [34mℹ[39m Cleaning 4 files
+@context-action/tool-protocol: [34mℹ[39m Cleaning 7 files
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m      [2m 63.12 kB[22m [2m│ gzip: 13.16 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.cjs.map  [2m132.13 kB[22m [2m│ gzip: 29.66 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m 2 files, total: 195.25 kB
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m42.71 kB[22m [2m│ gzip: 9.85 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m 1 files, total: 42.71 kB
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m41.89 kB[22m [2m│ gzip: 11.34 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m 1 files, total: 41.89 kB
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22m[1mindex.js[22m        [2m 63.03 kB[22m [2m│ gzip: 15.72 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22mindex.js.map    [2m124.42 kB[22m [2m│ gzip: 29.50 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22mindex.d.ts.map  [2m  3.66 kB[22m [2m│ gzip:  1.31 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 11.80 kB[22m [2m│ gzip:  2.91 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m 4 files, total: 202.92 kB
+@context-action/typedoc-vitepress-sync: [32m✔[39m Build complete in [32m1849ms[39m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m42.14 kB[22m [2m│ gzip:  9.77 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m94.85 kB[22m [2m│ gzip: 20.86 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 3.70 kB[22m [2m│ gzip:  1.28 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m14.77 kB[22m [2m│ gzip:  2.34 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m 4 files, total: 155.46 kB
+@context-action/tool-durable-operations: [32m✔[39m Build complete in [32m1886ms[39m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 3.70 kB[22m [2m│ gzip: 1.28 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m14.77 kB[22m [2m│ gzip: 2.35 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m 2 files, total: 18.47 kB
+@context-action/tool-durable-operations: [32m✔[39m Build complete in [32m1890ms[39m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m40.37 kB[22m [2m│ gzip: 11.14 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m89.50 kB[22m [2m│ gzip: 22.52 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 4.04 kB[22m [2m│ gzip:  1.51 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m19.63 kB[22m [2m│ gzip:  4.10 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m 4 files, total: 153.53 kB
+@context-action/tool-protocol: [32m✔[39m Build complete in [32m2057ms[39m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 4.04 kB[22m [2m│ gzip: 1.51 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m19.63 kB[22m [2m│ gzip: 4.10 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m 2 files, total: 23.66 kB
+@context-action/tool-protocol: [32m✔[39m Build complete in [32m2066ms[39m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m 62.79 kB[22m [2m│ gzip: 13.09 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m132.12 kB[22m [2m│ gzip: 29.66 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m  2.95 kB[22m [2m│ gzip:  1.01 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 11.86 kB[22m [2m│ gzip:  2.62 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m 4 files, total: 209.72 kB
+@context-action/mutative-core: [32m✔[39m Build complete in [32m2118ms[39m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 2.95 kB[22m [2m│ gzip: 1.01 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m11.86 kB[22m [2m│ gzip: 2.62 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m 2 files, total: 14.81 kB
+@context-action/mutative-core: [32m✔[39m Build complete in [32m2132ms[39m
+
+> @context-action/webmcp:build
+
+
+> @context-action/core:build
+
+
+> @context-action/ai-sdk:build
+
+
+> @context-action/mutative:build
+
+@context-action/core: (node:43456) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:43457) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:43455) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:43458) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:43475) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:43478) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:43479) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:43486) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 build /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsdown
+@context-action/core: > @context-action/core@0.9.2 build /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsdown
+@context-action/webmcp: > @context-action/webmcp@0.1.0 build /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsdown
+@context-action/mutative: > @context-action/mutative@0.8.8 build /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > tsdown
+@context-action/core: (node:43537) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:43513) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:43571) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/ai-sdk: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/webmcp: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/mutative: (node:43601) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/core/tsdown.config.ts[24m 
+@context-action/core: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/core: [34mℹ[39m target: [34mes2020[39m
+@context-action/core: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/core: [34mℹ[39m Build start
+@context-action/ai-sdk: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/ai-sdk/tsdown.config.ts[24m 
+@context-action/ai-sdk: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/ai-sdk: [34mℹ[39m target: [34mes2022[39m
+@context-action/ai-sdk: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/ai-sdk: [34mℹ[39m Build start
+@context-action/core: [34mℹ[39m Cleaning 7 files
+@context-action/ai-sdk: [34mℹ[39m Cleaning 7 files
+@context-action/mutative: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/webmcp: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/webmcp/tsdown.config.ts[24m 
+@context-action/webmcp: [34mℹ[39m entry: [34msrc/index.ts, src/profiles/chrome-legacy.ts[39m
+@context-action/webmcp: [34mℹ[39m target: [34mes2022[39m
+@context-action/webmcp: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/webmcp: [34mℹ[39m Build start
+@context-action/webmcp: [34mℹ[39m Cleaning 15 files
+@context-action/mutative: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/mutative/tsdown.config.ts[24m 
+@context-action/mutative: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/mutative: [34mℹ[39m target: [34mnode24.11.0[39m
+@context-action/mutative: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/mutative: [34mℹ[39m Build start
+@context-action/mutative: [43m WARN [49m We recommend using the ESM format instead of CommonJS.
+@context-action/mutative: The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+@context-action/mutative: Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+@context-action/mutative: [34mℹ[39m Cleaning 8 files
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m      [2m24.81 kB[22m [2m│ gzip:  5.82 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.cjs.map  [2m48.54 kB[22m [2m│ gzip: 11.22 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m 2 files, total: 73.35 kB
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m113.21 kB[22m [2m│ gzip: 24.71 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m 1 files, total: 113.21 kB
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m                   [2m10.01 kB[22m [2m│ gzip: 3.23 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mprofiles/chrome-legacy.cjs[22m  [2m 0.79 kB[22m [2m│ gzip: 0.45 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m 2 files, total: 10.80 kB
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map                   [2m0.77 kB[22m [2m│ gzip: 0.41 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22mprofiles/chrome-legacy.d.cts.map  [2m0.18 kB[22m [2m│ gzip: 0.16 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m                       [2m3.47 kB[22m [2m│ gzip: 0.99 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mprofiles/chrome-legacy.d.cts[22m[39m      [2m0.52 kB[22m [2m│ gzip: 0.28 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m 4 files, total: 4.93 kB
+@context-action/webmcp: [32m✔[39m Build complete in [32m1382ms[39m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                         [2m 9.84 kB[22m [2m│ gzip: 3.18 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mprofiles/chrome-legacy.js[22m        [2m 0.74 kB[22m [2m│ gzip: 0.42 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map                     [2m23.00 kB[22m [2m│ gzip: 6.81 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mprofiles/chrome-legacy.js.map    [2m 1.48 kB[22m [2m│ gzip: 0.72 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map                   [2m 0.76 kB[22m [2m│ gzip: 0.41 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mprofiles/chrome-legacy.d.ts.map  [2m 0.17 kB[22m [2m│ gzip: 0.16 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m                       [2m 3.46 kB[22m [2m│ gzip: 0.99 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mprofiles/chrome-legacy.d.ts[22m[39m      [2m 0.52 kB[22m [2m│ gzip: 0.27 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m 8 files, total: 39.98 kB
+@context-action/webmcp: [32m✔[39m Build complete in [32m1384ms[39m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 2.22 kB[22m [2m│ gzip: 0.89 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m10.65 kB[22m [2m│ gzip: 3.00 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m 2 files, total: 12.88 kB
+@context-action/mutative: [32m✔[39m Build complete in [32m1325ms[39m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m23.43 kB[22m [2m│ gzip:  5.69 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m48.65 kB[22m [2m│ gzip: 11.23 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 2.22 kB[22m [2m│ gzip:  0.89 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m10.65 kB[22m [2m│ gzip:  3.00 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m 4 files, total: 84.95 kB
+@context-action/mutative: [32m✔[39m Build complete in [32m1329ms[39m
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 6.06 kB[22m [2m│ gzip: 2.10 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m19.81 kB[22m [2m│ gzip: 4.50 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m 2 files, total: 25.87 kB
+@context-action/core: [32m✔[39m Build complete in [32m1462ms[39m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m112.71 kB[22m [2m│ gzip: 24.64 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m268.68 kB[22m [2m│ gzip: 62.76 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m  6.06 kB[22m [2m│ gzip:  2.10 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 19.81 kB[22m [2m│ gzip:  4.49 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m 4 files, total: 407.25 kB
+@context-action/core: [32m✔[39m Build complete in [32m1471ms[39m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m6.34 kB[22m [2m│ gzip: 2.21 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m 1 files, total: 6.34 kB
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m0.49 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m2.36 kB[22m [2m│ gzip: 0.74 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m 2 files, total: 2.85 kB
+@context-action/ai-sdk: [32m✔[39m Build complete in [32m1482ms[39m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m 6.14 kB[22m [2m│ gzip: 2.16 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m14.63 kB[22m [2m│ gzip: 4.78 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 0.49 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 2.36 kB[22m [2m│ gzip: 0.74 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m 4 files, total: 23.62 kB
+@context-action/ai-sdk: [32m✔[39m Build complete in [32m1483ms[39m
+
+> @context-action/react:build
+
+@context-action/react: (node:43620) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:43627) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 build /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > NODE_ENV=production tsdown
+@context-action/react: (node:43652) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/react: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/react/tsdown.config.ts[24m 
+@context-action/react: [34mℹ[39m entry: [34msrc/index.ts, src/advanced.ts, src/utils.ts, src/react18.ts, src/tools/index.ts, src/webmcp.ts[39m
+@context-action/react: [34mℹ[39m target: [34mes2022[39m
+@context-action/react: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/react: [34mℹ[39m Build start
+@context-action/react: [34mℹ[39m Cleaning 70 files
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m             [2m71.31 kB[22m [2m│ gzip: 14.27 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mtools/index.cjs[22m       [2m43.17 kB[22m [2m│ gzip:  9.19 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1madvanced.cjs[22m          [2m 6.26 kB[22m [2m│ gzip:  1.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mwebmcp.cjs[22m            [2m 3.75 kB[22m [2m│ gzip:  1.24 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mutils.cjs[22m             [2m 1.21 kB[22m [2m│ gzip:  0.34 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mreact18.cjs[22m           [2m 0.00 kB[22m [2m│ gzip:  0.02 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mStoreRegistry.cjs     [2m51.32 kB[22m [2m│ gzip: 13.45 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.cjs     [2m15.34 kB[22m [2m│ gzip:  3.62 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mcomparison.cjs        [2m 5.25 kB[22m [2m│ gzip:  1.36 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils2.cjs            [2m 3.57 kB[22m [2m│ gzip:  1.12 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrolldown-runtime.cjs  [2m 1.09 kB[22m [2m│ gzip:  0.53 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m 11 files, total: 202.25 kB
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map                [2m 6.45 kB[22m [2m│ gzip: 2.23 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mtools/index.d.cts.map          [2m 1.74 kB[22m [2m│ gzip: 0.70 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.d.cts.map        [2m 1.25 kB[22m [2m│ gzip: 0.62 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.types.d.cts.map  [2m 1.23 kB[22m [2m│ gzip: 0.51 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mtypes.d.cts.map                [2m 1.19 kB[22m [2m│ gzip: 0.50 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mStore.d.cts.map                [2m 0.96 kB[22m [2m│ gzip: 0.50 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils.d.cts.map                [2m 0.74 kB[22m [2m│ gzip: 0.39 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22madvanced.d.cts.map             [2m 0.39 kB[22m [2m│ gzip: 0.25 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mwebmcp.d.cts.map               [2m 0.19 kB[22m [2m│ gzip: 0.17 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m                    [2m19.34 kB[22m [2m│ gzip: 4.07 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mtools/index.d.cts[22m[39m              [2m 5.91 kB[22m [2m│ gzip: 1.54 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1madvanced.d.cts[22m[39m                 [2m 2.61 kB[22m [2m│ gzip: 0.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mutils2.d.cts[22m[39m                   [2m 1.02 kB[22m [2m│ gzip: 0.40 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mwebmcp.d.cts[22m[39m                   [2m 0.63 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mreact18.d.cts[22m[39m                  [2m 0.08 kB[22m [2m│ gzip: 0.08 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mActionContext.d.cts[39m            [2m 4.37 kB[22m [2m│ gzip: 1.38 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes.d.cts[39m                    [2m 4.07 kB[22m [2m│ gzip: 1.35 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mStore.d.cts[39m                    [2m 3.19 kB[22m [2m│ gzip: 1.12 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mActionContext.types.d.cts[39m      [2m 3.11 kB[22m [2m│ gzip: 0.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mutils.d.cts[39m                    [2m 1.79 kB[22m [2m│ gzip: 0.77 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m 20 files, total: 60.26 kB
+@context-action/react: [32m✔[39m Build complete in [32m858ms[39m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                      [2m 68.72 kB[22m [2m│ gzip: 14.06 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mtools/index.js[22m                [2m 39.97 kB[22m [2m│ gzip:  9.02 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1madvanced.js[22m                   [2m  5.11 kB[22m [2m│ gzip:  1.78 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mwebmcp.js[22m                     [2m  3.65 kB[22m [2m│ gzip:  1.20 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mutils.js[22m                      [2m  0.40 kB[22m [2m│ gzip:  0.19 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mreact18.js[22m                    [2m  0.00 kB[22m [2m│ gzip:  0.02 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map                  [2m156.58 kB[22m [2m│ gzip: 33.44 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStoreRegistry.js.map          [2m103.54 kB[22m [2m│ gzip: 27.95 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtools/index.js.map            [2m 79.57 kB[22m [2m│ gzip: 17.99 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStoreRegistry.js              [2m 48.55 kB[22m [2m│ gzip: 13.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.js.map          [2m 32.51 kB[22m [2m│ gzip:  8.24 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.js              [2m 14.70 kB[22m [2m│ gzip:  3.54 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mcomparison.js.map             [2m 11.82 kB[22m [2m│ gzip:  3.59 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22madvanced.js.map               [2m  9.37 kB[22m [2m│ gzip:  3.25 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mwebmcp.js.map                 [2m  7.09 kB[22m [2m│ gzip:  2.36 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map                [2m  6.45 kB[22m [2m│ gzip:  2.23 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mcomparison.js                 [2m  4.68 kB[22m [2m│ gzip:  1.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils2.js.map                 [2m  4.14 kB[22m [2m│ gzip:  1.20 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils2.js                     [2m  3.55 kB[22m [2m│ gzip:  1.11 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtools/index.d.ts.map          [2m  1.74 kB[22m [2m│ gzip:  0.70 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.d.ts.map        [2m  1.25 kB[22m [2m│ gzip:  0.62 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.types.d.ts.map  [2m  1.23 kB[22m [2m│ gzip:  0.51 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtypes.d.ts.map                [2m  1.18 kB[22m [2m│ gzip:  0.50 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStore.d.ts.map                [2m  0.95 kB[22m [2m│ gzip:  0.50 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils.d.ts.map                [2m  0.74 kB[22m [2m│ gzip:  0.38 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22madvanced.d.ts.map             [2m  0.39 kB[22m [2m│ gzip:  0.25 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mwebmcp.d.ts.map               [2m  0.19 kB[22m [2m│ gzip:  0.17 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m                    [2m 19.34 kB[22m [2m│ gzip:  4.06 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mtools/index.d.ts[22m[39m              [2m  5.90 kB[22m [2m│ gzip:  1.54 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1madvanced.d.ts[22m[39m                 [2m  2.61 kB[22m [2m│ gzip:  0.90 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mutils2.d.ts[22m[39m                   [2m  1.02 kB[22m [2m│ gzip:  0.39 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mwebmcp.d.ts[22m[39m                   [2m  0.62 kB[22m [2m│ gzip:  0.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mreact18.d.ts[22m[39m                  [2m  0.08 kB[22m [2m│ gzip:  0.08 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mActionContext.d.ts[39m            [2m  4.37 kB[22m [2m│ gzip:  1.38 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes.d.ts[39m                    [2m  4.06 kB[22m [2m│ gzip:  1.35 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mStore.d.ts[39m                    [2m  3.19 kB[22m [2m│ gzip:  1.12 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mActionContext.types.d.ts[39m      [2m  3.11 kB[22m [2m│ gzip:  0.91 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mutils.d.ts[39m                    [2m  1.82 kB[22m [2m│ gzip:  0.78 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m 38 files, total: 654.23 kB
+@context-action/react: [32m✔[39m Build complete in [32m868ms[39m
+
+> @context-action/llms-generator:build
+
+@context-action/llms-generator: (node:43661) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:43668) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 build /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > tsdown
+@context-action/llms-generator: (node:43694) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/llms-generator: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/llms-generator/tsdown.config.ts[24m 
+@context-action/llms-generator: [34mℹ[39m entry: [34msrc/index.ts, src/cli/index.ts[39m
+@context-action/llms-generator: [34mℹ[39m target: [34mnode24[39m
+@context-action/llms-generator: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/llms-generator: [34mℹ[39m Build start
+@context-action/llms-generator: [34mℹ[39m Cleaning 10 files
+@context-action/llms-generator: [34mℹ[39m Granting execute permission to [4mdist/cli/index.js[24m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[1mcli/index.js[22m        [2m186.78 kB[22m [2m│ gzip: 41.50 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[1mindex.js[22m            [2m  0.13 kB[22m [2m│ gzip:  0.11 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mcli/index.js.map    [2m377.59 kB[22m [2m│ gzip: 82.14 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22msrc.js.map          [2m 36.89 kB[22m [2m│ gzip:  7.87 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22msrc.js              [2m 20.92 kB[22m [2m│ gzip:  4.89 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mindex.d.ts.map      [2m  1.76 kB[22m [2m│ gzip:  0.60 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mcli/index.d.ts.map  [2m  0.11 kB[22m [2m│ gzip:  0.12 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m          [2m  7.05 kB[22m [2m│ gzip:  2.06 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[32m[1mcli/index.d.ts[22m[39m      [2m  0.14 kB[22m [2m│ gzip:  0.13 kB[22m
+@context-action/llms-generator: [34mℹ[39m 9 files, total: 631.36 kB
+@context-action/llms-generator: [32m✔[39m Build complete in [32m675ms[39m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target build for 10 projects
+
+
+
+> context-action-monorepo@1.0.1 test:ai-sdk-integration /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/tool-protocol build && pnpm --filter @context-action/ai-sdk build && node scripts/verify-ai-sdk-runtime.mjs
+
+
+> @context-action/tool-protocol@0.8.9 build /Users/junwoobang/workflow/context-action/packages/tool-protocol
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/tool-protocol/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2020
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  41.89 kB │ gzip: 11.34 kB
+ℹ [CJS] 1 files, total: 41.89 kB
+ℹ [CJS] dist/index.d.cts.map   4.04 kB │ gzip: 1.51 kB
+ℹ [CJS] dist/index.d.cts      19.63 kB │ gzip: 4.10 kB
+ℹ [CJS] 2 files, total: 23.66 kB
+✔ Build complete in 698ms
+ℹ [ESM] dist/index.js        40.37 kB │ gzip: 11.14 kB
+ℹ [ESM] dist/index.js.map    89.50 kB │ gzip: 22.52 kB
+ℹ [ESM] dist/index.d.ts.map   4.04 kB │ gzip:  1.51 kB
+ℹ [ESM] dist/index.d.ts      19.63 kB │ gzip:  4.10 kB
+ℹ [ESM] 4 files, total: 153.53 kB
+✔ Build complete in 699ms
+
+> @context-action/ai-sdk@0.1.0 build /Users/junwoobang/workflow/context-action/packages/ai-sdk
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/ai-sdk/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2022
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  6.34 kB │ gzip: 2.21 kB
+ℹ [CJS] 1 files, total: 6.34 kB
+ℹ [CJS] dist/index.d.cts.map  0.49 kB │ gzip: 0.32 kB
+ℹ [CJS] dist/index.d.cts      2.36 kB │ gzip: 0.74 kB
+ℹ [CJS] 2 files, total: 2.85 kB
+✔ Build complete in 808ms
+ℹ [ESM] dist/index.js         6.14 kB │ gzip: 2.16 kB
+ℹ [ESM] dist/index.js.map    14.63 kB │ gzip: 4.78 kB
+ℹ [ESM] dist/index.d.ts.map   0.49 kB │ gzip: 0.32 kB
+ℹ [ESM] dist/index.d.ts       2.36 kB │ gzip: 0.74 kB
+ℹ [ESM] 4 files, total: 23.62 kB
+✔ Build complete in 809ms
+AI SDK runtime integration passed
+
+> context-action-monorepo@1.0.1 verify:doc-snippets /Users/junwoobang/workflow/context-action
+> node scripts/verify-doc-snippets.mjs
+
+Documentation snippets compiled: 2
+
+> context-action-monorepo@1.0.1 verify:core-artifact-parity /Users/junwoobang/workflow/context-action
+> node scripts/verify-core-artifact-parity.mjs
+
+Verified core ESM/CJS runtime parity for diagnostics, limits, conditions, and timeout validation.
+
+> context-action-monorepo@1.0.1 verify:react-artifact-boundary /Users/junwoobang/workflow/context-action
+> node scripts/verify-react-artifact-boundary.mjs
+
+Verified React production artifact boundaries: default entry is tool-free and tools entry is explicit.
+
+> context-action-monorepo@1.0.1 verify:package-exports /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-exports.mjs
+
+
+@context-action/ai-sdk
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/core
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/llms-generator
+  ✓ . import -> ./dist/index.js [ESM loaded]
+  ✓ . types -> ./dist/index.d.ts
+  ✓ ./cli import -> ./dist/cli/index.js [ESM loaded]
+  ✓ ./cli types -> ./dist/cli/index.d.ts
+
+@context-action/mutative
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/mutative-core
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/react
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+  ✓ ./advanced import/types -> ./dist/advanced.d.ts
+  ✓ ./advanced import/default -> ./dist/advanced.js [ESM loaded]
+  ✓ ./advanced require/types -> ./dist/advanced.d.cts
+  ✓ ./advanced require/default -> ./dist/advanced.cjs [CJS loaded]
+  ✓ ./utils import/types -> ./dist/utils.d.ts
+  ✓ ./utils import/default -> ./dist/utils.js [ESM loaded]
+  ✓ ./utils require/types -> ./dist/utils.d.cts
+  ✓ ./utils require/default -> ./dist/utils.cjs [CJS loaded]
+  ✓ ./react18 import/types -> ./dist/react18.d.ts
+  ✓ ./react18 import/default -> ./dist/react18.js [ESM loaded]
+  ✓ ./react18 require/types -> ./dist/react18.d.cts
+  ✓ ./react18 require/default -> ./dist/react18.cjs [CJS loaded]
+  ✓ ./tools import/types -> ./dist/tools/index.d.ts
+  ✓ ./tools import/default -> ./dist/tools/index.js [ESM loaded]
+  ✓ ./tools require/types -> ./dist/tools/index.d.cts
+  ✓ ./tools require/default -> ./dist/tools/index.cjs [CJS loaded]
+  ✓ ./webmcp import/types -> ./dist/webmcp.d.ts
+  ✓ ./webmcp import/default -> ./dist/webmcp.js [ESM loaded]
+  ✓ ./webmcp require/types -> ./dist/webmcp.d.cts
+  ✓ ./webmcp require/default -> ./dist/webmcp.cjs [CJS loaded]
+
+@context-action/tool-durable-operations
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/tool-protocol
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/typedoc-vitepress-sync
+  ✓ . import -> ./dist/index.js [ESM loaded]
+  ✓ . types -> ./dist/index.d.ts
+  ✓ ./cli import -> ./bin/cli.js [runtime load skipped: executable CLI]
+
+@context-action/webmcp
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+  ✓ ./profiles/chrome-legacy import/types -> ./dist/profiles/chrome-legacy.d.ts
+  ✓ ./profiles/chrome-legacy import/default -> ./dist/profiles/chrome-legacy.js [ESM loaded]
+  ✓ ./profiles/chrome-legacy require/types -> ./dist/profiles/chrome-legacy.d.cts
+  ✓ ./profiles/chrome-legacy require/default -> ./dist/profiles/chrome-legacy.cjs [CJS loaded]
+
+Verified 10 packages, 63 export targets, and 31 runtime loads.
+
+> context-action-monorepo@1.0.1 verify:package-tarballs /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-tarballs.mjs
+
+
+@context-action/ai-sdk
+  ✓ context-action-ai-sdk-0.1.0.tgz (10 files, 7 manifest targets)
+
+@context-action/core
+  ✓ context-action-core-0.9.2.tgz (10 files, 7 manifest targets)
+
+@context-action/llms-generator
+  ✓ context-action-llms-generator-0.8.7.tgz (17 files, 7 manifest targets)
+
+@context-action/mutative
+  ✓ context-action-mutative-0.8.8.tgz (11 files, 7 manifest targets)
+
+@context-action/mutative-core
+  ✓ context-action-mutative-core-0.8.8.tgz (13 files, 7 manifest targets)
+
+@context-action/react
+  ✓ context-action-react-0.9.2.tgz (72 files, 27 manifest targets)
+
+@context-action/tool-durable-operations
+  ✓ context-action-tool-durable-operations-0.1.1.tgz (20 files, 8 manifest targets)
+
+@context-action/tool-protocol
+  ✓ context-action-tool-protocol-0.8.9.tgz (11 files, 7 manifest targets)
+
+@context-action/typedoc-vitepress-sync
+  ✓ context-action-typedoc-vitepress-sync-0.8.8.tgz (8 files, 6 manifest targets)
+
+@context-action/webmcp
+  ✓ context-action-webmcp-0.1.0.tgz (17 files, 11 manifest targets)
+
+Verified 10 npm package tarballs against their package publication contracts.
+
+> context-action-monorepo@1.0.1 package-boundary:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-boundaries.mjs
+
+Workspace package-boundary verification
+- workspace packages: 13
+- integration hosts: 2
+- source files scanned: 949
+- workspace imports checked: 300
+- violations: 0
+
+> context-action-monorepo@1.0.1 package-boundary:test /Users/junwoobang/workflow/context-action
+> node --test scripts/verify-package-boundaries.test.mjs
+
+✔ accepts declared workspace imports through exported entry points (186.561708ms)
+✔ rejects missing declarations and private workspace subpath imports (204.384209ms)
+✔ allows development-only imports in tests but rejects them from runtime source (406.746791ms)
+✔ rejects relative imports that escape an owning package (207.891084ms)
+ℹ tests 4
+ℹ suites 0
+ℹ pass 4
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 1059.903292
+
+> context-action-monorepo@1.0.1 verify:local-tool-consumers /Users/junwoobang/workflow/context-action
+> node scripts/verify-published-tool-consumers.cjs --local
+
+
+added 20 packages in 2s
+published tool package consumer imports passed: @context-action/core, @context-action/mutative-core, @context-action/mutative, @context-action/tool-protocol, @context-action/tool-durable-operations, @context-action/react/tools, @context-action/ai-sdk, @context-action/webmcp
+Local tarball tool package consumer smoke test passed: file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-hoq0Ka/local-packages/context-action-core-0.9.2.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-hoq0Ka/local-packages/context-action-mutative-core-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-hoq0Ka/local-packages/context-action-mutative-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-hoq0Ka/local-packages/context-action-tool-protocol-0.8.9.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-hoq0Ka/local-packages/context-action-tool-durable-operations-0.1.1.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-hoq0Ka/local-packages/context-action-react-0.9.2.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-hoq0Ka/local-packages/context-action-ai-sdk-0.1.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-hoq0Ka/local-packages/context-action-webmcp-0.1.0.tgz, react@19.2.8, ai@7.0.34, typescript@6.0.3
+
+> context-action-monorepo@1.0.1 verify:v1-lifecycle /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-lifecycle-contract.mjs
+
+Wrote passed lifecycle report to reports/release/v1.0.0/test-results/lifecycle-report.json
+
+> context-action-monorepo@1.0.1 verify:v1-release-manifest /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-manifest.mjs
+
+{"status":"ok","manifest":"docs/releases/v1.0.0/release-manifest.json","stage":"candidate-unapproved"}
+
+> context-action-monorepo@1.0.1 verify:v1-supply-chain /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-supply-chain.mjs
+
+Wrote passed supply-chain report to reports/release/v1.0.0/security-report.json
+
+> context-action-monorepo@1.0.1 tool-durable:test:evidence /Users/junwoobang/workflow/context-action
+> node --test scripts/verify-durable-operation-evidence-schema.test.mjs
+
+✔ complete evidence passes the strict deployment gate (140.393667ms)
+✔ schema-valid incomplete evidence is rejected by the strict gate (210.607083ms)
+ℹ tests 2
+ℹ suites 0
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 425.811833
+
+> context-action-monorepo@1.0.1 lint /Users/junwoobang/workflow/context-action
+> biome lint packages/core/src packages/tool-protocol/src packages/ai-sdk/src packages/webmcp/src packages/tool-durable-operations/src packages/react/src packages/mutative-core/src packages/mutative/src packages/llms-generator/src packages/typedoc-vitepress-sync/src scripts/security-audit.mjs scripts/verify-private-tools.mjs scripts/verify-package-boundaries.mjs scripts/verify-package-boundaries.test.mjs scripts/verify-durable-operation-evidence-schema.mjs scripts/verify-durable-operation-evidence-schema.test.mjs scripts/verify-ai-sdk-runtime.mjs scripts/verify-doc-snippets.mjs scripts/verify-react-compatibility.mjs scripts/verify-react-artifact-boundary.mjs scripts/verify-core-artifact-parity.mjs scripts/write-release-evidence.mjs scripts/verify-release-evidence.mjs scripts/release-evidence.test.mjs scripts/generate-release-inventory.mjs scripts/verify-v1-release-roadmap-alignment.mjs scripts/verify-react-webmcp-isolation.mjs scripts/verify-v1-core-migration-fixture.mjs scripts/verify-v1-lifecycle-contract.mjs scripts/verify-v1-release-manifest.mjs scripts/verify-v1-supply-chain.mjs
+
+Checked 161 files in 110ms. No fixes applied.
+
+> context-action-monorepo@1.0.1 convention:check /Users/junwoobang/workflow/context-action
+> node scripts/check-context-layered-conventions.mjs
+
+Context-Layered convention check
+- transitional direct registrations: 0 file(s)
+- stale transitional allowlist entries: 0 file(s)
+- invalid direct registrations: 0 file(s)
+- provider-order violations: 0 occurrence(s)
+- canonical layered roots: 31
+- layer-path/name violations: 0 occurrence(s)
+- classified non-canonical handler roots: 2 (advanced 1, compatibility 1)
+- migration classification violations: 0 occurrence(s)
+
+> context-action-monorepo@1.0.1 docs:management /Users/junwoobang/workflow/context-action
+> node scripts/verify-documentation-management.mjs
+
+Documentation management verification
+- paired directories checked: 3
+- issue forms checked: 3
+- convention discovery links checked: en, ko
+- change-management metadata and handoff checklist checked: en, ko
+- decision-record home and package-boundary gate checked: en, ko
+
+> context-action-monorepo@1.0.1 llms:check /Users/junwoobang/workflow/context-action
+> node packages/llms-generator/dist/cli/index.js detect-mismatches --check-only --fail-on-mismatch
+
+
+> context-action-monorepo@1.0.1 type-check /Users/junwoobang/workflow/context-action
+> lerna run type-check
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target type-check for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:type-check
+
+
+> @context-action/mutative-core:type-check
+
+
+> @context-action/tool-durable-operations:type-check
+
+
+> @context-action/typedoc-vitepress-sync:type-check
+
+@context-action/mutative-core: (node:46196) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:46195) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:46197) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:46198) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:46216) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:46222) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:46225) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:46226) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 type-check /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > tsc --noEmit
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 type-check /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > tsc --noEmit
+@context-action/tool-durable-operations: (node:46352) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:46338) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 type-check:src /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsc --noEmit
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 type-check:src /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsc --noEmit
+
+> @context-action/mutative:type-check
+
+@context-action/tool-durable-operations: (node:46430) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 test:type-check /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/tool-protocol: (node:46437) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:46438) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 test:type-check /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/mutative: (node:46510) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: > @context-action/mutative@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > tsc --noEmit
+
+> @context-action/core:type-check
+
+
+> @context-action/webmcp:type-check
+
+
+> @context-action/ai-sdk:type-check
+
+@context-action/ai-sdk: (node:46873) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:46872) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:46871) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:46886) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:46900) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:46899) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/webmcp: > @context-action/webmcp@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/core: > @context-action/core@0.9.2 type-check /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/ai-sdk: (node:46989) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:46994) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:46996) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 type-check:src /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsc --noEmit
+@context-action/webmcp: > @context-action/webmcp@0.1.0 type-check:src /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsc --noEmit
+@context-action/core: > @context-action/core@0.9.2 type-check:src /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsc --noEmit
+@context-action/core: (node:47103) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:47110) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: > @context-action/core@0.9.2 test:type-check /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/webmcp: (node:47117) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 test:type-check /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/webmcp: > @context-action/webmcp@0.1.0 test:type-check /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsc -p __tests__/tsconfig.json --pretty false
+
+> @context-action/react:type-check
+
+@context-action/react: (node:47218) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:47225) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 type-check /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/react: (node:47257) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 type-check:src /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > tsc --noEmit
+@context-action/react: (node:47301) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 test:type-check /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > tsc -p __tests__/tsconfig.json --pretty false
+
+> @context-action/llms-generator:type-check
+
+@context-action/llms-generator: (node:47673) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:47680) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 type-check /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > tsc --noEmit
+
+
+
+ Lerna (powered by Nx)   Successfully ran target type-check for 10 projects
+
+
+
+> context-action-monorepo@1.0.1 test /Users/junwoobang/workflow/context-action
+> lerna run test
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target test for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:test
+
+
+> @context-action/mutative-core:test
+
+
+> @context-action/tool-durable-operations:test
+
+
+> @context-action/typedoc-vitepress-sync:test
+
+@context-action/tool-durable-operations: (node:47761) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:47760) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:47759) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:47762) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:47785) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:47788) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:47790) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:47791) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 test /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 test /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 test /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > vitest run --config vitest.config.ts
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 test /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > jest
+@context-action/mutative-core: (node:47868) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:47844) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:47819) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:47906) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core:  RUN  v4.1.10 /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: (node:48082) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:48079) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:48085) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:48081) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:48083) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:48084) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:48086) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:48087) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:48080) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:48089) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:48091) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:48090) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:48088) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-hanging/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: ./reports/typedoc-vitepress-sync-metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.09s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: ./reports/typedoc-vitepress-sync-metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Package directory not found: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat SidebarGenerator.warn [as parseApiStructure] ([22m[2msrc/processors/SidebarGenerator.ts[2m:37:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.parseApiStructure [as sync] ([22m[2msrc/index.ts[2m:184:50)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:96:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.09s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 0
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/mutative-core:  Test Files  4 passed (4)
+@context-action/mutative-core:       Tests  29 passed (29)
+@context-action/mutative-core:    Start at  12:09:41
+@context-action/mutative-core:    Duration  1.56s (transform 3.39s, setup 165ms, import 4.01s, tests 50ms, environment 0ms)
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/tool-protocol: [1mTest Suites: [22m[1m[32m5 passed[39m[22m, 5 total
+@context-action/tool-protocol: [1mTests:       [22m[1m[32m57 passed[39m[22m, 57 total
+@context-action/tool-protocol: [1mSnapshots:   [22m0 total
+@context-action/tool-protocol: [1mTime:[22m        1.662 s
+@context-action/tool-protocol: [2mRan all test suites[22m[2m.[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/source/packages/test-package/test.md: Error: EACCES: permission denied, mkdir '/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test'[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:116:9)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Package directory not found: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat SidebarGenerator.warn [as parseApiStructure] ([22m[2msrc/processors/SidebarGenerator.ts[2m:37:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.parseApiStructure [as sync] ([22m[2msrc/index.ts[2m:184:50)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:116:9)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.03s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.15s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/source/packages/test-package/test.md: ENOSPC: no space left on device[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Recovery: No space left on device
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] 💡 Tip: Free up disk space and try again[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.error [as action] ([22m[2msrc/core/ErrorHandler.ts[2m:33:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.action [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:83:23)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest loaded: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 3
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 50.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 3
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/source/packages/test-package/huge.md: Markdown file exceeds the 8388608 byte processing limit: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/source/packages/test-package/huge.md[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:177:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 2 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 2
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 2
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+
+> @context-action/mutative:test
+
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest loaded: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed 1 stale generated API file(s) from .test-sync/target/test
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 2 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 2
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 40.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 2
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 4 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 4
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 4
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in .test-sync/target/test/problematic.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/TypeDocVitePressSync.test.ts[39m[0m[2m:196:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:310:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 4 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 4
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.03s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 4
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in .test-sync/target/test/bad.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🧹 Cleaning cache and generated files...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache cleared
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed target directory: .test-sync/target
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed sidebar config: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] ✅ Cleanup completed
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Auto-configured parallel processing: batchSize=18, maxWorkers=8
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Auto-optimization configured
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-0.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-1.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-10.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-11.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-12.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-13.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-14.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-15.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-16.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-17.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-18.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-19.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-2.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-20.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-21.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-22.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-23.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-24.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-25.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-26.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-27.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-28.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-29.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-3.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+
+> @context-action/core:test
+
+
+> @context-action/webmcp:test
+
+
+> @context-action/ai-sdk:test
+
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-30.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-31.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-32.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-33.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-34.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-35.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-36.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-37.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-38.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-39.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-4.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-40.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-41.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-42.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-43.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-44.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-45.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-46.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-47.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-48.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-49.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-5.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-50.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-51.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-52.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-53.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-54.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-55.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-56.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-57.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-58.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-59.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-6.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-60.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-61.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-62.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-63.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-64.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-65.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-66.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-67.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-68.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-69.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-7.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-70.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-71.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-72.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-73.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-74.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-75.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-76.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-77.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-78.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-79.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-8.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-80.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-81.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-82.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/mutative: (node:48096) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-83.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-84.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-85.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-86.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-87.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-88.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-89.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-9.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-90.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-91.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-92.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-93.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-94.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-95.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-96.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-97.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-98.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test-99.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 100 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 100
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.33s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 100
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 100
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/tool-durable-operations: [1mTest Suites: [22m[1m[32m9 passed[39m[22m, 9 total
+@context-action/tool-durable-operations: [1mTests:       [22m[1m[33m2 skipped[39m[22m, [1m[32m43 passed[39m[22m, 45 total
+@context-action/tool-durable-operations: [1mSnapshots:   [22m0 total
+@context-action/tool-durable-operations: [1mTime:[22m        [1m[33m2.159 s[39m[22m
+@context-action/tool-durable-operations: [2mRan all test suites[22m[2m.[22m
+@context-action/core: (node:48097) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/ai-sdk: (node:48099) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:48098) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 50 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 50
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.10s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 50
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Transient write failure for /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test.md; retrying (1/3)[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.warn [as writeFileWithRetry] ([22m[2msrc/core/FileProcessor.ts[2m:281:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.writeFileWithRetry [as processFile] ([22m[2msrc/core/FileProcessor.ts[2m:104:12)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:404:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Transient write failure for /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/target/test/test.md; retrying (2/3)[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.warn [as writeFileWithRetry] ([22m[2msrc/core/FileProcessor.ts[2m:281:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.writeFileWithRetry [as processFile] ([22m[2msrc/core/FileProcessor.ts[2m:104:12)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:404:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/source/packages/test-package/test.md: EACCES: permission denied[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:439:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Recovery: Permission denied
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] 💡 Tip: Check file permissions or run with appropriate privileges[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.warn [as action] ([22m[2msrc/core/ErrorHandler.ts[2m:26:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.action [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:83:23)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:439:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/source/packages/test-package/valid.md: Simulated failure[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:471:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-48085/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [1mTest Suites: [22m[1m[33m1 skipped[39m[22m, [1m[32m8 passed[39m[22m, 8 of 9 total
+@context-action/typedoc-vitepress-sync: [1mTests:       [22m[1m[33m15 skipped[39m[22m, [1m[32m113 passed[39m[22m, 128 total
+@context-action/typedoc-vitepress-sync: [1mSnapshots:   [22m0 total
+@context-action/typedoc-vitepress-sync: [1mTime:[22m        2.441 s
+@context-action/typedoc-vitepress-sync: [2mRan all test suites[22m[2m.[22m
+@context-action/core: (node:48113) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:48106) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:48122) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:48128) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: > @context-action/core@0.9.2 test /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/mutative: > @context-action/mutative@0.8.8 test /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > vitest run
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 test /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > jest --runInBand
+@context-action/webmcp: > @context-action/webmcp@0.1.0 test /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > jest --runInBand
+@context-action/mutative: (node:48185) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:48161) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:48234) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:48245) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative:  RUN  v4.1.10 /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: (node:48303) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:48310) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:48311) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:48312) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: [1mTest Suites: [22m[1m[32m1 passed[39m[22m, 1 total
+@context-action/ai-sdk: [1mTests:       [22m[1m[32m15 passed[39m[22m, 15 total
+@context-action/ai-sdk: [1mSnapshots:   [22m0 total
+@context-action/ai-sdk: [1mTime:[22m        0.351 s, estimated 1 s
+@context-action/ai-sdk: [2mRan all test suites[22m[2m.[22m
+@context-action/mutative:  Test Files  4 passed (4)
+@context-action/mutative:       Tests  40 passed (40)
+@context-action/mutative:    Start at  12:09:44
+@context-action/mutative:    Duration  555ms (transform 859ms, setup 0ms, import 1.13s, tests 66ms, environment 1ms)
+@context-action/webmcp: [1mTest Suites: [22m[1m[32m2 passed[39m[22m, 2 total
+@context-action/webmcp: [1mTests:       [22m[1m[32m18 passed[39m[22m, 18 total
+@context-action/webmcp: [1mSnapshots:   [22m0 total
+@context-action/webmcp: [1mTime:[22m        0.467 s, estimated 1 s
+@context-action/webmcp: [2mRan all test suites[22m[2m.[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:50.729Z] [DebugRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'parallel',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:50.733Z] [DebugRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.243Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.246Z] [ConcurrencyTest] Handler registered: updateUser {
+@context-action/core:       handlerId: 'updateUser_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.248Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.249Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.249Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.250Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.251Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.253Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.255Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.256Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.257Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.258Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.259Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.259Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.260Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.263Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.264Z] [ConcurrencyTest] Handler registered: updateUI { handlerId: 'ui-updater', priority: 60, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.264Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.265Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.265Z] [ConcurrencyTest] Handler registered: searchUsers { handlerId: 'user-search', priority: 80, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.266Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.267Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.267Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.268Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.269Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.271Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.285Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.286Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.288Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-0', priority: undefined, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.288Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-1', priority: undefined, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.289Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-2', priority: undefined, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.289Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-0', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.289Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-1', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.290Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-2', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.290Z] [ConcurrencyTest] Pipeline lookup for 'test' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.290Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.291Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.292Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.292Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.293Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.293Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.295Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.301Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Sequential: 0.00ms, Parallel: 0.00ms
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-docs-simple.test.ts[39m[0m[2m:456:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.302Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.303Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.304Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: 50,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.304Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_2',
+@context-action/core:       priority: 100,
+@context-action/core:       totalHandlers: 2
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.305Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.306Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.307Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler1', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.307Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler2', priority: 200, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.307Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler3', priority: 50, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.308Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.560Z] [ActionRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.563Z] [ActionRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.592Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.595Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.596Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.598Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.598Z] [TypeOnlyTestRegister] Pipeline lookup for 'anotherTypeOnly' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.599Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.600Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.601Z] [TypeOnlyTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.601Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.602Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.603Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.604Z] [TypeOnlyTestRegister] Handler registered: userLogout { handlerId: 'logout-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.604Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin', 'userLogout' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.605Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.606Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.606Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.607Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.607Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.608Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.608Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.609Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.610Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.610Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.612Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.613Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.613Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.614Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.615Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.635Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.638Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.639Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.640Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.641Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.641Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.642Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.642Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.643Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.644Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.645Z] [WarningTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.645Z] [WarningTestRegister] Pipeline lookup for 'userLogout' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.646Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.649Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.649Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.650Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.651Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.651Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.652Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.653Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.654Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.655Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.656Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.657Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.657Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.657Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.658Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.659Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.659Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.660Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.665Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.666Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.667Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.668Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.668Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.669Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.860Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.862Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Starting Promise.all operations...
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:48:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 completed { id: 1, timestamp: 1786244991864 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 completed { id: 2, timestamp: 1786244991865 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 completed { id: 3, timestamp: 1786244991866 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.867Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.868Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.868Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.869Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.871Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.872Z] [AsyncConcurrencyTest] Handler registered: syncTest { handlerId: 'sync-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.872Z] [AsyncConcurrencyTest] Handler registered: asyncTest { handlerId: 'async-handler', priority: 50, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.873Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.874Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.875Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:09:51.876Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [1mTest Suites: [22m[1m[32m34 passed[39m[22m, 34 total
+@context-action/core: [1mTests:       [22m[1m[32m766 passed[39m[22m, 766 total
+@context-action/core: [1mSnapshots:   [22m0 total
+@context-action/core: [1mTime:[22m        7.474 s, estimated 8 s
+@context-action/core: [2mRan all test suites[22m[2m.[22m
+
+> @context-action/react:test
+
+@context-action/react: (node:48435) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48442) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 test /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > jest
+@context-action/react: (node:48467) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48536) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48535) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48539) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48543) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48545) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48544) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48542) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48538) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48541) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48537) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:48540) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Business Logic Separation Proof:
+@context-action/react:           - Validation: Pure function, no dependencies
+@context-action/react:           - Upload: Async operation with callbacks
+@context-action/react:           - Progress tracking: 11 updates
+@context-action/react:           - Result: file_1786244995304
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:203:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Async State Machine Proof:
+@context-action/react:           - State transitions: validating → uploading → processing → complete
+@context-action/react:           - Progress updates: 11 notifications
+@context-action/react:           - State renders: 5
+@context-action/react:           - Progress renders: 12
+@context-action/react:           - Status renders: 6
+@context-action/react:           - Pattern: Direct mutation + notifyPath for selective updates
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:305:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Progress-Only Update Proof:
+@context-action/react:           - Progress updates: 10
+@context-action/react:           - Progress renders: 10 (selective)
+@context-action/react:           - State renders: 0 (not affected)
+@context-action/react:           - Efficiency: 100% (no wasted renders)
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:361:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Modular Business Logic Integration Proof:
+@context-action/react:     
+@context-action/react:           Business Logic Layer:
+@context-action/react:           - FileUploadService: Pure business logic (validation, upload, processing)
+@context-action/react:           - No React/store dependencies in business code
+@context-action/react:     
+@context-action/react:           State Management Layer:
+@context-action/react:           - TimeTravelStore with mutable mode
+@context-action/react:           - Direct mutation + notifyPath pattern
+@context-action/react:           - Path-based selective updates
+@context-action/react:     
+@context-action/react:           Rendering Efficiency:
+@context-action/react:           - Files list renders: 3 (only when files change)
+@context-action/react:           - Active upload renders: 8 (only when active upload changes)
+@context-action/react:           - Progress updates: 5 (no files list re-renders)
+@context-action/react:     
+@context-action/react:           Architecture Benefits:
+@context-action/react:           - ✅ Business logic testable in isolation
+@context-action/react:           - ✅ State management decoupled from business logic
+@context-action/react:           - ✅ Selective re-rendering prevents wasted renders
+@context-action/react:           - ✅ Batch updates with notifyPaths for efficiency
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:483:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Error State Management Proof:
+@context-action/react:           - Business logic validation: File size check
+@context-action/react:           - State transition: idle → error
+@context-action/react:           - Error message: "File size exceeds 10MB limit"
+@context-action/react:           - Selective rendering: Only state + error paths updated
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:563:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Complex Multi-file Upload Queue Proof:
+@context-action/react:     
+@context-action/react:           Queue Management:
+@context-action/react:           - Files processed: 3
+@context-action/react:           - Failed uploads: 0
+@context-action/react:           - Queue size: 3
+@context-action/react:     
+@context-action/react:           State Updates:
+@context-action/react:           - Per-file state transitions: idle → uploading → complete
+@context-action/react:           - Per-file progress updates: 5 updates per file
+@context-action/react:           - Global processing state: true → false
+@context-action/react:           - Current index tracking: -1 → 0 → 1 → 2 → -1
+@context-action/react:     
+@context-action/react:           Performance Benefits:
+@context-action/react:           - Selective path updates (queue[i].progress only)
+@context-action/react:           - Batch updates with notifyPaths
+@context-action/react:           - No unnecessary re-renders of other queue items
+@context-action/react:     
+@context-action/react:           Business Logic:
+@context-action/react:           - Queue orchestration separated from UI
+@context-action/react:           - State machine per file
+@context-action/react:           - Progress tracking independent of state changes
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:673:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:     🏪 Store 동시성 문제 분석 결과:
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:198:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     총 테스트: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:199:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Critical 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:200:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     High 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:201:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Medium 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:202:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🔄 [useMouseEventsLogic] Container unmounted, handlers deactivated
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:254:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🎯 [useMouseEventsLogic] Container mounted via reactive state
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:249:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🚀 [useMouseEventsLogic] Handlers are now ready
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:252:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Dispatch references: [ '0: function', '1: function', '2: function' ]
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/actions/dispatch-stability.test.tsx[39m[0m[2m:209:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Unique dispatch references: 1
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/actions/dispatch-stability.test.tsx[39m[0m[2m:214:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Performance Test Results:
+@context-action/react:           - setValue approach: 3 re-renders
+@context-action/react:           - notifyPath approach: 2 re-renders
+@context-action/react:           - Reduction: 33%
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:97:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Selective Re-rendering Proof:
+@context-action/react:           - user.name path: 2 renders (updated)
+@context-action/react:           - user.email path: 1 render (not updated)
+@context-action/react:           - ui.loading path: 1 render (not updated)
+@context-action/react:           - Efficiency: Only affected paths re-render
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:153:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ RAF Batching Proof:
+@context-action/react:           - notifyPath calls: 3
+@context-action/react:           - Re-renders after initial: 0 (batched)
+@context-action/react:           - Batching: Working
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:195:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ notifyPaths Batching Proof:
+@context-action/react:           - Paths notified: 3
+@context-action/react:           - RAF cycles: 1
+@context-action/react:           - Each subscriber: 2 total renders (1 initial + 1 batched)
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:248:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Event Loop Control Proof:
+@context-action/react:           - Total re-renders: 2
+@context-action/react:           - Loading state: notified without re-render
+@context-action/react:           - Final data: single re-render
+@context-action/react:           - Efficiency: Minimal render cycles
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:295:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Infinite Loop Prevention Proof:
+@context-action/react:           - Subscription calls: 1 (not infinite)
+@context-action/react:           - Processing calls: 1
+@context-action/react:           - Method: Direct mutation + notifyPath
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:338:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           🔄 Batched vs Immediate Mode Comparison:
+@context-action/react:     
+@context-action/react:           Batched Mode (RAF):
+@context-action/react:           - Render count: 1
+@context-action/react:           - Behavior: Multiple notifyPath calls batched into single RAF frame
+@context-action/react:           - Use case: High-frequency updates, animations, smooth UI
+@context-action/react:     
+@context-action/react:           Immediate Mode:
+@context-action/react:           - Render count: 1
+@context-action/react:           - Behavior: Each notifyPath triggers immediate notification
+@context-action/react:           - Use case: Critical updates, testing, predictable timing
+@context-action/react:     
+@context-action/react:           Difference: 0 additional renders in immediate mode
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:398:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     ✅ Immediate mode: Listeners triggered synchronously
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:56:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     ✅ Batched mode: Listeners deferred to RAF and batched
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:93:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:     📊 Mode Comparison Results:
+@context-action/react:     - Immediate mode: 5 notifications (5 notifyPath calls = 5 notifications)
+@context-action/react:     - Batched mode before RAF: 0 notifications
+@context-action/react:     - Batched mode after RAF: 1 notifications (5 notifyPath calls = 1 batched notification)
+@context-action/react:     - Difference: 4x more notifications in immediate mode
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:141:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Store references across Provider re-creations:
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:291:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     0: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     1: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     2: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           📊 Performance Benchmark (100 iterations):
+@context-action/react:     
+@context-action/react:           setValue Approach:
+@context-action/react:           - Total renders: 101
+@context-action/react:           - Time: 3200.00ms
+@context-action/react:     
+@context-action/react:           notifyPath Approach:
+@context-action/react:           - Total renders: 101
+@context-action/react:           - Time: 3200.00ms
+@context-action/react:     
+@context-action/react:           Improvements:
+@context-action/react:           - Render reduction: 0.0%
+@context-action/react:           - Time improvement: 0.0%
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:480:15)[22m[2m[22m
+@context-action/react: [1mTest Suites: [22m[1m[32m52 passed[39m[22m, 52 total
+@context-action/react: [1mTests:       [22m[1m[32m688 passed[39m[22m, 688 total
+@context-action/react: [1mSnapshots:   [22m0 total
+@context-action/react: [1mTime:[22m        [1m[33m5.251 s[39m[22m
+@context-action/react: [2mRan all test suites[22m[2m.[22m
+
+> @context-action/llms-generator:test
+
+@context-action/llms-generator: (node:48556) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:48563) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 test /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > jest
+@context-action/llms-generator: (node:48588) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: [1mTest Suites: [22m[1m[32m15 passed[39m[22m, 15 total
+@context-action/llms-generator: [1mTests:       [22m[1m[32m224 passed[39m[22m, 224 total
+@context-action/llms-generator: [1mSnapshots:   [22m0 total
+@context-action/llms-generator: [1mTime:[22m        [1m[33m2.477 s[39m[22m
+@context-action/llms-generator: [2mRan all test suites[22m[2m.[22m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target test for 10 projects
+
+
+
+> example@1.0.0 check /Users/junwoobang/workflow/context-action/example
+> biome check src && pnpm run verify:catalog && pnpm run verify:approval && pnpm run verify:trace && pnpm run verify:usecase && pnpm run verify:conditional && pnpm run verify:mouse-action && pnpm run verify:mouse-pattern && pnpm run verify:mouse-enhanced
+
+Checked 536 files in 237ms. No fixes applied.
+
+> example@1.0.0 verify:catalog /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-mcp-function-calling-catalog.mjs
+
+MCP/function-calling catalog contract check
+- UI catalog tool references checked: 7
+- standalone catalog tool references checked: 12
+- Live Code Editor catalog tool references checked: 8
+- realtime web-coding catalog tool references checked: 7
+- AI runner response-message history checked: 2 showcases
+- realtime local-agent source/mode contract checked
+- example tools/list/tools/call trace methods checked
+- example agent.request trace lifecycle checked
+- live editor agent/discovery trace lifecycle checked
+- live editor action/presentation boundary checked
+- live editor observability/settings/export boundaries checked
+- live editor document mutation/preview boundary checked
+- live editor workspace/document observability boundary checked
+- live editor reset approval boundary checked
+- realtime web-coding handler/action/presentation boundary checked
+- realtime web-coding observability/trace export boundary checked
+- realtime web-coding workspace action boundary checked
+- realtime web-coding shared document action boundary checked
+- realtime web-coding reset approval boundary checked
+
+> example@1.0.0 preverify:approval /Users/junwoobang/workflow/context-action/example
+> pnpm --filter @context-action/core build
+
+
+> @context-action/core@0.9.2 build /Users/junwoobang/workflow/context-action/packages/core
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/core/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2020
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  113.21 kB │ gzip: 24.71 kB
+ℹ [CJS] 1 files, total: 113.21 kB
+ℹ [CJS] dist/index.d.cts.map   6.06 kB │ gzip: 2.10 kB
+ℹ [CJS] dist/index.d.cts      19.81 kB │ gzip: 4.50 kB
+ℹ [CJS] 2 files, total: 25.87 kB
+✔ Build complete in 719ms
+ℹ [ESM] dist/index.js        112.71 kB │ gzip: 24.64 kB
+ℹ [ESM] dist/index.js.map    268.68 kB │ gzip: 62.76 kB
+ℹ [ESM] dist/index.d.ts.map    6.06 kB │ gzip:  2.10 kB
+ℹ [ESM] dist/index.d.ts       19.81 kB │ gzip:  4.49 kB
+ℹ [ESM] 4 files, total: 407.25 kB
+✔ Build complete in 727ms
+
+> example@1.0.0 verify:approval /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-example-live-editor-approval.mjs
+
+Verified Live Code Editor filesystem approval lifecycle.
+
+> example@1.0.0 verify:trace /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-example-tool-call-trace.mjs
+
+Verified example tool trace provenance and no-raw-payload projection.
+
+> example@1.0.0 verify:usecase /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-live-usecase-conventions.mjs
+
+Live Code Editor usecase convention check
+- contexts: action + store providers
+- business: pure validation, packet, and activity functions
+- handlers: registry orchestration only
+- facade: reactive view model + stable commands
+- recipe: facade-driven presentation only
+
+> example@1.0.0 verify:conditional /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-conditional-permission-conventions.mjs
+
+Conditional permission usecase convention check
+- contexts: Action → Store provider boundary
+- business: pure role/action permission evaluation
+- actions: semantic check and secure-operation commands
+- handlers: Registry orchestration with fail-secure guard
+- page: facade-driven presentation and store subscriptions
+
+> example@1.0.0 verify:mouse-action /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-context-store-action-mouse-conventions.mjs
+
+Context-store action-based mouse convention check
+- contexts: Action + Store contracts and Provider boundary
+- business: pure path, velocity, and activity calculations
+- actions: typed handler factories using business rules
+- handlers: six action registrations in one Registry
+- compatibility: legacy store path re-export retained
+
+> example@1.0.0 verify:mouse-pattern /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-context-store-pattern-conventions.mjs
+
+Context-store pattern convention check
+- contexts: canonical boundary with legacy bridge isolated
+- provider: Action → Store → Registry composition
+- handlers: six mouse action registrations
+- consumers: no direct legacy context imports
+
+> example@1.0.0 verify:mouse-enhanced /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-enhanced-context-store-conventions.mjs
+
+Enhanced context-store convention check
+- contexts: typed Store, Action, and Ref contracts
+- business: pure movement, click, activity, and metric rules
+- actions: semantic mouse command facade
+- provider: Action → Store → Ref → Registry composition
+- handlers: five action registrations outside the View
+- compatibility: legacy model path re-export retained
+
+> example@1.0.0 prebuild /Users/junwoobang/workflow/context-action/example
+> pnpm --filter @context-action/openrouter-browser-storage check && pnpm --filter @context-action/openrouter-browser-storage build
+
+
+> @context-action/openrouter-browser-storage@0.0.0 check /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage
+> pnpm exec biome check src
+
+Checked 1 file in 7ms. No fixes applied.
+
+> @context-action/openrouter-browser-storage@0.0.0 build /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24.11.0
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+
+ WARN  We recommend using the ESM format instead of CommonJS.
+The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+
+ℹ Cleaning 8 files
+ℹ [CJS] dist/index.cjs      2.80 kB │ gzip: 0.93 kB
+ℹ [CJS] dist/index.cjs.map  4.00 kB │ gzip: 1.43 kB
+ℹ [CJS] 2 files, total: 6.80 kB
+ℹ [CJS] dist/index.d.cts.map  0.13 kB │ gzip: 0.13 kB
+ℹ [CJS] dist/index.d.cts      0.57 kB │ gzip: 0.27 kB
+ℹ [CJS] 2 files, total: 0.70 kB
+✔ Build complete in 398ms
+ℹ [ESM] dist/index.js        2.55 kB │ gzip: 0.87 kB
+ℹ [ESM] dist/index.js.map    4.00 kB │ gzip: 1.43 kB
+ℹ [ESM] dist/index.d.ts.map  0.13 kB │ gzip: 0.13 kB
+ℹ [ESM] dist/index.d.ts      0.57 kB │ gzip: 0.26 kB
+ℹ [ESM] 4 files, total: 7.25 kB
+✔ Build complete in 399ms
+
+> example@1.0.0 build /Users/junwoobang/workflow/context-action/example
+> tsc && vite build
+
+vite v8.1.5 building client environment for production...
+[2Ktransforming...✓ 617 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/index.html                                                   2.23 kB │ gzip:   0.97 kB
+dist/assets/ChatPage-ubcKJM2V.css                                 1.21 kB │ gzip:   0.49 kB
+dist/assets/LiveCodeEditorPage-BGn3uVXL.css                       3.00 kB │ gzip:   1.07 kB
+dist/assets/PriorityPerformancePage-BJCO70AV.css                  4.87 kB │ gzip:   1.21 kB
+dist/assets/ToolContextAIDemo-ByChMvQp.css                        7.79 kB │ gzip:   1.91 kB
+dist/assets/LiveWebCodingPage-C_ERQ4ZK.css                       10.75 kB │ gzip:   2.83 kB
+dist/assets/tool-result-format-D5ejSXo7.css                      17.45 kB │ gzip:   4.07 kB
+dist/assets/index-BhQagSdA.css                                  103.05 kB │ gzip:  15.27 kB
+dist/assets/github-DKNKrW6Q.js                                    0.33 kB │ gzip:   0.23 kB
+dist/assets/rolldown-runtime-b3L32Ng1.js                          0.69 kB │ gzip:   0.42 kB
+dist/assets/useSourceLinkRegistration-CWVhPFw4.js                 0.87 kB │ gzip:   0.51 kB
+dist/assets/Container-Ccwmkx4I.js                                 0.97 kB │ gzip:   0.60 kB
+dist/assets/Status-1r9AZ6wY.js                                    1.26 kB │ gzip:   0.70 kB
+dist/assets/useRegisterSourceFile-WayGyomj.js                     1.53 kB │ gzip:   0.74 kB
+dist/assets/Card-BPUJpjf_.js                                      2.68 kB │ gzip:   0.97 kB
+dist/assets/SourceLink-HdIYjwXn.js                                2.69 kB │ gzip:   1.22 kB
+dist/assets/MemoizationPerformancePage-DBHqXQ12.js                2.93 kB │ gzip:   1.12 kB
+dist/assets/logger-C85UoTAn.js                                    3.45 kB │ gzip:   1.22 kB
+dist/assets/TimeTravelStore-DUxQtGfA.js                           4.61 kB │ gzip:   1.42 kB
+dist/assets/ActionGuardIndexPage-DclMNWOi.js                      5.38 kB │ gzip:   2.21 kB
+dist/assets/FoundationsOverview-C5z1NGuM.js                       5.46 kB │ gzip:   1.51 kB
+dist/assets/ActionLifecycleWorkbenchPage-CkAqq7QL.js              6.29 kB │ gzip:   2.65 kB
+dist/assets/ActionContext-ioSZTSlF.js                             6.67 kB │ gzip:   2.55 kB
+dist/assets/PerformanceOverview-Cyc5AM2e.js                       7.20 kB │ gzip:   1.78 kB
+dist/assets/WarningDemoPage-C8Jiv7II.js                           7.71 kB │ gzip:   2.75 kB
+dist/assets/time-travel-store-pattern-r--jf3PW.js                 7.83 kB │ gzip:   2.92 kB
+dist/assets/EnhancedContextStoreProvider-CC8zaAhl.js              7.93 kB │ gzip:   3.05 kB
+dist/assets/createRefContext-BK0td0DI.js                          8.26 kB │ gzip:   2.94 kB
+dist/assets/FormValidation-BdAR14LC.js                            8.30 kB │ gzip:   2.60 kB
+dist/assets/MouseEventsIndexPage-DoBxPp8m.js                      9.18 kB │ gzip:   2.32 kB
+dist/assets/WorkflowSteps-B7OdYVi7.js                             9.34 kB │ gzip:   3.01 kB
+dist/assets/ImplementationScenarioLibraryPage-Bedm-EDh.js         9.79 kB │ gzip:   3.10 kB
+dist/assets/UtilitiesOverview-Ce2DP4eI.js                        10.85 kB │ gzip:   2.63 kB
+dist/assets/TimeTravelTestPage-DGcvP6av.js                       11.02 kB │ gzip:   4.18 kB
+dist/assets/BasicsPage-BBArJN4n.js                               11.43 kB │ gzip:   4.18 kB
+dist/assets/DemoPage-DtEroLmR.js                                 11.45 kB │ gzip:   3.85 kB
+dist/assets/IntegrationsOverview-B0fTzzHV.js                     11.55 kB │ gzip:   3.30 kB
+dist/assets/ToastConfigPage-BERvzVel.js                          11.80 kB │ gzip:   3.99 kB
+dist/assets/ConditionalPatternsIndex-DzOPHhLP.js                 12.18 kB │ gzip:   3.38 kB
+dist/assets/FormBuilderPage-6QVcOZ1c.js                          12.65 kB │ gzip:   3.35 kB
+dist/assets/ToolContextAIDemo-Biag6pSw.js                        13.21 kB │ gzip:   5.09 kB
+dist/assets/FeatureToggle-BZoiazvN.js                            13.28 kB │ gzip:   4.10 kB
+dist/assets/ui-CvdPn6tv.js                                       13.33 kB │ gzip:   4.35 kB
+dist/assets/EnhancedAbortableSearchExample-CBzX7RLm.js           13.47 kB │ gzip:   4.62 kB
+dist/assets/ActionGuardOverview-us-0PrP4.js                      13.68 kB │ gzip:   3.10 kB
+dist/assets/ConcurrentActionsPage-C1AFQOdg.js                    13.81 kB │ gzip:   4.91 kB
+dist/assets/ExamplesUtilitiesOverview-ClN-Oer2.js                13.94 kB │ gzip:   3.33 kB
+dist/assets/ActionGuardContextStoreMouseEventsPage-CQNwmtBw.js   14.88 kB │ gzip:   5.18 kB
+dist/assets/HomePage-DzoTMJd1.js                                 14.94 kB │ gzip:   4.50 kB
+dist/assets/LegacyMouseEventsPage-CRKMFp_z.js                    15.07 kB │ gzip:   5.35 kB
+dist/assets/PatternsOverview-D4kq4gyt.js                         15.55 kB │ gzip:   3.40 kB
+dist/assets/AdvancedFilteringPage-Dv-zR17G.js                    16.40 kB │ gzip:   4.71 kB
+dist/assets/BasicsPage-CYdbuL4F.js                               17.00 kB │ gzip:   5.17 kB
+dist/assets/HooksPage-qfxHrtZv.js                                17.35 kB │ gzip:   6.02 kB
+dist/assets/tool-call-trace-BdnAafEP.js                          18.53 kB │ gzip:   6.57 kB
+dist/assets/UseRefMountStateTestPage-5xAQ3Ed-.js                 18.73 kB │ gzip:   5.94 kB
+dist/assets/AdvancedPage-c67NV9TB.js                             20.26 kB │ gzip:   6.25 kB
+dist/assets/ContextPage-BqGJU8nn.js                              21.38 kB │ gzip:   6.55 kB
+dist/assets/RefsIndexPage-DAhs-IcG.js                            21.50 kB │ gzip:   5.30 kB
+dist/assets/ProviderPage-C6H-ZiKP.js                             21.63 kB │ gzip:   5.64 kB
+dist/assets/WaitForRefsPerformancePage-DsiLKZQt.js               22.45 kB │ gzip:   5.35 kB
+dist/assets/DemosIndexPage-C7Ju5663.js                           24.14 kB │ gzip:   7.16 kB
+dist/assets/PermissionBasedExecution-PtudIGRv.js                 24.14 kB │ gzip:   7.48 kB
+dist/assets/CanvasRefDemoPage-Dl5tKKqC.js                        24.24 kB │ gzip:   6.33 kB
+dist/assets/SourceLinkDirectory-DUaL6tcx.js                      25.02 kB │ gzip:   7.64 kB
+dist/assets/CoreConceptsOverview-BvXdwCT6.js                     25.17 kB │ gzip:   5.80 kB
+dist/assets/LogMonitor-D_SjJVh3.js                               25.52 kB │ gzip:   8.26 kB
+dist/assets/ImmutabilityTestPage-BsyfyQ33.js                     26.83 kB │ gzip:   8.44 kB
+dist/assets/TimeTravelContextTestPage-DxuETKtW.js                27.02 kB │ gzip:   7.36 kB
+dist/assets/AccessRequestExamplePage-CKmkLdZj.js                 28.22 kB │ gzip:   7.93 kB
+dist/assets/RenewalRiskReviewExamplePage-D_lJsRHg.js             28.88 kB │ gzip:   8.13 kB
+dist/assets/ContextStoreActionPage-DJ6Agu_8.js                   29.90 kB │ gzip:   8.25 kB
+dist/assets/McpFunctionCallingCatalog-KuSQ1M9_.js                30.04 kB │ gzip:   7.92 kB
+dist/assets/IncidentEscalationExamplePage-CoMsHgN3.js            30.14 kB │ gzip:   8.22 kB
+dist/assets/FlowControlPlaygroundPageV2-Cwz6qLTx.js              30.76 kB │ gzip:   8.89 kB
+dist/assets/BusinessLogicPage-CehACubk.js                        31.39 kB │ gzip:   9.24 kB
+dist/assets/LoggerPage-CRglWGrQ.js                               31.69 kB │ gzip:   9.71 kB
+dist/assets/NonReactiveContextStorePage-B6N8Ss2P.js              32.81 kB │ gzip:   9.28 kB
+dist/assets/ChatPage-fIJqm76h.js                                 34.69 kB │ gzip:  10.86 kB
+dist/assets/LiveWebCodingPage-t--pAXbY.js                        36.17 kB │ gzip:  12.66 kB
+dist/assets/CanonicalOrderExamplePage-BqZ9uIOd.js                36.36 kB │ gzip:   9.69 kB
+dist/assets/EnhancedContextStorePage-6PLFBuO1.js                 37.54 kB │ gzip:  10.79 kB
+dist/assets/DemoPage-CWGEWOSG.js                                 38.12 kB │ gzip:  10.53 kB
+dist/assets/ThrottleComparisonPageRefactored-D54R_A9u.js         38.45 kB │ gzip:  10.04 kB
+dist/assets/ScrollPageRefactored-DajJO-7y.js                     38.80 kB │ gzip:   9.35 kB
+dist/assets/ApiBlockingPageRefactored-B6MynotF.js                42.05 kB │ gzip:  10.64 kB
+dist/assets/SearchPageRefactored-BqdewG0L.js                     43.50 kB │ gzip:  10.62 kB
+dist/assets/UseActionWithResultPage-CykoOTMW.js                  44.36 kB │ gzip:  11.99 kB
+dist/assets/CanvasPage-DQ1sq0HU.js                               50.80 kB │ gzip:  15.04 kB
+dist/assets/ActionRegister-DYcTScvM.js                           50.99 kB │ gzip:  13.49 kB
+dist/assets/ActionGuardPageRefactored-DLqR9xZk.js                51.74 kB │ gzip:  14.38 kB
+dist/assets/PriorityPerformancePage-BOGP1BmW.js                  51.75 kB │ gzip:  16.03 kB
+dist/assets/store-definition-DDz1VMMq.js                         58.54 kB │ gzip:  17.46 kB
+dist/assets/LayeredArchitecturePage-CZfwM0ie.js                  58.59 kB │ gzip:  15.62 kB
+dist/assets/ImperativeRefPage-CqUA0kVr.js                        87.04 kB │ gzip:  23.02 kB
+dist/assets/index-DJoCrtX8.js                                    87.17 kB │ gzip:  23.43 kB
+dist/assets/LiveCodeEditorPage-PvL-mEBg.js                       89.69 kB │ gzip:  30.29 kB
+dist/assets/tool-result-format-D7TCD8Nj.js                      144.61 kB │ gzip:  47.90 kB
+dist/assets/react-vendor-DmnbxDi2.js                            239.43 kB │ gzip:  77.60 kB
+dist/assets/openrouter-models-C5bSTcxO.js                       570.87 kB │ gzip: 140.43 kB
+
+[33m[PLUGIN_TIMINGS] [0mYour build spent significant time in plugin `@rolldown/plugin-babel`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.
+
+✓ built in 10.52s
+
+> context-action-monorepo@1.0.1 docs:build /Users/junwoobang/workflow/context-action
+> vitepress build docs
+
+
+  vitepress v1.6.4
+
+- building client + server bundles...
+[32m✓[0m building client + server bundles...
+- rendering pages...
+[32m✓[0m rendering pages...
+build complete in 38.04s.
+
+> context-action-monorepo@1.0.1 verify:private-tools /Users/junwoobang/workflow/context-action
+> node scripts/verify-private-tools.mjs
+
+
+> @context-action/style-testing@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/style-testing
+> tsc --noEmit
+
+
+> @context-action/style-testing@0.1.0 test /Users/junwoobang/workflow/context-action/packages/style-testing
+> pnpm run build && node --test test/*.test.mjs
+
+
+> @context-action/style-testing@0.1.0 build /Users/junwoobang/workflow/context-action/packages/style-testing
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/style-testing/tsdown.config.ts 
+ℹ entry: src/index.ts, src/cli/index.ts, src/analyzers/babel-plugin.ts
+ℹ target: node24
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 14 files
+ℹ Granting execute permission to dist/cli/index.js
+ℹ dist/cli/index.js                      4.08 kB │ gzip: 1.53 kB
+ℹ dist/analyzers/babel-plugin.js         1.21 kB │ gzip: 0.54 kB
+ℹ dist/index.js                          0.31 kB │ gzip: 0.19 kB
+ℹ dist/reporter-_x_EL2or.js.map         37.03 kB │ gzip: 9.68 kB
+ℹ dist/reporter-_x_EL2or.js             17.45 kB │ gzip: 4.84 kB
+ℹ dist/cli/index.js.map                  7.58 kB │ gzip: 2.52 kB
+ℹ dist/analyzers/babel-plugin.js.map     3.22 kB │ gzip: 1.21 kB
+ℹ dist/index.d.ts.map                    0.94 kB │ gzip: 0.49 kB
+ℹ dist/analyzers/babel-plugin.d.ts.map   0.17 kB │ gzip: 0.16 kB
+ℹ dist/index.d.ts                        3.42 kB │ gzip: 1.18 kB
+ℹ dist/analyzers/babel-plugin.d.ts       0.41 kB │ gzip: 0.26 kB
+ℹ dist/cli/index.d.ts                    0.01 kB │ gzip: 0.03 kB
+ℹ 12 files, total: 75.83 kB
+✔ Build complete in 781ms
+
+> @context-action/style-testing@0.1.0 postbuild /Users/junwoobang/workflow/context-action/packages/style-testing
+> pnpm verify:exports
+
+
+> @context-action/style-testing@0.1.0 verify:exports /Users/junwoobang/workflow/context-action/packages/style-testing
+> node scripts/verify-exports.mjs
+
+Verified 6 style-testing export artifacts.
+✔ the Babel plugin creates stable IDs and preserves explicitly supplied IDs (43.191583ms)
+✔ the extractor and diff engine agree on Tailwind-derived styles (3.957583ms)
+ℹ tests 2
+ℹ suites 0
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 409.900709
+Verified workspace-only tool package.

--- a/release-evidence/v1.0.0-dev-full/logs/roadmap.log
+++ b/release-evidence/v1.0.0-dev-full/logs/roadmap.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 release:roadmap:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-roadmap-alignment.mjs
+
+v1 release roadmaps aligned (6 invariants).

--- a/release-evidence/v1.0.0-dev-full/logs/verify-all.log
+++ b/release-evidence/v1.0.0-dev-full/logs/verify-all.log
@@ -1,0 +1,6120 @@
+
+> context-action-monorepo@1.0.1 verify:all /Users/junwoobang/workflow/context-action
+> pnpm build:live-code-editor && pnpm build && pnpm test:ai-sdk-integration && pnpm verify:doc-snippets && pnpm verify:core-artifact-parity && pnpm verify:react-artifact-boundary && pnpm verify:package-exports && pnpm verify:package-tarballs && pnpm package-boundary:check && pnpm package-boundary:test && pnpm verify:local-tool-consumers && pnpm verify:v1-lifecycle && pnpm verify:v1-release-manifest && pnpm verify:v1-supply-chain && pnpm tool-durable:test:evidence && pnpm lint && pnpm convention:check && pnpm docs:management && pnpm llms:check && pnpm type-check && pnpm test && pnpm --filter example check && pnpm --filter example build && pnpm docs:build && pnpm verify:private-tools
+
+
+> context-action-monorepo@1.0.1 build:live-code-editor /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/live-code-editor build
+
+
+> @context-action/live-code-editor@0.0.0 build /Users/junwoobang/workflow/context-action/packages/live-code-editor
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/live-code-editor/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24.11.0
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+
+ WARN  We recommend using the ESM format instead of CommonJS.
+The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+
+ℹ Cleaning 8 files
+ℹ [CJS] dist/index.cjs       72.86 kB │ gzip: 16.05 kB
+ℹ [CJS] dist/index.cjs.map  144.26 kB │ gzip: 30.79 kB
+ℹ [CJS] 2 files, total: 217.12 kB
+ℹ [CJS] dist/index.d.cts.map   3.01 kB │ gzip: 1.21 kB
+ℹ [CJS] dist/index.d.cts      13.00 kB │ gzip: 2.98 kB
+ℹ [CJS] 2 files, total: 16.02 kB
+✔ Build complete in 416ms
+ℹ [ESM] dist/index.js         72.01 kB │ gzip: 15.91 kB
+ℹ [ESM] dist/index.js.map    144.26 kB │ gzip: 30.78 kB
+ℹ [ESM] dist/index.d.ts.map    3.01 kB │ gzip:  1.21 kB
+ℹ [ESM] dist/index.d.ts       13.00 kB │ gzip:  2.98 kB
+ℹ [ESM] 4 files, total: 232.28 kB
+✔ Build complete in 420ms
+
+> context-action-monorepo@1.0.1 build /Users/junwoobang/workflow/context-action
+> lerna run build
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target build for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:build
+
+
+> @context-action/mutative-core:build
+
+
+> @context-action/tool-durable-operations:build
+
+
+> @context-action/typedoc-vitepress-sync:build
+
+@context-action/tool-protocol: (node:11829) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:11832) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:11830) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:11831) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:11854) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:11859) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:11858) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:11860) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 build /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsdown
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 build /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > tsdown
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 build /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsdown
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 build /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > tsdown
+@context-action/tool-protocol: (node:11898) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:11954) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:11950) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:11960) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/tool-protocol: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/mutative-core: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync/tsdown.config.ts[24m 
+@context-action/mutative-core: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/mutative-core/tsdown.config.ts[24m 
+@context-action/tool-protocol: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/tool-protocol/tsdown.config.ts[24m 
+@context-action/mutative-core: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m target: [34mnode24[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/mutative-core: [34mℹ[39m target: [34mnode14.0.0[39m
+@context-action/mutative-core: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m Build start
+@context-action/mutative-core: [34mℹ[39m Build start
+@context-action/tool-protocol: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/tool-protocol: [34mℹ[39m target: [34mes2020[39m
+@context-action/tool-protocol: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/tool-protocol: [34mℹ[39m Build start
+@context-action/tool-durable-operations: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/tool-durable-operations/tsdown.config.ts[24m 
+@context-action/typedoc-vitepress-sync: [34mℹ[39m Cleaning 4 files
+@context-action/mutative-core: [34mℹ[39m Cleaning 8 files
+@context-action/tool-durable-operations: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/tool-durable-operations: [34mℹ[39m target: [34mes2020[39m
+@context-action/tool-durable-operations: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/tool-durable-operations: [34mℹ[39m Build start
+@context-action/tool-protocol: [34mℹ[39m Cleaning 7 files
+@context-action/tool-durable-operations: [34mℹ[39m Cleaning 7 files
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m42.71 kB[22m [2m│ gzip: 9.85 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m 1 files, total: 42.71 kB
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m41.89 kB[22m [2m│ gzip: 11.34 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m 1 files, total: 41.89 kB
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m      [2m 63.12 kB[22m [2m│ gzip: 13.16 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.cjs.map  [2m132.13 kB[22m [2m│ gzip: 29.66 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m 2 files, total: 195.25 kB
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22m[1mindex.js[22m        [2m 63.03 kB[22m [2m│ gzip: 15.72 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22mindex.js.map    [2m124.42 kB[22m [2m│ gzip: 29.50 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22mindex.d.ts.map  [2m  3.66 kB[22m [2m│ gzip:  1.31 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 11.80 kB[22m [2m│ gzip:  2.91 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m 4 files, total: 202.92 kB
+@context-action/typedoc-vitepress-sync: [32m✔[39m Build complete in [32m989ms[39m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m42.14 kB[22m [2m│ gzip:  9.77 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m94.85 kB[22m [2m│ gzip: 20.86 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 3.70 kB[22m [2m│ gzip:  1.28 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m14.77 kB[22m [2m│ gzip:  2.34 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m 4 files, total: 155.46 kB
+@context-action/tool-durable-operations: [32m✔[39m Build complete in [32m1005ms[39m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 3.70 kB[22m [2m│ gzip: 1.28 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m14.77 kB[22m [2m│ gzip: 2.35 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m 2 files, total: 18.47 kB
+@context-action/tool-durable-operations: [32m✔[39m Build complete in [32m1008ms[39m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m40.37 kB[22m [2m│ gzip: 11.14 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m89.50 kB[22m [2m│ gzip: 22.52 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 4.04 kB[22m [2m│ gzip:  1.51 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m19.63 kB[22m [2m│ gzip:  4.10 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m 4 files, total: 153.53 kB
+@context-action/tool-protocol: [32m✔[39m Build complete in [32m1028ms[39m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 4.04 kB[22m [2m│ gzip: 1.51 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m19.63 kB[22m [2m│ gzip: 4.10 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m 2 files, total: 23.66 kB
+@context-action/tool-protocol: [32m✔[39m Build complete in [32m1030ms[39m
+
+> @context-action/webmcp:build
+
+
+> @context-action/core:build
+
+
+> @context-action/ai-sdk:build
+
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m 62.79 kB[22m [2m│ gzip: 13.09 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m132.12 kB[22m [2m│ gzip: 29.66 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m  2.95 kB[22m [2m│ gzip:  1.01 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 11.86 kB[22m [2m│ gzip:  2.62 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m 4 files, total: 209.72 kB
+@context-action/mutative-core: [32m✔[39m Build complete in [32m1083ms[39m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 2.95 kB[22m [2m│ gzip: 1.01 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m11.86 kB[22m [2m│ gzip: 2.62 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m 2 files, total: 14.81 kB
+@context-action/mutative-core: [32m✔[39m Build complete in [32m1083ms[39m
+
+> @context-action/mutative:build
+
+@context-action/webmcp: (node:11982) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:11983) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:11984) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:11985) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:12005) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:12007) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:12006) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:12014) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: > @context-action/webmcp@0.1.0 build /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsdown
+@context-action/core: > @context-action/core@0.9.2 build /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsdown
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 build /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsdown
+@context-action/mutative: > @context-action/mutative@0.8.8 build /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > tsdown
+@context-action/webmcp: (node:12065) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:12089) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:12066) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/ai-sdk: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/core: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/mutative: (node:12129) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/core/tsdown.config.ts[24m 
+@context-action/webmcp: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/webmcp/tsdown.config.ts[24m 
+@context-action/ai-sdk: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/ai-sdk/tsdown.config.ts[24m 
+@context-action/core: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/core: [34mℹ[39m target: [34mes2020[39m
+@context-action/core: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/ai-sdk: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/ai-sdk: [34mℹ[39m target: [34mes2022[39m
+@context-action/webmcp: [34mℹ[39m entry: [34msrc/index.ts, src/profiles/chrome-legacy.ts[39m
+@context-action/webmcp: [34mℹ[39m target: [34mes2022[39m
+@context-action/webmcp: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/ai-sdk: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/core: [34mℹ[39m Build start
+@context-action/webmcp: [34mℹ[39m Build start
+@context-action/ai-sdk: [34mℹ[39m Build start
+@context-action/ai-sdk: [34mℹ[39m Cleaning 7 files
+@context-action/core: [34mℹ[39m Cleaning 7 files
+@context-action/webmcp: [34mℹ[39m Cleaning 15 files
+@context-action/mutative: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/mutative: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/mutative/tsdown.config.ts[24m 
+@context-action/mutative: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/mutative: [34mℹ[39m target: [34mnode24.11.0[39m
+@context-action/mutative: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/mutative: [34mℹ[39m Build start
+@context-action/mutative: [43m WARN [49m We recommend using the ESM format instead of CommonJS.
+@context-action/mutative: The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+@context-action/mutative: Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+@context-action/mutative: [34mℹ[39m Cleaning 8 files
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m113.21 kB[22m [2m│ gzip: 24.71 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m 1 files, total: 113.21 kB
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m      [2m24.81 kB[22m [2m│ gzip:  5.82 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.cjs.map  [2m48.54 kB[22m [2m│ gzip: 11.22 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m 2 files, total: 73.35 kB
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m                   [2m10.01 kB[22m [2m│ gzip: 3.23 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mprofiles/chrome-legacy.cjs[22m  [2m 0.79 kB[22m [2m│ gzip: 0.45 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m 2 files, total: 10.80 kB
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map                   [2m0.77 kB[22m [2m│ gzip: 0.41 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22mprofiles/chrome-legacy.d.cts.map  [2m0.18 kB[22m [2m│ gzip: 0.16 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m                       [2m3.47 kB[22m [2m│ gzip: 0.99 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mprofiles/chrome-legacy.d.cts[22m[39m      [2m0.52 kB[22m [2m│ gzip: 0.28 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m 4 files, total: 4.93 kB
+@context-action/webmcp: [32m✔[39m Build complete in [32m828ms[39m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                         [2m 9.84 kB[22m [2m│ gzip: 3.18 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mprofiles/chrome-legacy.js[22m        [2m 0.74 kB[22m [2m│ gzip: 0.42 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map                     [2m23.00 kB[22m [2m│ gzip: 6.81 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mprofiles/chrome-legacy.js.map    [2m 1.48 kB[22m [2m│ gzip: 0.72 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map                   [2m 0.76 kB[22m [2m│ gzip: 0.41 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mprofiles/chrome-legacy.d.ts.map  [2m 0.17 kB[22m [2m│ gzip: 0.16 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m                       [2m 3.46 kB[22m [2m│ gzip: 0.99 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mprofiles/chrome-legacy.d.ts[22m[39m      [2m 0.52 kB[22m [2m│ gzip: 0.27 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m 8 files, total: 39.98 kB
+@context-action/webmcp: [32m✔[39m Build complete in [32m830ms[39m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m6.34 kB[22m [2m│ gzip: 2.21 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m 1 files, total: 6.34 kB
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m0.49 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m2.36 kB[22m [2m│ gzip: 0.74 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m 2 files, total: 2.85 kB
+@context-action/ai-sdk: [32m✔[39m Build complete in [32m890ms[39m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m 6.14 kB[22m [2m│ gzip: 2.16 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m14.63 kB[22m [2m│ gzip: 4.78 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 0.49 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 2.36 kB[22m [2m│ gzip: 0.74 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m 4 files, total: 23.62 kB
+@context-action/ai-sdk: [32m✔[39m Build complete in [32m891ms[39m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m23.43 kB[22m [2m│ gzip:  5.69 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m48.65 kB[22m [2m│ gzip: 11.23 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 2.22 kB[22m [2m│ gzip:  0.89 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m10.65 kB[22m [2m│ gzip:  3.00 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m 4 files, total: 84.95 kB
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 2.22 kB[22m [2m│ gzip: 0.89 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m10.65 kB[22m [2m│ gzip: 3.00 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m 2 files, total: 12.88 kB
+@context-action/mutative: [32m✔[39m Build complete in [32m847ms[39m
+@context-action/mutative: [32m✔[39m Build complete in [32m847ms[39m
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 6.06 kB[22m [2m│ gzip: 2.10 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m19.81 kB[22m [2m│ gzip: 4.50 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m 2 files, total: 25.87 kB
+@context-action/core: [32m✔[39m Build complete in [32m929ms[39m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m112.71 kB[22m [2m│ gzip: 24.64 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m268.68 kB[22m [2m│ gzip: 62.76 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m  6.06 kB[22m [2m│ gzip:  2.10 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 19.81 kB[22m [2m│ gzip:  4.49 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m 4 files, total: 407.25 kB
+@context-action/core: [32m✔[39m Build complete in [32m938ms[39m
+
+> @context-action/react:build
+
+@context-action/react: (node:12139) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:12146) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 build /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > NODE_ENV=production tsdown
+@context-action/react: (node:12171) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/react: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/react/tsdown.config.ts[24m 
+@context-action/react: [34mℹ[39m entry: [34msrc/index.ts, src/advanced.ts, src/utils.ts, src/react18.ts, src/tools/index.ts, src/webmcp.ts[39m
+@context-action/react: [34mℹ[39m target: [34mes2022[39m
+@context-action/react: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/react: [34mℹ[39m Build start
+@context-action/react: [34mℹ[39m Cleaning 70 files
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m             [2m71.31 kB[22m [2m│ gzip: 14.27 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mtools/index.cjs[22m       [2m43.17 kB[22m [2m│ gzip:  9.19 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1madvanced.cjs[22m          [2m 6.26 kB[22m [2m│ gzip:  1.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mwebmcp.cjs[22m            [2m 3.75 kB[22m [2m│ gzip:  1.24 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mutils.cjs[22m             [2m 1.21 kB[22m [2m│ gzip:  0.34 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mreact18.cjs[22m           [2m 0.00 kB[22m [2m│ gzip:  0.02 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mStoreRegistry.cjs     [2m51.32 kB[22m [2m│ gzip: 13.45 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.cjs     [2m15.34 kB[22m [2m│ gzip:  3.62 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mcomparison.cjs        [2m 5.25 kB[22m [2m│ gzip:  1.36 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils2.cjs            [2m 3.57 kB[22m [2m│ gzip:  1.12 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrolldown-runtime.cjs  [2m 1.09 kB[22m [2m│ gzip:  0.53 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m 11 files, total: 202.25 kB
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map                [2m 6.45 kB[22m [2m│ gzip: 2.23 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mtools/index.d.cts.map          [2m 1.74 kB[22m [2m│ gzip: 0.70 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.d.cts.map        [2m 1.25 kB[22m [2m│ gzip: 0.62 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.types.d.cts.map  [2m 1.23 kB[22m [2m│ gzip: 0.51 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mtypes.d.cts.map                [2m 1.19 kB[22m [2m│ gzip: 0.50 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mStore.d.cts.map                [2m 0.96 kB[22m [2m│ gzip: 0.50 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils.d.cts.map                [2m 0.74 kB[22m [2m│ gzip: 0.39 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22madvanced.d.cts.map             [2m 0.39 kB[22m [2m│ gzip: 0.25 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mwebmcp.d.cts.map               [2m 0.19 kB[22m [2m│ gzip: 0.17 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m                    [2m19.34 kB[22m [2m│ gzip: 4.07 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mtools/index.d.cts[22m[39m              [2m 5.91 kB[22m [2m│ gzip: 1.54 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1madvanced.d.cts[22m[39m                 [2m 2.61 kB[22m [2m│ gzip: 0.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mutils2.d.cts[22m[39m                   [2m 1.02 kB[22m [2m│ gzip: 0.40 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mwebmcp.d.cts[22m[39m                   [2m 0.63 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mreact18.d.cts[22m[39m                  [2m 0.08 kB[22m [2m│ gzip: 0.08 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mActionContext.d.cts[39m            [2m 4.37 kB[22m [2m│ gzip: 1.38 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes.d.cts[39m                    [2m 4.07 kB[22m [2m│ gzip: 1.35 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mStore.d.cts[39m                    [2m 3.19 kB[22m [2m│ gzip: 1.12 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mActionContext.types.d.cts[39m      [2m 3.11 kB[22m [2m│ gzip: 0.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mutils.d.cts[39m                    [2m 1.79 kB[22m [2m│ gzip: 0.77 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m 20 files, total: 60.26 kB
+@context-action/react: [32m✔[39m Build complete in [32m852ms[39m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                      [2m 68.72 kB[22m [2m│ gzip: 14.06 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mtools/index.js[22m                [2m 39.97 kB[22m [2m│ gzip:  9.02 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1madvanced.js[22m                   [2m  5.11 kB[22m [2m│ gzip:  1.78 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mwebmcp.js[22m                     [2m  3.65 kB[22m [2m│ gzip:  1.20 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mutils.js[22m                      [2m  0.40 kB[22m [2m│ gzip:  0.19 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mreact18.js[22m                    [2m  0.00 kB[22m [2m│ gzip:  0.02 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map                  [2m156.58 kB[22m [2m│ gzip: 33.44 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStoreRegistry.js.map          [2m103.54 kB[22m [2m│ gzip: 27.95 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtools/index.js.map            [2m 79.57 kB[22m [2m│ gzip: 17.99 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStoreRegistry.js              [2m 48.55 kB[22m [2m│ gzip: 13.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.js.map          [2m 32.51 kB[22m [2m│ gzip:  8.24 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.js              [2m 14.70 kB[22m [2m│ gzip:  3.54 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mcomparison.js.map             [2m 11.82 kB[22m [2m│ gzip:  3.59 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22madvanced.js.map               [2m  9.37 kB[22m [2m│ gzip:  3.25 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mwebmcp.js.map                 [2m  7.09 kB[22m [2m│ gzip:  2.36 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map                [2m  6.45 kB[22m [2m│ gzip:  2.23 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mcomparison.js                 [2m  4.68 kB[22m [2m│ gzip:  1.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils2.js.map                 [2m  4.14 kB[22m [2m│ gzip:  1.20 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils2.js                     [2m  3.55 kB[22m [2m│ gzip:  1.11 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtools/index.d.ts.map          [2m  1.74 kB[22m [2m│ gzip:  0.70 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.d.ts.map        [2m  1.25 kB[22m [2m│ gzip:  0.62 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.types.d.ts.map  [2m  1.23 kB[22m [2m│ gzip:  0.51 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtypes.d.ts.map                [2m  1.18 kB[22m [2m│ gzip:  0.50 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStore.d.ts.map                [2m  0.95 kB[22m [2m│ gzip:  0.50 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils.d.ts.map                [2m  0.74 kB[22m [2m│ gzip:  0.38 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22madvanced.d.ts.map             [2m  0.39 kB[22m [2m│ gzip:  0.25 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mwebmcp.d.ts.map               [2m  0.19 kB[22m [2m│ gzip:  0.17 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m                    [2m 19.34 kB[22m [2m│ gzip:  4.06 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mtools/index.d.ts[22m[39m              [2m  5.90 kB[22m [2m│ gzip:  1.54 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1madvanced.d.ts[22m[39m                 [2m  2.61 kB[22m [2m│ gzip:  0.90 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mutils2.d.ts[22m[39m                   [2m  1.02 kB[22m [2m│ gzip:  0.39 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mwebmcp.d.ts[22m[39m                   [2m  0.62 kB[22m [2m│ gzip:  0.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mreact18.d.ts[22m[39m                  [2m  0.08 kB[22m [2m│ gzip:  0.08 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mActionContext.d.ts[39m            [2m  4.37 kB[22m [2m│ gzip:  1.38 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes.d.ts[39m                    [2m  4.06 kB[22m [2m│ gzip:  1.35 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mStore.d.ts[39m                    [2m  3.19 kB[22m [2m│ gzip:  1.12 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mActionContext.types.d.ts[39m      [2m  3.11 kB[22m [2m│ gzip:  0.91 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mutils.d.ts[39m                    [2m  1.82 kB[22m [2m│ gzip:  0.78 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m 38 files, total: 654.23 kB
+@context-action/react: [32m✔[39m Build complete in [32m865ms[39m
+
+> @context-action/llms-generator:build
+
+@context-action/llms-generator: (node:12183) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:12190) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 build /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > tsdown
+@context-action/llms-generator: (node:12215) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/llms-generator: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/llms-generator/tsdown.config.ts[24m 
+@context-action/llms-generator: [34mℹ[39m entry: [34msrc/index.ts, src/cli/index.ts[39m
+@context-action/llms-generator: [34mℹ[39m target: [34mnode24[39m
+@context-action/llms-generator: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/llms-generator: [34mℹ[39m Build start
+@context-action/llms-generator: [34mℹ[39m Cleaning 10 files
+@context-action/llms-generator: [34mℹ[39m Granting execute permission to [4mdist/cli/index.js[24m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[1mcli/index.js[22m        [2m186.78 kB[22m [2m│ gzip: 41.50 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[1mindex.js[22m            [2m  0.13 kB[22m [2m│ gzip:  0.11 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mcli/index.js.map    [2m377.59 kB[22m [2m│ gzip: 82.14 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22msrc.js.map          [2m 36.89 kB[22m [2m│ gzip:  7.87 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22msrc.js              [2m 20.92 kB[22m [2m│ gzip:  4.89 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mindex.d.ts.map      [2m  1.76 kB[22m [2m│ gzip:  0.60 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mcli/index.d.ts.map  [2m  0.11 kB[22m [2m│ gzip:  0.12 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m          [2m  7.05 kB[22m [2m│ gzip:  2.06 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[32m[1mcli/index.d.ts[22m[39m      [2m  0.14 kB[22m [2m│ gzip:  0.13 kB[22m
+@context-action/llms-generator: [34mℹ[39m 9 files, total: 631.36 kB
+@context-action/llms-generator: [32m✔[39m Build complete in [32m612ms[39m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target build for 10 projects
+
+
+
+> context-action-monorepo@1.0.1 test:ai-sdk-integration /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/tool-protocol build && pnpm --filter @context-action/ai-sdk build && node scripts/verify-ai-sdk-runtime.mjs
+
+
+> @context-action/tool-protocol@0.8.9 build /Users/junwoobang/workflow/context-action/packages/tool-protocol
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/tool-protocol/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2020
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  41.89 kB │ gzip: 11.34 kB
+ℹ [CJS] 1 files, total: 41.89 kB
+ℹ [CJS] dist/index.d.cts.map   4.04 kB │ gzip: 1.51 kB
+ℹ [CJS] dist/index.d.cts      19.63 kB │ gzip: 4.10 kB
+ℹ [CJS] 2 files, total: 23.66 kB
+✔ Build complete in 614ms
+ℹ [ESM] dist/index.js        40.37 kB │ gzip: 11.14 kB
+ℹ [ESM] dist/index.js.map    89.50 kB │ gzip: 22.52 kB
+ℹ [ESM] dist/index.d.ts.map   4.04 kB │ gzip:  1.51 kB
+ℹ [ESM] dist/index.d.ts      19.63 kB │ gzip:  4.10 kB
+ℹ [ESM] 4 files, total: 153.53 kB
+✔ Build complete in 615ms
+
+> @context-action/ai-sdk@0.1.0 build /Users/junwoobang/workflow/context-action/packages/ai-sdk
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/ai-sdk/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2022
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  6.34 kB │ gzip: 2.21 kB
+ℹ [CJS] 1 files, total: 6.34 kB
+ℹ [ESM] dist/index.js         6.14 kB │ gzip: 2.16 kB
+ℹ [ESM] dist/index.js.map    14.63 kB │ gzip: 4.78 kB
+ℹ [ESM] dist/index.d.ts.map   0.49 kB │ gzip: 0.32 kB
+ℹ [ESM] dist/index.d.ts       2.36 kB │ gzip: 0.74 kB
+ℹ [ESM] 4 files, total: 23.62 kB
+✔ Build complete in 657ms
+ℹ [CJS] dist/index.d.cts.map  0.49 kB │ gzip: 0.32 kB
+ℹ [CJS] dist/index.d.cts      2.36 kB │ gzip: 0.74 kB
+ℹ [CJS] 2 files, total: 2.85 kB
+✔ Build complete in 658ms
+AI SDK runtime integration passed
+
+> context-action-monorepo@1.0.1 verify:doc-snippets /Users/junwoobang/workflow/context-action
+> node scripts/verify-doc-snippets.mjs
+
+Documentation snippets compiled: 2
+
+> context-action-monorepo@1.0.1 verify:core-artifact-parity /Users/junwoobang/workflow/context-action
+> node scripts/verify-core-artifact-parity.mjs
+
+Verified core ESM/CJS runtime parity for diagnostics, limits, conditions, and timeout validation.
+
+> context-action-monorepo@1.0.1 verify:react-artifact-boundary /Users/junwoobang/workflow/context-action
+> node scripts/verify-react-artifact-boundary.mjs
+
+Verified React production artifact boundaries: default entry is tool-free and tools entry is explicit.
+
+> context-action-monorepo@1.0.1 verify:package-exports /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-exports.mjs
+
+
+@context-action/ai-sdk
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/core
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/llms-generator
+  ✓ . import -> ./dist/index.js [ESM loaded]
+  ✓ . types -> ./dist/index.d.ts
+  ✓ ./cli import -> ./dist/cli/index.js [ESM loaded]
+  ✓ ./cli types -> ./dist/cli/index.d.ts
+
+@context-action/mutative
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/mutative-core
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/react
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+  ✓ ./advanced import/types -> ./dist/advanced.d.ts
+  ✓ ./advanced import/default -> ./dist/advanced.js [ESM loaded]
+  ✓ ./advanced require/types -> ./dist/advanced.d.cts
+  ✓ ./advanced require/default -> ./dist/advanced.cjs [CJS loaded]
+  ✓ ./utils import/types -> ./dist/utils.d.ts
+  ✓ ./utils import/default -> ./dist/utils.js [ESM loaded]
+  ✓ ./utils require/types -> ./dist/utils.d.cts
+  ✓ ./utils require/default -> ./dist/utils.cjs [CJS loaded]
+  ✓ ./react18 import/types -> ./dist/react18.d.ts
+  ✓ ./react18 import/default -> ./dist/react18.js [ESM loaded]
+  ✓ ./react18 require/types -> ./dist/react18.d.cts
+  ✓ ./react18 require/default -> ./dist/react18.cjs [CJS loaded]
+  ✓ ./tools import/types -> ./dist/tools/index.d.ts
+  ✓ ./tools import/default -> ./dist/tools/index.js [ESM loaded]
+  ✓ ./tools require/types -> ./dist/tools/index.d.cts
+  ✓ ./tools require/default -> ./dist/tools/index.cjs [CJS loaded]
+  ✓ ./webmcp import/types -> ./dist/webmcp.d.ts
+  ✓ ./webmcp import/default -> ./dist/webmcp.js [ESM loaded]
+  ✓ ./webmcp require/types -> ./dist/webmcp.d.cts
+  ✓ ./webmcp require/default -> ./dist/webmcp.cjs [CJS loaded]
+
+@context-action/tool-durable-operations
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/tool-protocol
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/typedoc-vitepress-sync
+  ✓ . import -> ./dist/index.js [ESM loaded]
+  ✓ . types -> ./dist/index.d.ts
+  ✓ ./cli import -> ./bin/cli.js [runtime load skipped: executable CLI]
+
+@context-action/webmcp
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+  ✓ ./profiles/chrome-legacy import/types -> ./dist/profiles/chrome-legacy.d.ts
+  ✓ ./profiles/chrome-legacy import/default -> ./dist/profiles/chrome-legacy.js [ESM loaded]
+  ✓ ./profiles/chrome-legacy require/types -> ./dist/profiles/chrome-legacy.d.cts
+  ✓ ./profiles/chrome-legacy require/default -> ./dist/profiles/chrome-legacy.cjs [CJS loaded]
+
+Verified 10 packages, 63 export targets, and 31 runtime loads.
+
+> context-action-monorepo@1.0.1 verify:package-tarballs /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-tarballs.mjs
+
+
+@context-action/ai-sdk
+  ✓ context-action-ai-sdk-0.1.0.tgz (10 files, 7 manifest targets)
+
+@context-action/core
+  ✓ context-action-core-0.9.2.tgz (10 files, 7 manifest targets)
+
+@context-action/llms-generator
+  ✓ context-action-llms-generator-0.8.7.tgz (17 files, 7 manifest targets)
+
+@context-action/mutative
+  ✓ context-action-mutative-0.8.8.tgz (11 files, 7 manifest targets)
+
+@context-action/mutative-core
+  ✓ context-action-mutative-core-0.8.8.tgz (13 files, 7 manifest targets)
+
+@context-action/react
+  ✓ context-action-react-0.9.2.tgz (72 files, 27 manifest targets)
+
+@context-action/tool-durable-operations
+  ✓ context-action-tool-durable-operations-0.1.1.tgz (20 files, 8 manifest targets)
+
+@context-action/tool-protocol
+  ✓ context-action-tool-protocol-0.8.9.tgz (11 files, 7 manifest targets)
+
+@context-action/typedoc-vitepress-sync
+  ✓ context-action-typedoc-vitepress-sync-0.8.8.tgz (8 files, 6 manifest targets)
+
+@context-action/webmcp
+  ✓ context-action-webmcp-0.1.0.tgz (17 files, 11 manifest targets)
+
+Verified 10 npm package tarballs against their package publication contracts.
+
+> context-action-monorepo@1.0.1 package-boundary:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-boundaries.mjs
+
+Workspace package-boundary verification
+- workspace packages: 13
+- integration hosts: 2
+- source files scanned: 949
+- workspace imports checked: 300
+- violations: 0
+
+> context-action-monorepo@1.0.1 package-boundary:test /Users/junwoobang/workflow/context-action
+> node --test scripts/verify-package-boundaries.test.mjs
+
+✔ accepts declared workspace imports through exported entry points (185.901667ms)
+✔ rejects missing declarations and private workspace subpath imports (169.298875ms)
+✔ allows development-only imports in tests but rejects them from runtime source (337.005834ms)
+✔ rejects relative imports that escape an owning package (167.389334ms)
+ℹ tests 4
+ℹ suites 0
+ℹ pass 4
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 922.564625
+
+> context-action-monorepo@1.0.1 verify:local-tool-consumers /Users/junwoobang/workflow/context-action
+> node scripts/verify-published-tool-consumers.cjs --local
+
+
+added 20 packages in 862ms
+published tool package consumer imports passed: @context-action/core, @context-action/mutative-core, @context-action/mutative, @context-action/tool-protocol, @context-action/tool-durable-operations, @context-action/react/tools, @context-action/ai-sdk, @context-action/webmcp
+Local tarball tool package consumer smoke test passed: file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-9yE56f/local-packages/context-action-core-0.9.2.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-9yE56f/local-packages/context-action-mutative-core-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-9yE56f/local-packages/context-action-mutative-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-9yE56f/local-packages/context-action-tool-protocol-0.8.9.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-9yE56f/local-packages/context-action-tool-durable-operations-0.1.1.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-9yE56f/local-packages/context-action-react-0.9.2.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-9yE56f/local-packages/context-action-ai-sdk-0.1.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-9yE56f/local-packages/context-action-webmcp-0.1.0.tgz, react@19.2.8, ai@7.0.34, typescript@6.0.3
+
+> context-action-monorepo@1.0.1 verify:v1-lifecycle /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-lifecycle-contract.mjs
+
+Wrote passed lifecycle report to reports/release/v1.0.0/test-results/lifecycle-report.json
+
+> context-action-monorepo@1.0.1 verify:v1-release-manifest /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-manifest.mjs
+
+{"status":"ok","manifest":"docs/releases/v1.0.0/release-manifest.json","stage":"candidate-unapproved"}
+
+> context-action-monorepo@1.0.1 verify:v1-supply-chain /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-supply-chain.mjs
+
+Wrote passed supply-chain report to reports/release/v1.0.0/security-report.json
+
+> context-action-monorepo@1.0.1 tool-durable:test:evidence /Users/junwoobang/workflow/context-action
+> node --test scripts/verify-durable-operation-evidence-schema.test.mjs
+
+✔ complete evidence passes the strict deployment gate (80.597583ms)
+✔ schema-valid incomplete evidence is rejected by the strict gate (158.1205ms)
+ℹ tests 2
+ℹ suites 0
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 286.445542
+
+> context-action-monorepo@1.0.1 lint /Users/junwoobang/workflow/context-action
+> biome lint packages/core/src packages/tool-protocol/src packages/ai-sdk/src packages/webmcp/src packages/tool-durable-operations/src packages/react/src packages/mutative-core/src packages/mutative/src packages/llms-generator/src packages/typedoc-vitepress-sync/src scripts/security-audit.mjs scripts/verify-private-tools.mjs scripts/verify-package-boundaries.mjs scripts/verify-package-boundaries.test.mjs scripts/verify-durable-operation-evidence-schema.mjs scripts/verify-durable-operation-evidence-schema.test.mjs scripts/verify-ai-sdk-runtime.mjs scripts/verify-doc-snippets.mjs scripts/verify-react-compatibility.mjs scripts/verify-react-artifact-boundary.mjs scripts/verify-core-artifact-parity.mjs scripts/write-release-evidence.mjs scripts/verify-release-evidence.mjs scripts/release-evidence.test.mjs scripts/generate-release-inventory.mjs scripts/verify-v1-release-roadmap-alignment.mjs scripts/verify-react-webmcp-isolation.mjs scripts/verify-v1-core-migration-fixture.mjs scripts/verify-v1-lifecycle-contract.mjs scripts/verify-v1-release-manifest.mjs scripts/verify-v1-supply-chain.mjs
+
+Checked 161 files in 81ms. No fixes applied.
+
+> context-action-monorepo@1.0.1 convention:check /Users/junwoobang/workflow/context-action
+> node scripts/check-context-layered-conventions.mjs
+
+Context-Layered convention check
+- transitional direct registrations: 0 file(s)
+- stale transitional allowlist entries: 0 file(s)
+- invalid direct registrations: 0 file(s)
+- provider-order violations: 0 occurrence(s)
+- canonical layered roots: 31
+- layer-path/name violations: 0 occurrence(s)
+- classified non-canonical handler roots: 2 (advanced 1, compatibility 1)
+- migration classification violations: 0 occurrence(s)
+
+> context-action-monorepo@1.0.1 docs:management /Users/junwoobang/workflow/context-action
+> node scripts/verify-documentation-management.mjs
+
+Documentation management verification
+- paired directories checked: 3
+- issue forms checked: 3
+- convention discovery links checked: en, ko
+- change-management metadata and handoff checklist checked: en, ko
+- decision-record home and package-boundary gate checked: en, ko
+
+> context-action-monorepo@1.0.1 llms:check /Users/junwoobang/workflow/context-action
+> node packages/llms-generator/dist/cli/index.js detect-mismatches --check-only --fail-on-mismatch
+
+
+> context-action-monorepo@1.0.1 type-check /Users/junwoobang/workflow/context-action
+> lerna run type-check
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target type-check for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:type-check
+
+
+> @context-action/mutative-core:type-check
+
+
+> @context-action/tool-durable-operations:type-check
+
+
+> @context-action/typedoc-vitepress-sync:type-check
+
+@context-action/tool-protocol: (node:14284) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:14286) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:14287) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:14285) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:14313) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:14314) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:14310) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:14315) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > tsc --noEmit
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 type-check /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 type-check /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > tsc --noEmit
+@context-action/tool-durable-operations: (node:14438) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:14439) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 type-check:src /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsc --noEmit
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 type-check:src /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsc --noEmit
+
+> @context-action/mutative:type-check
+
+@context-action/mutative: (node:14513) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:14512) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:14520) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 test:type-check /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 test:type-check /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/mutative: (node:14527) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: > @context-action/mutative@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > tsc --noEmit
+
+> @context-action/core:type-check
+
+
+> @context-action/webmcp:type-check
+
+
+> @context-action/ai-sdk:type-check
+
+@context-action/webmcp: (node:14625) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:14626) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:14624) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:14644) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:14645) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:14647) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/webmcp: > @context-action/webmcp@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/core: > @context-action/core@0.9.2 type-check /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/webmcp: (node:14743) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:14741) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:14742) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: > @context-action/core@0.9.2 type-check:src /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsc --noEmit
+@context-action/webmcp: > @context-action/webmcp@0.1.0 type-check:src /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsc --noEmit
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 type-check:src /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsc --noEmit
+@context-action/core: (node:14849) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:14856) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: > @context-action/core@0.9.2 test:type-check /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/webmcp: > @context-action/webmcp@0.1.0 test:type-check /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/ai-sdk: (node:14863) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 test:type-check /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsc -p __tests__/tsconfig.json --pretty false
+
+> @context-action/react:type-check
+
+@context-action/react: (node:14963) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:14970) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 type-check /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/react: (node:15002) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 type-check:src /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > tsc --noEmit
+@context-action/react: (node:15042) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 test:type-check /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > tsc -p __tests__/tsconfig.json --pretty false
+
+> @context-action/llms-generator:type-check
+
+@context-action/llms-generator: (node:15078) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:15085) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 type-check /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > tsc --noEmit
+
+
+
+ Lerna (powered by Nx)   Successfully ran target type-check for 10 projects
+
+
+
+> context-action-monorepo@1.0.1 test /Users/junwoobang/workflow/context-action
+> lerna run test
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target test for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:test
+
+
+> @context-action/mutative-core:test
+
+
+> @context-action/tool-durable-operations:test
+
+
+> @context-action/typedoc-vitepress-sync:test
+
+@context-action/tool-protocol: (node:15408) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:15418) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:15417) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:15419) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:15648) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:15644) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:15649) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:15681) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 test /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 test /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > vitest run --config vitest.config.ts
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 test /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 test /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > jest
+@context-action/mutative-core: (node:15913) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:15915) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:15921) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:15960) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core:  RUN  v4.1.10 /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: (node:16148) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:16147) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:16149) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:16152) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:16150) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:16151) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:16153) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:16154) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:16155) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:16157) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:16156) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:16159) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:16158) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-hanging/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: ./reports/typedoc-vitepress-sync-metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.05s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: ./reports/typedoc-vitepress-sync-metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/mutative-core:  Test Files  4 passed (4)
+@context-action/mutative-core:       Tests  29 passed (29)
+@context-action/mutative-core:    Start at  12:03:24
+@context-action/mutative-core:    Duration  851ms (transform 1.85s, setup 102ms, import 2.21s, tests 59ms, environment 0ms)
+@context-action/tool-protocol: [1mTest Suites: [22m[1m[32m5 passed[39m[22m, 5 total
+@context-action/tool-protocol: [1mTests:       [22m[1m[32m57 passed[39m[22m, 57 total
+@context-action/tool-protocol: [1mSnapshots:   [22m0 total
+@context-action/tool-protocol: [1mTime:[22m        0.924 s, estimated 1 s
+@context-action/tool-protocol: [2mRan all test suites[22m[2m.[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Package directory not found: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat SidebarGenerator.warn [as parseApiStructure] ([22m[2msrc/processors/SidebarGenerator.ts[2m:37:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.parseApiStructure [as sync] ([22m[2msrc/index.ts[2m:184:50)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:96:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.04s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 0
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+
+> @context-action/mutative:test
+
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/source/packages/test-package/test.md: Error: EACCES: permission denied, mkdir '/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test'[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:116:9)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Package directory not found: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat SidebarGenerator.warn [as parseApiStructure] ([22m[2msrc/processors/SidebarGenerator.ts[2m:37:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.parseApiStructure [as sync] ([22m[2msrc/index.ts[2m:184:50)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:116:9)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.04s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/source/packages/test-package/test.md: ENOSPC: no space left on device[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Recovery: No space left on device
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] 💡 Tip: Free up disk space and try again[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.error [as action] ([22m[2msrc/core/ErrorHandler.ts[2m:33:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.action [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:83:23)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest loaded: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 3
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 50.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 3
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/source/packages/test-package/huge.md: Markdown file exceeds the 8388608 byte processing limit: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/source/packages/test-package/huge.md[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:177:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 2 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 2
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 2
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest loaded: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed 1 stale generated API file(s) from .test-sync/target/test
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 2 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 2
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 40.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 2
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in .test-sync/target/test/problematic.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/TypeDocVitePressSync.test.ts[39m[0m[2m:196:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 4 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 4
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 4
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 4 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 4
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 4
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:310:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in .test-sync/target/test/bad.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🧹 Cleaning cache and generated files...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache cleared
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed target directory: .test-sync/target
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed sidebar config: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] ✅ Cleanup completed
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+
+> @context-action/core:test
+
+
+> @context-action/webmcp:test
+
+
+> @context-action/ai-sdk:test
+
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Auto-configured parallel processing: batchSize=18, maxWorkers=8
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Auto-optimization configured
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-0.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-1.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-10.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-11.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-12.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-13.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-14.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-15.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-16.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-17.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-18.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-19.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-2.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-20.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-21.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-22.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-23.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-24.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-25.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-26.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-27.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-28.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-29.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-3.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-30.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-31.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-32.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-33.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-34.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-35.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-36.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-37.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/tool-durable-operations: [1mTest Suites: [22m[1m[32m9 passed[39m[22m, 9 total
+@context-action/tool-durable-operations: [1mTests:       [22m[1m[33m2 skipped[39m[22m, [1m[32m43 passed[39m[22m, 45 total
+@context-action/tool-durable-operations: [1mSnapshots:   [22m0 total
+@context-action/tool-durable-operations: [1mTime:[22m        1.118 s, estimated 2 s
+@context-action/tool-durable-operations: [2mRan all test suites[22m[2m.[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-38.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-39.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-4.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-40.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-41.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-42.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-43.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-44.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-45.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-46.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-47.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-48.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-49.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-5.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-50.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-51.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-52.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-53.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-54.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/mutative: (node:16162) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-55.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-56.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-57.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-58.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-59.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-6.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-60.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-61.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-62.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-63.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-64.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-65.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-66.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-67.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-68.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-69.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-7.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-70.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-71.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-72.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-73.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-74.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-75.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-76.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-77.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-78.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-79.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-8.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-80.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-81.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-82.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-83.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-84.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-85.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-86.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-87.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-88.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-89.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-9.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-90.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-91.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-92.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-93.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-94.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-95.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-96.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-97.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-98.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test-99.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 100 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 100
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.17s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 100
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 100
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/webmcp: (node:16164) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:16165) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:16163) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 50 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 50
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.03s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 50
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Transient write failure for /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test.md; retrying (1/3)[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.warn [as writeFileWithRetry] ([22m[2msrc/core/FileProcessor.ts[2m:281:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.writeFileWithRetry [as processFile] ([22m[2msrc/core/FileProcessor.ts[2m:104:12)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:404:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Transient write failure for /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/target/test/test.md; retrying (2/3)[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.warn [as writeFileWithRetry] ([22m[2msrc/core/FileProcessor.ts[2m:281:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.writeFileWithRetry [as processFile] ([22m[2msrc/core/FileProcessor.ts[2m:104:12)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:404:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/source/packages/test-package/test.md: EACCES: permission denied[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:439:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Recovery: Permission denied
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] 💡 Tip: Check file permissions or run with appropriate privileges[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.warn [as action] ([22m[2msrc/core/ErrorHandler.ts[2m:26:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.action [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:83:23)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:439:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/source/packages/test-package/valid.md: Simulated failure[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:471:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-16153/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/mutative: (node:16172) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: > @context-action/mutative@0.8.8 test /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > vitest run
+@context-action/webmcp: (node:16196) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:16198) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:16200) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: > @context-action/webmcp@0.1.0 test /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > jest --runInBand
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 test /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > jest --runInBand
+@context-action/core: > @context-action/core@0.9.2 test /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/mutative: (node:16229) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:16304) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:16263) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:16309) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative:  RUN  v4.1.10 /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: (node:16327) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:16328) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:16325) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:16326) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: [1mTest Suites: [22m[1m[33m1 skipped[39m[22m, [1m[32m8 passed[39m[22m, 8 of 9 total
+@context-action/typedoc-vitepress-sync: [1mTests:       [22m[1m[33m15 skipped[39m[22m, [1m[32m113 passed[39m[22m, 128 total
+@context-action/typedoc-vitepress-sync: [1mSnapshots:   [22m0 total
+@context-action/typedoc-vitepress-sync: [1mTime:[22m        1.804 s, estimated 2 s
+@context-action/typedoc-vitepress-sync: [2mRan all test suites[22m[2m.[22m
+@context-action/mutative:  Test Files  4 passed (4)
+@context-action/mutative:       Tests  40 passed (40)
+@context-action/mutative:    Start at  12:03:26
+@context-action/mutative:    Duration  289ms (transform 361ms, setup 0ms, import 462ms, tests 37ms, environment 0ms)
+@context-action/ai-sdk: [1mTest Suites: [22m[1m[32m1 passed[39m[22m, 1 total
+@context-action/ai-sdk: [1mTests:       [22m[1m[32m15 passed[39m[22m, 15 total
+@context-action/ai-sdk: [1mSnapshots:   [22m0 total
+@context-action/ai-sdk: [1mTime:[22m        0.197 s, estimated 1 s
+@context-action/ai-sdk: [2mRan all test suites[22m[2m.[22m
+@context-action/webmcp: [1mTest Suites: [22m[1m[32m2 passed[39m[22m, 2 total
+@context-action/webmcp: [1mTests:       [22m[1m[32m18 passed[39m[22m, 18 total
+@context-action/webmcp: [1mSnapshots:   [22m0 total
+@context-action/webmcp: [1mTime:[22m        0.203 s, estimated 1 s
+@context-action/webmcp: [2mRan all test suites[22m[2m.[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.197Z] [DebugRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'parallel',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.200Z] [DebugRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.611Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.613Z] [ConcurrencyTest] Handler registered: updateUser {
+@context-action/core:       handlerId: 'updateUser_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.615Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.616Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.617Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.617Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.618Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.618Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.619Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.620Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.621Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.622Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.623Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.623Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.624Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.625Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.626Z] [ConcurrencyTest] Handler registered: updateUI { handlerId: 'ui-updater', priority: 60, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.626Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.627Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.628Z] [ConcurrencyTest] Handler registered: searchUsers { handlerId: 'user-search', priority: 80, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.630Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.631Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.633Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.634Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.635Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.636Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.655Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.656Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.657Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-0', priority: undefined, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.657Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-1', priority: undefined, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.658Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-2', priority: undefined, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.658Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-0', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.659Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-1', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.659Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-2', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.659Z] [ConcurrencyTest] Pipeline lookup for 'test' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.660Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.660Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.661Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.662Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.663Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.663Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.664Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.665Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Sequential: 0.00ms, Parallel: 0.00ms
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-docs-simple.test.ts[39m[0m[2m:456:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.666Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.667Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.667Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: 50,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.668Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_2',
+@context-action/core:       priority: 100,
+@context-action/core:       totalHandlers: 2
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.668Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.669Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.669Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler1', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.670Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler2', priority: 200, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.674Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler3', priority: 50, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.675Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.774Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.775Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.776Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.777Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.777Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.778Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.778Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.780Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.780Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.781Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.782Z] [WarningTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.782Z] [WarningTestRegister] Pipeline lookup for 'userLogout' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.783Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.784Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.785Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.785Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.786Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.786Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.787Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.788Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.789Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.790Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.790Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.791Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.791Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.792Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.792Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.793Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.793Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.794Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.794Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.796Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.796Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.797Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.798Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.798Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.987Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.989Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.990Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.991Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.991Z] [TypeOnlyTestRegister] Pipeline lookup for 'anotherTypeOnly' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.992Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.993Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.993Z] [TypeOnlyTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.994Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.995Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.995Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.996Z] [TypeOnlyTestRegister] Handler registered: userLogout { handlerId: 'logout-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.996Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin', 'userLogout' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.997Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.998Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.999Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:32.999Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.000Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.000Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.001Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.001Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.002Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.003Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.007Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.008Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.009Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.010Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.010Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.085Z] [ActionRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.089Z] [ActionRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.187Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.189Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Starting Promise.all operations...
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:48:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 completed { id: 1, timestamp: 1786244613191 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 completed { id: 2, timestamp: 1786244613192 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 completed { id: 3, timestamp: 1786244613192 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.193Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.194Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.194Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.195Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.197Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.198Z] [AsyncConcurrencyTest] Handler registered: syncTest { handlerId: 'sync-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.198Z] [AsyncConcurrencyTest] Handler registered: asyncTest { handlerId: 'async-handler', priority: 50, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.199Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.199Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.200Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:03:33.200Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [1mTest Suites: [22m[1m[32m34 passed[39m[22m, 34 total
+@context-action/core: [1mTests:       [22m[1m[32m766 passed[39m[22m, 766 total
+@context-action/core: [1mSnapshots:   [22m0 total
+@context-action/core: [1mTime:[22m        6.972 s, estimated 7 s
+@context-action/core: [2mRan all test suites[22m[2m.[22m
+
+> @context-action/react:test
+
+@context-action/react: (node:16515) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16522) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@0.9.2 test /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > jest
+@context-action/react: (node:16547) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16622) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16621) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16619) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16617) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16618) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16616) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16620) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16626) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16623) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16625) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:16624) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Business Logic Separation Proof:
+@context-action/react:           - Validation: Pure function, no dependencies
+@context-action/react:           - Upload: Async operation with callbacks
+@context-action/react:           - Progress tracking: 11 updates
+@context-action/react:           - Result: file_1786244615665
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:203:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Async State Machine Proof:
+@context-action/react:           - State transitions: validating → uploading → processing → complete
+@context-action/react:           - Progress updates: 11 notifications
+@context-action/react:           - State renders: 5
+@context-action/react:           - Progress renders: 12
+@context-action/react:           - Status renders: 6
+@context-action/react:           - Pattern: Direct mutation + notifyPath for selective updates
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:305:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Progress-Only Update Proof:
+@context-action/react:           - Progress updates: 10
+@context-action/react:           - Progress renders: 10 (selective)
+@context-action/react:           - State renders: 0 (not affected)
+@context-action/react:           - Efficiency: 100% (no wasted renders)
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:361:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Modular Business Logic Integration Proof:
+@context-action/react:     
+@context-action/react:           Business Logic Layer:
+@context-action/react:           - FileUploadService: Pure business logic (validation, upload, processing)
+@context-action/react:           - No React/store dependencies in business code
+@context-action/react:     
+@context-action/react:           State Management Layer:
+@context-action/react:           - TimeTravelStore with mutable mode
+@context-action/react:           - Direct mutation + notifyPath pattern
+@context-action/react:           - Path-based selective updates
+@context-action/react:     
+@context-action/react:           Rendering Efficiency:
+@context-action/react:           - Files list renders: 3 (only when files change)
+@context-action/react:           - Active upload renders: 8 (only when active upload changes)
+@context-action/react:           - Progress updates: 5 (no files list re-renders)
+@context-action/react:     
+@context-action/react:           Architecture Benefits:
+@context-action/react:           - ✅ Business logic testable in isolation
+@context-action/react:           - ✅ State management decoupled from business logic
+@context-action/react:           - ✅ Selective re-rendering prevents wasted renders
+@context-action/react:           - ✅ Batch updates with notifyPaths for efficiency
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:483:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Error State Management Proof:
+@context-action/react:           - Business logic validation: File size check
+@context-action/react:           - State transition: idle → error
+@context-action/react:           - Error message: "File size exceeds 10MB limit"
+@context-action/react:           - Selective rendering: Only state + error paths updated
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:563:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Complex Multi-file Upload Queue Proof:
+@context-action/react:     
+@context-action/react:           Queue Management:
+@context-action/react:           - Files processed: 3
+@context-action/react:           - Failed uploads: 0
+@context-action/react:           - Queue size: 3
+@context-action/react:     
+@context-action/react:           State Updates:
+@context-action/react:           - Per-file state transitions: idle → uploading → complete
+@context-action/react:           - Per-file progress updates: 5 updates per file
+@context-action/react:           - Global processing state: true → false
+@context-action/react:           - Current index tracking: -1 → 0 → 1 → 2 → -1
+@context-action/react:     
+@context-action/react:           Performance Benefits:
+@context-action/react:           - Selective path updates (queue[i].progress only)
+@context-action/react:           - Batch updates with notifyPaths
+@context-action/react:           - No unnecessary re-renders of other queue items
+@context-action/react:     
+@context-action/react:           Business Logic:
+@context-action/react:           - Queue orchestration separated from UI
+@context-action/react:           - State machine per file
+@context-action/react:           - Progress tracking independent of state changes
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:673:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Performance Test Results:
+@context-action/react:           - setValue approach: 3 re-renders
+@context-action/react:           - notifyPath approach: 2 re-renders
+@context-action/react:           - Reduction: 33%
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:97:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Selective Re-rendering Proof:
+@context-action/react:           - user.name path: 2 renders (updated)
+@context-action/react:           - user.email path: 1 render (not updated)
+@context-action/react:           - ui.loading path: 1 render (not updated)
+@context-action/react:           - Efficiency: Only affected paths re-render
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:153:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ RAF Batching Proof:
+@context-action/react:           - notifyPath calls: 3
+@context-action/react:           - Re-renders after initial: 0 (batched)
+@context-action/react:           - Batching: Working
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:195:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ notifyPaths Batching Proof:
+@context-action/react:           - Paths notified: 3
+@context-action/react:           - RAF cycles: 1
+@context-action/react:           - Each subscriber: 2 total renders (1 initial + 1 batched)
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:248:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Event Loop Control Proof:
+@context-action/react:           - Total re-renders: 2
+@context-action/react:           - Loading state: notified without re-render
+@context-action/react:           - Final data: single re-render
+@context-action/react:           - Efficiency: Minimal render cycles
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:295:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Infinite Loop Prevention Proof:
+@context-action/react:           - Subscription calls: 1 (not infinite)
+@context-action/react:           - Processing calls: 1
+@context-action/react:           - Method: Direct mutation + notifyPath
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:338:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           🔄 Batched vs Immediate Mode Comparison:
+@context-action/react:     
+@context-action/react:           Batched Mode (RAF):
+@context-action/react:           - Render count: 1
+@context-action/react:           - Behavior: Multiple notifyPath calls batched into single RAF frame
+@context-action/react:           - Use case: High-frequency updates, animations, smooth UI
+@context-action/react:     
+@context-action/react:           Immediate Mode:
+@context-action/react:           - Render count: 1
+@context-action/react:           - Behavior: Each notifyPath triggers immediate notification
+@context-action/react:           - Use case: Critical updates, testing, predictable timing
+@context-action/react:     
+@context-action/react:           Difference: 0 additional renders in immediate mode
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:398:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           📊 Performance Benchmark (100 iterations):
+@context-action/react:     
+@context-action/react:           setValue Approach:
+@context-action/react:           - Total renders: 101
+@context-action/react:           - Time: 3200.00ms
+@context-action/react:     
+@context-action/react:           notifyPath Approach:
+@context-action/react:           - Total renders: 101
+@context-action/react:           - Time: 3200.00ms
+@context-action/react:     
+@context-action/react:           Improvements:
+@context-action/react:           - Render reduction: 0.0%
+@context-action/react:           - Time improvement: 0.0%
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:480:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🔄 [useMouseEventsLogic] Container unmounted, handlers deactivated
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:254:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🎯 [useMouseEventsLogic] Container mounted via reactive state
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:249:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🚀 [useMouseEventsLogic] Handlers are now ready
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:252:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Store references across Provider re-creations:
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:291:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     0: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     1: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     2: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Dispatch references: [ '0: function', '1: function', '2: function' ]
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/actions/dispatch-stability.test.tsx[39m[0m[2m:209:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Unique dispatch references: 1
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/actions/dispatch-stability.test.tsx[39m[0m[2m:214:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:     🏪 Store 동시성 문제 분석 결과:
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:198:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     총 테스트: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:199:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Critical 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:200:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     High 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:201:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Medium 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:202:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     ✅ Immediate mode: Listeners triggered synchronously
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:56:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     ✅ Batched mode: Listeners deferred to RAF and batched
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:93:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:     📊 Mode Comparison Results:
+@context-action/react:     - Immediate mode: 5 notifications (5 notifyPath calls = 5 notifications)
+@context-action/react:     - Batched mode before RAF: 0 notifications
+@context-action/react:     - Batched mode after RAF: 1 notifications (5 notifyPath calls = 1 batched notification)
+@context-action/react:     - Difference: 4x more notifications in immediate mode
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:141:13)[22m[2m[22m
+@context-action/react: [1mTest Suites: [22m[1m[32m52 passed[39m[22m, 52 total
+@context-action/react: [1mTests:       [22m[1m[32m688 passed[39m[22m, 688 total
+@context-action/react: [1mSnapshots:   [22m0 total
+@context-action/react: [1mTime:[22m        2.688 s, estimated 3 s
+@context-action/react: [2mRan all test suites[22m[2m.[22m
+
+> @context-action/llms-generator:test
+
+@context-action/llms-generator: (node:16627) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:16634) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 test /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > jest
+@context-action/llms-generator: (node:16659) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: [1mTest Suites: [22m[1m[32m15 passed[39m[22m, 15 total
+@context-action/llms-generator: [1mTests:       [22m[1m[32m224 passed[39m[22m, 224 total
+@context-action/llms-generator: [1mSnapshots:   [22m0 total
+@context-action/llms-generator: [1mTime:[22m        1.153 s
+@context-action/llms-generator: [2mRan all test suites[22m[2m.[22m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target test for 10 projects
+
+
+
+> example@1.0.0 check /Users/junwoobang/workflow/context-action/example
+> biome check src && pnpm run verify:catalog && pnpm run verify:approval && pnpm run verify:trace && pnpm run verify:usecase && pnpm run verify:conditional && pnpm run verify:mouse-action && pnpm run verify:mouse-pattern && pnpm run verify:mouse-enhanced
+
+Checked 536 files in 199ms. No fixes applied.
+
+> example@1.0.0 verify:catalog /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-mcp-function-calling-catalog.mjs
+
+MCP/function-calling catalog contract check
+- UI catalog tool references checked: 7
+- standalone catalog tool references checked: 12
+- Live Code Editor catalog tool references checked: 8
+- realtime web-coding catalog tool references checked: 7
+- AI runner response-message history checked: 2 showcases
+- realtime local-agent source/mode contract checked
+- example tools/list/tools/call trace methods checked
+- example agent.request trace lifecycle checked
+- live editor agent/discovery trace lifecycle checked
+- live editor action/presentation boundary checked
+- live editor observability/settings/export boundaries checked
+- live editor document mutation/preview boundary checked
+- live editor workspace/document observability boundary checked
+- live editor reset approval boundary checked
+- realtime web-coding handler/action/presentation boundary checked
+- realtime web-coding observability/trace export boundary checked
+- realtime web-coding workspace action boundary checked
+- realtime web-coding shared document action boundary checked
+- realtime web-coding reset approval boundary checked
+
+> example@1.0.0 preverify:approval /Users/junwoobang/workflow/context-action/example
+> pnpm --filter @context-action/core build
+
+
+> @context-action/core@0.9.2 build /Users/junwoobang/workflow/context-action/packages/core
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/core/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2020
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  113.21 kB │ gzip: 24.71 kB
+ℹ [CJS] 1 files, total: 113.21 kB
+ℹ [CJS] dist/index.d.cts.map   6.06 kB │ gzip: 2.10 kB
+ℹ [CJS] dist/index.d.cts      19.81 kB │ gzip: 4.50 kB
+ℹ [CJS] 2 files, total: 25.87 kB
+✔ Build complete in 649ms
+ℹ [ESM] dist/index.js        112.71 kB │ gzip: 24.64 kB
+ℹ [ESM] dist/index.js.map    268.68 kB │ gzip: 62.76 kB
+ℹ [ESM] dist/index.d.ts.map    6.06 kB │ gzip:  2.10 kB
+ℹ [ESM] dist/index.d.ts       19.81 kB │ gzip:  4.49 kB
+ℹ [ESM] 4 files, total: 407.25 kB
+✔ Build complete in 657ms
+
+> example@1.0.0 verify:approval /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-example-live-editor-approval.mjs
+
+Verified Live Code Editor filesystem approval lifecycle.
+
+> example@1.0.0 verify:trace /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-example-tool-call-trace.mjs
+
+Verified example tool trace provenance and no-raw-payload projection.
+
+> example@1.0.0 verify:usecase /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-live-usecase-conventions.mjs
+
+Live Code Editor usecase convention check
+- contexts: action + store providers
+- business: pure validation, packet, and activity functions
+- handlers: registry orchestration only
+- facade: reactive view model + stable commands
+- recipe: facade-driven presentation only
+
+> example@1.0.0 verify:conditional /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-conditional-permission-conventions.mjs
+
+Conditional permission usecase convention check
+- contexts: Action → Store provider boundary
+- business: pure role/action permission evaluation
+- actions: semantic check and secure-operation commands
+- handlers: Registry orchestration with fail-secure guard
+- page: facade-driven presentation and store subscriptions
+
+> example@1.0.0 verify:mouse-action /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-context-store-action-mouse-conventions.mjs
+
+Context-store action-based mouse convention check
+- contexts: Action + Store contracts and Provider boundary
+- business: pure path, velocity, and activity calculations
+- actions: typed handler factories using business rules
+- handlers: six action registrations in one Registry
+- compatibility: legacy store path re-export retained
+
+> example@1.0.0 verify:mouse-pattern /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-context-store-pattern-conventions.mjs
+
+Context-store pattern convention check
+- contexts: canonical boundary with legacy bridge isolated
+- provider: Action → Store → Registry composition
+- handlers: six mouse action registrations
+- consumers: no direct legacy context imports
+
+> example@1.0.0 verify:mouse-enhanced /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-enhanced-context-store-conventions.mjs
+
+Enhanced context-store convention check
+- contexts: typed Store, Action, and Ref contracts
+- business: pure movement, click, activity, and metric rules
+- actions: semantic mouse command facade
+- provider: Action → Store → Ref → Registry composition
+- handlers: five action registrations outside the View
+- compatibility: legacy model path re-export retained
+
+> example@1.0.0 prebuild /Users/junwoobang/workflow/context-action/example
+> pnpm --filter @context-action/openrouter-browser-storage check && pnpm --filter @context-action/openrouter-browser-storage build
+
+
+> @context-action/openrouter-browser-storage@0.0.0 check /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage
+> pnpm exec biome check src
+
+Checked 1 file in 3ms. No fixes applied.
+
+> @context-action/openrouter-browser-storage@0.0.0 build /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24.11.0
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+
+ WARN  We recommend using the ESM format instead of CommonJS.
+The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+
+ℹ Cleaning 8 files
+ℹ [CJS] dist/index.cjs      2.80 kB │ gzip: 0.93 kB
+ℹ [CJS] dist/index.cjs.map  4.00 kB │ gzip: 1.43 kB
+ℹ [CJS] 2 files, total: 6.80 kB
+ℹ [CJS] dist/index.d.cts.map  0.13 kB │ gzip: 0.13 kB
+ℹ [CJS] dist/index.d.cts      0.57 kB │ gzip: 0.27 kB
+ℹ [CJS] 2 files, total: 0.70 kB
+✔ Build complete in 323ms
+ℹ [ESM] dist/index.js        2.55 kB │ gzip: 0.87 kB
+ℹ [ESM] dist/index.js.map    4.00 kB │ gzip: 1.43 kB
+ℹ [ESM] dist/index.d.ts.map  0.13 kB │ gzip: 0.13 kB
+ℹ [ESM] dist/index.d.ts      0.57 kB │ gzip: 0.26 kB
+ℹ [ESM] 4 files, total: 7.25 kB
+✔ Build complete in 324ms
+
+> example@1.0.0 build /Users/junwoobang/workflow/context-action/example
+> tsc && vite build
+
+vite v8.1.5 building client environment for production...
+[2Ktransforming...✓ 617 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/index.html                                                   2.23 kB │ gzip:   0.97 kB
+dist/assets/ChatPage-ubcKJM2V.css                                 1.21 kB │ gzip:   0.49 kB
+dist/assets/LiveCodeEditorPage-BGn3uVXL.css                       3.00 kB │ gzip:   1.07 kB
+dist/assets/PriorityPerformancePage-BJCO70AV.css                  4.87 kB │ gzip:   1.21 kB
+dist/assets/ToolContextAIDemo-ByChMvQp.css                        7.79 kB │ gzip:   1.91 kB
+dist/assets/LiveWebCodingPage-C_ERQ4ZK.css                       10.75 kB │ gzip:   2.83 kB
+dist/assets/tool-result-format-D5ejSXo7.css                      17.45 kB │ gzip:   4.07 kB
+dist/assets/index-BhQagSdA.css                                  103.05 kB │ gzip:  15.27 kB
+dist/assets/github-DKNKrW6Q.js                                    0.33 kB │ gzip:   0.23 kB
+dist/assets/rolldown-runtime-b3L32Ng1.js                          0.69 kB │ gzip:   0.42 kB
+dist/assets/useSourceLinkRegistration-CWVhPFw4.js                 0.87 kB │ gzip:   0.51 kB
+dist/assets/Container-Ccwmkx4I.js                                 0.97 kB │ gzip:   0.60 kB
+dist/assets/Status-1r9AZ6wY.js                                    1.26 kB │ gzip:   0.70 kB
+dist/assets/useRegisterSourceFile-WayGyomj.js                     1.53 kB │ gzip:   0.74 kB
+dist/assets/Card-BPUJpjf_.js                                      2.68 kB │ gzip:   0.97 kB
+dist/assets/SourceLink-HdIYjwXn.js                                2.69 kB │ gzip:   1.22 kB
+dist/assets/MemoizationPerformancePage-DBHqXQ12.js                2.93 kB │ gzip:   1.12 kB
+dist/assets/logger-C85UoTAn.js                                    3.45 kB │ gzip:   1.22 kB
+dist/assets/TimeTravelStore-DUxQtGfA.js                           4.61 kB │ gzip:   1.42 kB
+dist/assets/ActionGuardIndexPage-DclMNWOi.js                      5.38 kB │ gzip:   2.21 kB
+dist/assets/FoundationsOverview-C5z1NGuM.js                       5.46 kB │ gzip:   1.51 kB
+dist/assets/ActionLifecycleWorkbenchPage-CkAqq7QL.js              6.29 kB │ gzip:   2.65 kB
+dist/assets/ActionContext-ioSZTSlF.js                             6.67 kB │ gzip:   2.55 kB
+dist/assets/PerformanceOverview-Cyc5AM2e.js                       7.20 kB │ gzip:   1.78 kB
+dist/assets/WarningDemoPage-C8Jiv7II.js                           7.71 kB │ gzip:   2.75 kB
+dist/assets/time-travel-store-pattern-r--jf3PW.js                 7.83 kB │ gzip:   2.92 kB
+dist/assets/EnhancedContextStoreProvider-CC8zaAhl.js              7.93 kB │ gzip:   3.05 kB
+dist/assets/createRefContext-BK0td0DI.js                          8.26 kB │ gzip:   2.94 kB
+dist/assets/FormValidation-BdAR14LC.js                            8.30 kB │ gzip:   2.60 kB
+dist/assets/MouseEventsIndexPage-DoBxPp8m.js                      9.18 kB │ gzip:   2.32 kB
+dist/assets/WorkflowSteps-B7OdYVi7.js                             9.34 kB │ gzip:   3.01 kB
+dist/assets/ImplementationScenarioLibraryPage-Bedm-EDh.js         9.79 kB │ gzip:   3.10 kB
+dist/assets/UtilitiesOverview-Ce2DP4eI.js                        10.85 kB │ gzip:   2.63 kB
+dist/assets/TimeTravelTestPage-DGcvP6av.js                       11.02 kB │ gzip:   4.18 kB
+dist/assets/BasicsPage-BBArJN4n.js                               11.43 kB │ gzip:   4.18 kB
+dist/assets/DemoPage-DtEroLmR.js                                 11.45 kB │ gzip:   3.85 kB
+dist/assets/IntegrationsOverview-B0fTzzHV.js                     11.55 kB │ gzip:   3.30 kB
+dist/assets/ToastConfigPage-BERvzVel.js                          11.80 kB │ gzip:   3.99 kB
+dist/assets/ConditionalPatternsIndex-DzOPHhLP.js                 12.18 kB │ gzip:   3.38 kB
+dist/assets/FormBuilderPage-6QVcOZ1c.js                          12.65 kB │ gzip:   3.35 kB
+dist/assets/ToolContextAIDemo-Biag6pSw.js                        13.21 kB │ gzip:   5.09 kB
+dist/assets/FeatureToggle-BZoiazvN.js                            13.28 kB │ gzip:   4.10 kB
+dist/assets/ui-CvdPn6tv.js                                       13.33 kB │ gzip:   4.35 kB
+dist/assets/EnhancedAbortableSearchExample-CBzX7RLm.js           13.47 kB │ gzip:   4.62 kB
+dist/assets/ActionGuardOverview-us-0PrP4.js                      13.68 kB │ gzip:   3.10 kB
+dist/assets/ConcurrentActionsPage-C1AFQOdg.js                    13.81 kB │ gzip:   4.91 kB
+dist/assets/ExamplesUtilitiesOverview-ClN-Oer2.js                13.94 kB │ gzip:   3.33 kB
+dist/assets/ActionGuardContextStoreMouseEventsPage-CQNwmtBw.js   14.88 kB │ gzip:   5.18 kB
+dist/assets/HomePage-DzoTMJd1.js                                 14.94 kB │ gzip:   4.50 kB
+dist/assets/LegacyMouseEventsPage-CRKMFp_z.js                    15.07 kB │ gzip:   5.35 kB
+dist/assets/PatternsOverview-D4kq4gyt.js                         15.55 kB │ gzip:   3.40 kB
+dist/assets/AdvancedFilteringPage-Dv-zR17G.js                    16.40 kB │ gzip:   4.71 kB
+dist/assets/BasicsPage-CYdbuL4F.js                               17.00 kB │ gzip:   5.17 kB
+dist/assets/HooksPage-qfxHrtZv.js                                17.35 kB │ gzip:   6.02 kB
+dist/assets/tool-call-trace-BdnAafEP.js                          18.53 kB │ gzip:   6.57 kB
+dist/assets/UseRefMountStateTestPage-5xAQ3Ed-.js                 18.73 kB │ gzip:   5.94 kB
+dist/assets/AdvancedPage-c67NV9TB.js                             20.26 kB │ gzip:   6.25 kB
+dist/assets/ContextPage-BqGJU8nn.js                              21.38 kB │ gzip:   6.55 kB
+dist/assets/RefsIndexPage-DAhs-IcG.js                            21.50 kB │ gzip:   5.30 kB
+dist/assets/ProviderPage-C6H-ZiKP.js                             21.63 kB │ gzip:   5.64 kB
+dist/assets/WaitForRefsPerformancePage-DsiLKZQt.js               22.45 kB │ gzip:   5.35 kB
+dist/assets/DemosIndexPage-C7Ju5663.js                           24.14 kB │ gzip:   7.16 kB
+dist/assets/PermissionBasedExecution-PtudIGRv.js                 24.14 kB │ gzip:   7.48 kB
+dist/assets/CanvasRefDemoPage-Dl5tKKqC.js                        24.24 kB │ gzip:   6.33 kB
+dist/assets/SourceLinkDirectory-DUaL6tcx.js                      25.02 kB │ gzip:   7.64 kB
+dist/assets/CoreConceptsOverview-BvXdwCT6.js                     25.17 kB │ gzip:   5.80 kB
+dist/assets/LogMonitor-D_SjJVh3.js                               25.52 kB │ gzip:   8.26 kB
+dist/assets/ImmutabilityTestPage-BsyfyQ33.js                     26.83 kB │ gzip:   8.44 kB
+dist/assets/TimeTravelContextTestPage-DxuETKtW.js                27.02 kB │ gzip:   7.36 kB
+dist/assets/AccessRequestExamplePage-CKmkLdZj.js                 28.22 kB │ gzip:   7.93 kB
+dist/assets/RenewalRiskReviewExamplePage-D_lJsRHg.js             28.88 kB │ gzip:   8.13 kB
+dist/assets/ContextStoreActionPage-DJ6Agu_8.js                   29.90 kB │ gzip:   8.25 kB
+dist/assets/McpFunctionCallingCatalog-KuSQ1M9_.js                30.04 kB │ gzip:   7.92 kB
+dist/assets/IncidentEscalationExamplePage-CoMsHgN3.js            30.14 kB │ gzip:   8.22 kB
+dist/assets/FlowControlPlaygroundPageV2-Cwz6qLTx.js              30.76 kB │ gzip:   8.89 kB
+dist/assets/BusinessLogicPage-CehACubk.js                        31.39 kB │ gzip:   9.24 kB
+dist/assets/LoggerPage-CRglWGrQ.js                               31.69 kB │ gzip:   9.71 kB
+dist/assets/NonReactiveContextStorePage-B6N8Ss2P.js              32.81 kB │ gzip:   9.28 kB
+dist/assets/ChatPage-fIJqm76h.js                                 34.69 kB │ gzip:  10.86 kB
+dist/assets/LiveWebCodingPage-t--pAXbY.js                        36.17 kB │ gzip:  12.66 kB
+dist/assets/CanonicalOrderExamplePage-BqZ9uIOd.js                36.36 kB │ gzip:   9.69 kB
+dist/assets/EnhancedContextStorePage-6PLFBuO1.js                 37.54 kB │ gzip:  10.79 kB
+dist/assets/DemoPage-CWGEWOSG.js                                 38.12 kB │ gzip:  10.53 kB
+dist/assets/ThrottleComparisonPageRefactored-D54R_A9u.js         38.45 kB │ gzip:  10.04 kB
+dist/assets/ScrollPageRefactored-DajJO-7y.js                     38.80 kB │ gzip:   9.35 kB
+dist/assets/ApiBlockingPageRefactored-B6MynotF.js                42.05 kB │ gzip:  10.64 kB
+dist/assets/SearchPageRefactored-BqdewG0L.js                     43.50 kB │ gzip:  10.62 kB
+dist/assets/UseActionWithResultPage-CykoOTMW.js                  44.36 kB │ gzip:  11.99 kB
+dist/assets/CanvasPage-DQ1sq0HU.js                               50.80 kB │ gzip:  15.04 kB
+dist/assets/ActionRegister-DYcTScvM.js                           50.99 kB │ gzip:  13.49 kB
+dist/assets/ActionGuardPageRefactored-DLqR9xZk.js                51.74 kB │ gzip:  14.38 kB
+dist/assets/PriorityPerformancePage-BOGP1BmW.js                  51.75 kB │ gzip:  16.03 kB
+dist/assets/store-definition-DDz1VMMq.js                         58.54 kB │ gzip:  17.46 kB
+dist/assets/LayeredArchitecturePage-CZfwM0ie.js                  58.59 kB │ gzip:  15.62 kB
+dist/assets/ImperativeRefPage-CqUA0kVr.js                        87.04 kB │ gzip:  23.02 kB
+dist/assets/index-DJoCrtX8.js                                    87.17 kB │ gzip:  23.43 kB
+dist/assets/LiveCodeEditorPage-PvL-mEBg.js                       89.69 kB │ gzip:  30.29 kB
+dist/assets/tool-result-format-D7TCD8Nj.js                      144.61 kB │ gzip:  47.90 kB
+dist/assets/react-vendor-DmnbxDi2.js                            239.43 kB │ gzip:  77.60 kB
+dist/assets/openrouter-models-C5bSTcxO.js                       570.87 kB │ gzip: 140.43 kB
+
+[33m[PLUGIN_TIMINGS] [0mYour build spent significant time in plugin `@rolldown/plugin-babel`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.
+
+✓ built in 10.09s
+
+> context-action-monorepo@1.0.1 docs:build /Users/junwoobang/workflow/context-action
+> vitepress build docs
+
+
+  vitepress v1.6.4
+
+- building client + server bundles...
+[32m✓[0m building client + server bundles...
+- rendering pages...
+[32m✓[0m rendering pages...
+build complete in 36.72s.
+
+> context-action-monorepo@1.0.1 verify:private-tools /Users/junwoobang/workflow/context-action
+> node scripts/verify-private-tools.mjs
+
+
+> @context-action/style-testing@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/style-testing
+> tsc --noEmit
+
+
+> @context-action/style-testing@0.1.0 test /Users/junwoobang/workflow/context-action/packages/style-testing
+> pnpm run build && node --test test/*.test.mjs
+
+
+> @context-action/style-testing@0.1.0 build /Users/junwoobang/workflow/context-action/packages/style-testing
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/style-testing/tsdown.config.ts 
+ℹ entry: src/index.ts, src/cli/index.ts, src/analyzers/babel-plugin.ts
+ℹ target: node24
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 14 files
+ℹ Granting execute permission to dist/cli/index.js
+ℹ dist/cli/index.js                      4.08 kB │ gzip: 1.53 kB
+ℹ dist/analyzers/babel-plugin.js         1.21 kB │ gzip: 0.54 kB
+ℹ dist/index.js                          0.31 kB │ gzip: 0.19 kB
+ℹ dist/reporter-_x_EL2or.js.map         37.03 kB │ gzip: 9.68 kB
+ℹ dist/reporter-_x_EL2or.js             17.45 kB │ gzip: 4.84 kB
+ℹ dist/cli/index.js.map                  7.58 kB │ gzip: 2.52 kB
+ℹ dist/analyzers/babel-plugin.js.map     3.22 kB │ gzip: 1.21 kB
+ℹ dist/index.d.ts.map                    0.94 kB │ gzip: 0.49 kB
+ℹ dist/analyzers/babel-plugin.d.ts.map   0.17 kB │ gzip: 0.16 kB
+ℹ dist/index.d.ts                        3.42 kB │ gzip: 1.18 kB
+ℹ dist/analyzers/babel-plugin.d.ts       0.41 kB │ gzip: 0.26 kB
+ℹ dist/cli/index.d.ts                    0.01 kB │ gzip: 0.03 kB
+ℹ 12 files, total: 75.83 kB
+✔ Build complete in 632ms
+
+> @context-action/style-testing@0.1.0 postbuild /Users/junwoobang/workflow/context-action/packages/style-testing
+> pnpm verify:exports
+
+
+> @context-action/style-testing@0.1.0 verify:exports /Users/junwoobang/workflow/context-action/packages/style-testing
+> node scripts/verify-exports.mjs
+
+Verified 6 style-testing export artifacts.
+✔ the Babel plugin creates stable IDs and preserves explicitly supplied IDs (38.22275ms)
+✔ the extractor and diff engine agree on Tailwind-derived styles (4.013ms)
+ℹ tests 2
+ℹ suites 0
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 350.975959
+Verified workspace-only tool package.

--- a/release-evidence/v1.0.0-dev-g9/logs/osv.log
+++ b/release-evidence/v1.0.0-dev-g9/logs/osv.log
@@ -1,0 +1,8 @@
+
+> context-action-monorepo@1.0.1 security:audit /Users/junwoobang/workflow/context-action
+> node scripts/security-audit.mjs
+
+OSV audit checked 1474 npm package versions.
+OSV audit filtered 1 configured vulnerability match(es):
+  react-router@7.18.1: GHSA-qwww-vcr4-c8h2 (Example uses browser routing only; react-router-dom 8.3.0 is not published, so the paired DOM package cannot be upgraded independently. Re-evaluate before expiry.)
+OSV audit found no vulnerability matches.

--- a/release-evidence/v1.0.0-dev-g9/logs/supply-chain.log
+++ b/release-evidence/v1.0.0-dev-g9/logs/supply-chain.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 verify:v1-supply-chain /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-supply-chain.mjs
+
+Wrote passed supply-chain report to reports/release/v1.0.0/security-report.json

--- a/release-evidence/v1.0.0-dev-m0/logs/inventory.log
+++ b/release-evidence/v1.0.0-dev-m0/logs/inventory.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 release:inventory /Users/junwoobang/workflow/context-action
+> node scripts/generate-release-inventory.mjs
+
+Wrote inventory for 10 publishable packages to reports/release/v1.0.0/package-inventory.json

--- a/release-evidence/v1.0.0-dev-m0/logs/manifest.log
+++ b/release-evidence/v1.0.0-dev-m0/logs/manifest.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 verify:v1-release-manifest /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-manifest.mjs
+
+{"status":"ok","manifest":"docs/releases/v1.0.0/release-manifest.json","stage":"candidate-unapproved"}

--- a/release-evidence/v1.0.0-dev-m0/logs/roadmap.log
+++ b/release-evidence/v1.0.0-dev-m0/logs/roadmap.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 release:roadmap:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-roadmap-alignment.mjs
+
+v1 release roadmaps aligned (6 invariants).

--- a/release-evidence/v1.0.0-dev-m3/logs/core-tests.log
+++ b/release-evidence/v1.0.0-dev-m3/logs/core-tests.log
@@ -1,0 +1,868 @@
+
+> context-action-monorepo@1.0.1 test:core /Users/junwoobang/workflow/context-action
+> lerna run test --scope=@context-action/core
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+lerna notice filter including "@context-action/core"
+lerna info filter [ '@context-action/core' ]
+
+> @context-action/core:test
+
+@context-action/core: (node:69479) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:69486) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: > @context-action/core@0.9.2 test /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/core: (node:69510) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:01.830Z] [DebugRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'parallel',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:01.833Z] [DebugRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.273Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.275Z] [ConcurrencyTest] Handler registered: updateUser {
+@context-action/core:       handlerId: 'updateUser_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.276Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.278Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.279Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.280Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.281Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.281Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.282Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.283Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.284Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.285Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.287Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.287Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.288Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.289Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.289Z] [ConcurrencyTest] Handler registered: updateUI { handlerId: 'ui-updater', priority: 60, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.290Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.291Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.291Z] [ConcurrencyTest] Handler registered: searchUsers { handlerId: 'user-search', priority: 80, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.292Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.292Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.293Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.294Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.295Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.296Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.310Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.312Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.312Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-0', priority: undefined, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.312Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-1', priority: undefined, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.313Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-2', priority: undefined, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.313Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-0', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.313Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-1', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.314Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-2', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.314Z] [ConcurrencyTest] Pipeline lookup for 'test' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.314Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.315Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.316Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.316Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.317Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.317Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.319Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.320Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Sequential: 0.00ms, Parallel: 0.00ms
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-docs-simple.test.ts[39m[0m[2m:456:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.321Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.322Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.323Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: 50,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.323Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_2',
+@context-action/core:       priority: 100,
+@context-action/core:       totalHandlers: 2
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.324Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.324Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.325Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler1', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.325Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler2', priority: 200, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.325Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler3', priority: 50, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.326Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.509Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.511Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.513Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.514Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.514Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.515Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.516Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.516Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.517Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.519Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.520Z] [WarningTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.520Z] [WarningTestRegister] Pipeline lookup for 'userLogout' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.521Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.524Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.524Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.525Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.526Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.526Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.527Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.528Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.529Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.530Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.531Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.531Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.532Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.532Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.532Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.533Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.534Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.534Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.534Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.537Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.538Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.539Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.540Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.541Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.611Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.613Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.614Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.615Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.615Z] [TypeOnlyTestRegister] Pipeline lookup for 'anotherTypeOnly' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.616Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.616Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.617Z] [TypeOnlyTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.617Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.618Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.619Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.620Z] [TypeOnlyTestRegister] Handler registered: userLogout { handlerId: 'logout-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.620Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin', 'userLogout' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.621Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.622Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.622Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.623Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.623Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.624Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.624Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.625Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.626Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.627Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.628Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.629Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.630Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.631Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.631Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.754Z] [ActionRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.756Z] [ActionRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.838Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.839Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Starting Promise.all operations...
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:48:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 completed { id: 1, timestamp: 1786243862841 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 completed { id: 2, timestamp: 1786243862842 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 completed { id: 3, timestamp: 1786243862843 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.844Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.845Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.845Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.846Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.847Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.847Z] [AsyncConcurrencyTest] Handler registered: syncTest { handlerId: 'sync-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.847Z] [AsyncConcurrencyTest] Handler registered: asyncTest { handlerId: 'async-handler', priority: 50, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.848Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.849Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.849Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T02:51:02.850Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [1mTest Suites: [22m[1m[32m34 passed[39m[22m, 34 total
+@context-action/core: [1mTests:       [22m[1m[32m766 passed[39m[22m, 766 total
+@context-action/core: [1mSnapshots:   [22m0 total
+@context-action/core: [1mTime:[22m        7.122 s
+@context-action/core: [2mRan all test suites[22m[2m.[22m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target test for project @context-action/core
+
+

--- a/release-evidence/v1.0.0-dev-m3/logs/lifecycle.log
+++ b/release-evidence/v1.0.0-dev-m3/logs/lifecycle.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 verify:v1-lifecycle /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-lifecycle-contract.mjs
+
+Wrote passed lifecycle report to reports/release/v1.0.0/test-results/lifecycle-report.json

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/ai-sdk.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/ai-sdk.log
@@ -1,0 +1,51 @@
+
+> context-action-monorepo@1.0.1 test:ai-sdk-integration /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/tool-protocol build && pnpm --filter @context-action/ai-sdk build && node scripts/verify-ai-sdk-runtime.mjs
+
+
+> @context-action/tool-protocol@0.8.9 build /Users/junwoobang/workflow/context-action/packages/tool-protocol
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/tool-protocol/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2020
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  41.89 kB │ gzip: 11.34 kB
+ℹ [CJS] 1 files, total: 41.89 kB
+ℹ [CJS] dist/index.d.cts.map   4.04 kB │ gzip: 1.51 kB
+ℹ [CJS] dist/index.d.cts      19.63 kB │ gzip: 4.10 kB
+ℹ [CJS] 2 files, total: 23.66 kB
+✔ Build complete in 767ms
+ℹ [ESM] dist/index.js        40.37 kB │ gzip: 11.14 kB
+ℹ [ESM] dist/index.js.map    89.50 kB │ gzip: 22.52 kB
+ℹ [ESM] dist/index.d.ts.map   4.04 kB │ gzip:  1.51 kB
+ℹ [ESM] dist/index.d.ts      19.63 kB │ gzip:  4.10 kB
+ℹ [ESM] 4 files, total: 153.53 kB
+✔ Build complete in 768ms
+
+> @context-action/ai-sdk@0.1.0 build /Users/junwoobang/workflow/context-action/packages/ai-sdk
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/ai-sdk/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2022
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  6.34 kB │ gzip: 2.21 kB
+ℹ [CJS] 1 files, total: 6.34 kB
+ℹ [CJS] dist/index.d.cts.map  0.49 kB │ gzip: 0.32 kB
+ℹ [CJS] dist/index.d.cts      2.36 kB │ gzip: 0.74 kB
+ℹ [CJS] 2 files, total: 2.85 kB
+✔ Build complete in 582ms
+ℹ [ESM] dist/index.js         6.14 kB │ gzip: 2.16 kB
+ℹ [ESM] dist/index.js.map    14.63 kB │ gzip: 4.78 kB
+ℹ [ESM] dist/index.d.ts.map   0.49 kB │ gzip: 0.32 kB
+ℹ [ESM] dist/index.d.ts       2.36 kB │ gzip: 0.74 kB
+ℹ [ESM] 4 files, total: 23.62 kB
+✔ Build complete in 583ms
+AI SDK runtime integration passed

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/local-tool-consumers.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/local-tool-consumers.log
@@ -1,0 +1,8 @@
+
+> context-action-monorepo@1.0.1 verify:local-tool-consumers /Users/junwoobang/workflow/context-action
+> node scripts/verify-published-tool-consumers.cjs --local
+
+
+added 20 packages in 721ms
+published tool package consumer imports passed: @context-action/core, @context-action/mutative-core, @context-action/mutative, @context-action/tool-protocol, @context-action/tool-durable-operations, @context-action/react/tools, @context-action/ai-sdk, @context-action/webmcp
+Local tarball tool package consumer smoke test passed: file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-nFe6yU/local-packages/context-action-core-0.9.2.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-nFe6yU/local-packages/context-action-mutative-core-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-nFe6yU/local-packages/context-action-mutative-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-nFe6yU/local-packages/context-action-tool-protocol-0.8.9.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-nFe6yU/local-packages/context-action-tool-durable-operations-0.1.1.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-nFe6yU/local-packages/context-action-react-0.9.2.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-nFe6yU/local-packages/context-action-ai-sdk-0.1.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-nFe6yU/local-packages/context-action-webmcp-0.1.0.tgz, react@19.2.8, ai@7.0.34, typescript@6.0.3

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/migration-fixture.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/migration-fixture.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 verify:v1-core-migration /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-core-migration-fixture.mjs
+
+Packed @context-action/core v1 migration fixture passed.

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/package-tarballs.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/package-tarballs.log
@@ -1,0 +1,36 @@
+
+> context-action-monorepo@1.0.1 verify:package-tarballs /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-tarballs.mjs
+
+
+@context-action/ai-sdk
+  ✓ context-action-ai-sdk-0.1.0.tgz (10 files, 7 manifest targets)
+
+@context-action/core
+  ✓ context-action-core-0.9.2.tgz (10 files, 7 manifest targets)
+
+@context-action/llms-generator
+  ✓ context-action-llms-generator-0.8.7.tgz (17 files, 7 manifest targets)
+
+@context-action/mutative
+  ✓ context-action-mutative-0.8.8.tgz (11 files, 7 manifest targets)
+
+@context-action/mutative-core
+  ✓ context-action-mutative-core-0.8.8.tgz (13 files, 7 manifest targets)
+
+@context-action/react
+  ✓ context-action-react-0.9.2.tgz (72 files, 27 manifest targets)
+
+@context-action/tool-durable-operations
+  ✓ context-action-tool-durable-operations-0.1.1.tgz (20 files, 8 manifest targets)
+
+@context-action/tool-protocol
+  ✓ context-action-tool-protocol-0.8.9.tgz (11 files, 7 manifest targets)
+
+@context-action/typedoc-vitepress-sync
+  ✓ context-action-typedoc-vitepress-sync-0.8.8.tgz (8 files, 6 manifest targets)
+
+@context-action/webmcp
+  ✓ context-action-webmcp-0.1.0.tgz (17 files, 11 manifest targets)
+
+Verified 10 npm package tarballs against their package publication contracts.

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/react-18.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/react-18.log
@@ -1,0 +1,12 @@
+
+> context-action-monorepo@1.0.1 verify:react-compatibility /Users/junwoobang/workflow/context-action
+> node scripts/verify-react-compatibility.mjs -- --react-version 18.3.1 --react-types 18.3.12 --react-dom-types 18.3.1
+
+
+added 18 packages, and audited 19 packages in 662ms
+
+1 package is looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+React 18.3.1 compatibility passed with @types/react 18.3.12.

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/react-19.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/react-19.log
@@ -1,0 +1,12 @@
+
+> context-action-monorepo@1.0.1 verify:react-compatibility /Users/junwoobang/workflow/context-action
+> node scripts/verify-react-compatibility.mjs -- --react-version 19.2.8 --react-types 19.2.17 --react-dom-types 19.2.3
+
+
+added 15 packages, and audited 16 packages in 665ms
+
+1 package is looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+React 19.2.8 compatibility passed with @types/react 19.2.17.

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/security.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/security.log
@@ -1,0 +1,8 @@
+
+> context-action-monorepo@1.0.1 security:audit /Users/junwoobang/workflow/context-action
+> node scripts/security-audit.mjs
+
+OSV audit checked 1474 npm package versions.
+OSV audit filtered 1 configured vulnerability match(es):
+  react-router@7.18.1: GHSA-qwww-vcr4-c8h2 (Example uses browser routing only; react-router-dom 8.3.0 is not published, so the paired DOM package cannot be upgraded independently. Re-evaluate before expiry.)
+OSV audit found no vulnerability matches.

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/tool-protocol.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/tool-protocol.log
@@ -1,0 +1,30 @@
+
+> context-action-monorepo@1.0.1 test:tool-protocol /Users/junwoobang/workflow/context-action
+> lerna run test --scope=@context-action/tool-protocol
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+lerna notice filter including "@context-action/tool-protocol"
+lerna info filter [ '@context-action/tool-protocol' ]
+
+> @context-action/tool-protocol:test
+
+@context-action/tool-protocol: (node:58267) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:58274) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: > @context-action/tool-protocol@0.8.9 test /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/tool-protocol: (node:58299) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: [1mTest Suites: [22m[1m[32m5 passed[39m[22m, 5 total
+@context-action/tool-protocol: [1mTests:       [22m[1m[32m57 passed[39m[22m, 57 total
+@context-action/tool-protocol: [1mSnapshots:   [22m0 total
+@context-action/tool-protocol: [1mTime:[22m        0.284 s, estimated 1 s
+@context-action/tool-protocol: [2mRan all test suites[22m[2m.[22m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target test for project @context-action/tool-protocol
+
+

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/webmcp-isolation.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/webmcp-isolation.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 verify:react-webmcp-isolation /Users/junwoobang/workflow/context-action
+> node scripts/verify-react-webmcp-isolation.mjs
+
+React WebMCP API is isolated behind @context-action/react/webmcp.

--- a/release-evidence/v1.0.0-dev-m4-m5/logs/webmcp.log
+++ b/release-evidence/v1.0.0-dev-m4-m5/logs/webmcp.log
@@ -1,0 +1,30 @@
+
+> context-action-monorepo@1.0.1 test:webmcp /Users/junwoobang/workflow/context-action
+> lerna run test --scope=@context-action/webmcp
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+lerna notice filter including "@context-action/webmcp"
+lerna info filter [ '@context-action/webmcp' ]
+
+> @context-action/webmcp:test
+
+@context-action/webmcp: (node:58521) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:58529) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: > @context-action/webmcp@0.1.0 test /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > jest --runInBand
+@context-action/webmcp: (node:58553) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: [1mTest Suites: [22m[1m[32m2 passed[39m[22m, 2 total
+@context-action/webmcp: [1mTests:       [22m[1m[32m18 passed[39m[22m, 18 total
+@context-action/webmcp: [1mSnapshots:   [22m0 total
+@context-action/webmcp: [1mTime:[22m        0.133 s, estimated 1 s
+@context-action/webmcp: [2mRan all test suites[22m[2m.[22m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target test for project @context-action/webmcp
+
+

--- a/release-evidence/v1.0.0-rc.0-preapproval-1/artifacts/01-release-manifest.json
+++ b/release-evidence/v1.0.0-rc.0-preapproval-1/artifacts/01-release-manifest.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "./release-manifest.schema.json",
+  "schemaVersion": "context-action-v1-release-manifest.v1",
+  "status": "candidate-unapproved",
+  "release": "context-action-v1.0.0",
+  "commit": null,
+  "packages": {
+    "@context-action/core": "1.0.0-rc.0",
+    "@context-action/react": "1.0.0-rc.0",
+    "@context-action/tool-protocol": "1.0.0-rc.0",
+    "@context-action/webmcp": "0.1.0-rc.0"
+  },
+  "stableSurfaces": [
+    "@context-action/core",
+    "@context-action/react",
+    "@context-action/tool-protocol"
+  ],
+  "experimentalSurfaces": [
+    "@context-action/webmcp",
+    "@context-action/react/webmcp"
+  ],
+  "requiredBeforeCertification": [
+    "Set the immutable RC commit for the published candidate.",
+    "Record provenance and external-consumer results for the published candidate.",
+    "Obtain the independent adversarial audit required for RC certification."
+  ]
+}

--- a/release-evidence/v1.0.0-rc.0-preapproval-1/artifacts/02-package-inventory.json
+++ b/release-evidence/v1.0.0-rc.0-preapproval-1/artifacts/02-package-inventory.json
@@ -1,0 +1,764 @@
+{
+  "schemaVersion": "context-action-release-inventory.v1",
+  "release": "context-action-v1.0.0",
+  "generatedAt": "2026-08-09T03:47:17.160Z",
+  "source": {
+    "workspace": "pnpm-workspace.yaml",
+    "versioning": "lerna-independent",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "packages": [
+    {
+      "name": "@context-action/ai-sdk",
+      "directory": "packages/ai-sdk",
+      "sourceVersion": "0.1.0",
+      "candidateClassification": "experimental-or-supporting-stable",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "not-found"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=24.11.0"
+        },
+        "peerDependencies": {
+          "ai": "^7.0.0"
+        }
+      },
+      "packageFields": {
+        "main": "dist/index.cjs",
+        "module": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "sideEffects": false
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/index.d.cts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/index.cjs"
+        }
+      ]
+    },
+    {
+      "name": "@context-action/core",
+      "directory": "packages/core",
+      "sourceVersion": "1.0.0-rc.0",
+      "candidateClassification": "stable-1x",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "published",
+        "version": "0.9.2"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=24.11.0"
+        },
+        "peerDependencies": {}
+      },
+      "packageFields": {
+        "main": "dist/index.cjs",
+        "module": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "sideEffects": null
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/index.d.cts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/index.cjs"
+        }
+      ]
+    },
+    {
+      "name": "@context-action/llms-generator",
+      "directory": "packages/llms-generator",
+      "sourceVersion": "0.8.7",
+      "candidateClassification": "internal",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "published",
+        "version": "0.8.7"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=24.11.0"
+        },
+        "peerDependencies": {}
+      },
+      "packageFields": {
+        "main": "./dist/index.js",
+        "module": null,
+        "types": "./dist/index.d.ts",
+        "sideEffects": null
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": "./cli",
+          "conditions": [
+            "import"
+          ],
+          "target": "./dist/cli/index.js"
+        },
+        {
+          "subpath": "./cli",
+          "conditions": [
+            "types"
+          ],
+          "target": "./dist/cli/index.d.ts"
+        }
+      ]
+    },
+    {
+      "name": "@context-action/mutative",
+      "directory": "packages/mutative",
+      "sourceVersion": "0.8.8",
+      "candidateClassification": "decision-needed",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "published",
+        "version": "0.8.8"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=24.11.0"
+        },
+        "peerDependencies": {}
+      },
+      "packageFields": {
+        "main": "dist/index.cjs",
+        "module": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "sideEffects": false
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/index.d.cts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/index.cjs"
+        }
+      ]
+    },
+    {
+      "name": "@context-action/mutative-core",
+      "directory": "packages/mutative-core",
+      "sourceVersion": "0.8.8",
+      "candidateClassification": "decision-needed",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "published",
+        "version": "0.8.8"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=14.0"
+        },
+        "peerDependencies": {}
+      },
+      "packageFields": {
+        "main": "dist/index.cjs",
+        "module": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "sideEffects": false
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/index.d.cts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/index.cjs"
+        }
+      ]
+    },
+    {
+      "name": "@context-action/react",
+      "directory": "packages/react",
+      "sourceVersion": "1.0.0-rc.0",
+      "candidateClassification": "stable-1x",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "published",
+        "version": "0.9.2"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=24.11.0"
+        },
+        "peerDependencies": {
+          "react": "^18.0.0 || ^19.0.0"
+        }
+      },
+      "packageFields": {
+        "main": "dist/index.cjs",
+        "module": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "sideEffects": false
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/index.d.cts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/index.cjs"
+        },
+        {
+          "subpath": "./advanced",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/advanced.d.ts"
+        },
+        {
+          "subpath": "./advanced",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/advanced.js"
+        },
+        {
+          "subpath": "./advanced",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/advanced.d.cts"
+        },
+        {
+          "subpath": "./advanced",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/advanced.cjs"
+        },
+        {
+          "subpath": "./utils",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/utils.d.ts"
+        },
+        {
+          "subpath": "./utils",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/utils.js"
+        },
+        {
+          "subpath": "./utils",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/utils.d.cts"
+        },
+        {
+          "subpath": "./utils",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/utils.cjs"
+        },
+        {
+          "subpath": "./react18",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/react18.d.ts"
+        },
+        {
+          "subpath": "./react18",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/react18.js"
+        },
+        {
+          "subpath": "./react18",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/react18.d.cts"
+        },
+        {
+          "subpath": "./react18",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/react18.cjs"
+        },
+        {
+          "subpath": "./tools",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/tools/index.d.ts"
+        },
+        {
+          "subpath": "./tools",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/tools/index.js"
+        },
+        {
+          "subpath": "./tools",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/tools/index.d.cts"
+        },
+        {
+          "subpath": "./tools",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/tools/index.cjs"
+        },
+        {
+          "subpath": "./webmcp",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/webmcp.d.ts"
+        },
+        {
+          "subpath": "./webmcp",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/webmcp.js"
+        },
+        {
+          "subpath": "./webmcp",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/webmcp.d.cts"
+        },
+        {
+          "subpath": "./webmcp",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/webmcp.cjs"
+        }
+      ]
+    },
+    {
+      "name": "@context-action/tool-durable-operations",
+      "directory": "packages/tool-durable-operations",
+      "sourceVersion": "0.1.1",
+      "candidateClassification": "decision-needed",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "published",
+        "version": "0.1.1"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=24.11.0"
+        },
+        "peerDependencies": {}
+      },
+      "packageFields": {
+        "main": "dist/index.cjs",
+        "module": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "sideEffects": false
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/index.d.cts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/index.cjs"
+        }
+      ]
+    },
+    {
+      "name": "@context-action/tool-protocol",
+      "directory": "packages/tool-protocol",
+      "sourceVersion": "1.0.0-rc.0",
+      "candidateClassification": "supporting-stable",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "published",
+        "version": "0.8.8"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=24.11.0"
+        },
+        "peerDependencies": {}
+      },
+      "packageFields": {
+        "main": "dist/index.cjs",
+        "module": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "sideEffects": false
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/index.d.cts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/index.cjs"
+        }
+      ]
+    },
+    {
+      "name": "@context-action/typedoc-vitepress-sync",
+      "directory": "packages/typedoc-vitepress-sync",
+      "sourceVersion": "0.8.8",
+      "candidateClassification": "internal",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "published",
+        "version": "0.8.8"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=24.11.0"
+        },
+        "peerDependencies": {
+          "typedoc": "^0.28.20",
+          "vitepress": "^1.6.4"
+        }
+      },
+      "packageFields": {
+        "main": "dist/index.js",
+        "module": null,
+        "types": "dist/index.d.ts",
+        "sideEffects": null
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": "./cli",
+          "conditions": [
+            "import"
+          ],
+          "target": "./bin/cli.js"
+        }
+      ]
+    },
+    {
+      "name": "@context-action/webmcp",
+      "directory": "packages/webmcp",
+      "sourceVersion": "0.1.0-rc.0",
+      "candidateClassification": "experimental",
+      "requiredDecision": "Approve final v1 scope and target version; candidate classifications are not a release approval.",
+      "published": {
+        "status": "not-found"
+      },
+      "runtime": {
+        "engines": {
+          "node": ">=24.11.0"
+        },
+        "peerDependencies": {}
+      },
+      "packageFields": {
+        "main": "dist/index.cjs",
+        "module": "dist/index.js",
+        "types": "dist/index.d.ts",
+        "sideEffects": false
+      },
+      "exports": [
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/index.d.ts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/index.js"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/index.d.cts"
+        },
+        {
+          "subpath": ".",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/index.cjs"
+        },
+        {
+          "subpath": "./profiles/chrome-legacy",
+          "conditions": [
+            "import",
+            "types"
+          ],
+          "target": "./dist/profiles/chrome-legacy.d.ts"
+        },
+        {
+          "subpath": "./profiles/chrome-legacy",
+          "conditions": [
+            "import",
+            "default"
+          ],
+          "target": "./dist/profiles/chrome-legacy.js"
+        },
+        {
+          "subpath": "./profiles/chrome-legacy",
+          "conditions": [
+            "require",
+            "types"
+          ],
+          "target": "./dist/profiles/chrome-legacy.d.cts"
+        },
+        {
+          "subpath": "./profiles/chrome-legacy",
+          "conditions": [
+            "require",
+            "default"
+          ],
+          "target": "./dist/profiles/chrome-legacy.cjs"
+        }
+      ]
+    }
+  ]
+}

--- a/release-evidence/v1.0.0-rc.0-preapproval-1/artifacts/03-lifecycle-report.json
+++ b/release-evidence/v1.0.0-rc.0-preapproval-1/artifacts/03-lifecycle-report.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": "context-action-v1-lifecycle-report.v1",
+  "release": "context-action-v1.0.0",
+  "generatedAt": "2026-08-09T03:44:22.133Z",
+  "status": "passed",
+  "command": {
+    "command": "pnpm",
+    "args": [
+      "--filter",
+      "@context-action/core",
+      "exec",
+      "jest",
+      "--runInBand",
+      "--runTestsByPath",
+      "__tests__/unit/action-register.lifecycle.test.ts",
+      "__tests__/unit/execution-result-metrics.test.ts",
+      "__tests__/type-safety/ActionRegister.type-safety.test.ts"
+    ],
+    "exitCode": 0,
+    "output": "Test Suites: 3 passed, 3 total\nTests:       93 passed, 93 total\nSnapshots:   0 total\nTime:        0.468 s, estimated 1 s\nRan all test suites within paths \"__tests__/unit/action-register.lifecycle.test.ts\", \"__tests__/unit/execution-result-metrics.test.ts\", \"__tests__/type-safety/ActionRegister.type-safety.test.ts\".\n"
+  },
+  "coverage": [
+    "queue wait cancellation and destroy rejection",
+    "debounce cancellation",
+    "retry telemetry and terminal outcomes",
+    "reentrant destroyAsync and active-handler drain",
+    "race loser drain before cleanup",
+    "ExecutionResult metric and immutable-snapshot contracts"
+  ],
+  "sourceInvariants": [
+    {
+      "name": "three-state lifecycle",
+      "passed": true
+    },
+    {
+      "name": "reentrant stable shutdown promise",
+      "passed": true
+    },
+    {
+      "name": "abort before drain",
+      "passed": true
+    },
+    {
+      "name": "drain dispatches and handlers",
+      "passed": true
+    },
+    {
+      "name": "finalize only after drain",
+      "passed": true
+    }
+  ]
+}

--- a/release-evidence/v1.0.0-rc.0-preapproval-1/artifacts/04-security-report.json
+++ b/release-evidence/v1.0.0-rc.0-preapproval-1/artifacts/04-security-report.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": "context-action-v1-security-report.v1",
+  "release": "context-action-v1.0.0",
+  "generatedAt": "2026-08-09T03:44:38.317Z",
+  "status": "passed",
+  "scope": {
+    "publicPackages": [
+      "@context-action/ai-sdk",
+      "@context-action/core",
+      "@context-action/llms-generator",
+      "@context-action/mutative",
+      "@context-action/mutative-core",
+      "@context-action/react",
+      "@context-action/tool-durable-operations",
+      "@context-action/tool-protocol",
+      "@context-action/typedoc-vitepress-sync",
+      "@context-action/webmcp"
+    ],
+    "workflows": [
+      "ci.yml",
+      "deploy-all.yml",
+      "publish-mutative.yml",
+      "publish-packages.yml",
+      "publish-prerelease.yml"
+    ],
+    "limits": [
+      "This local verifier checks release configuration, not a registry provenance attestation.",
+      "Run pnpm security:audit and verify the post-publish npm provenance record for certification."
+    ]
+  },
+  "checks": [
+    {
+      "name": "security policy",
+      "passed": true,
+      "detail": "SECURITY.md must define supported versions and private reporting"
+    },
+    {
+      "name": "lockfile",
+      "passed": true,
+      "detail": "pnpm-lock.yaml must be present"
+    },
+    {
+      "name": "pinned GitHub Actions",
+      "passed": true,
+      "detail": "44 external action references use full commit SHAs"
+    },
+    {
+      "name": "npm provenance permission",
+      "passed": true,
+      "detail": "all npm publish workflows must grant id-token: write for npm provenance"
+    },
+    {
+      "name": "license @context-action/ai-sdk",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    },
+    {
+      "name": "license @context-action/core",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    },
+    {
+      "name": "license @context-action/llms-generator",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    },
+    {
+      "name": "license @context-action/mutative",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    },
+    {
+      "name": "license @context-action/mutative-core",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    },
+    {
+      "name": "license @context-action/react",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    },
+    {
+      "name": "license @context-action/tool-durable-operations",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    },
+    {
+      "name": "license @context-action/tool-protocol",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    },
+    {
+      "name": "license @context-action/typedoc-vitepress-sync",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    },
+    {
+      "name": "license @context-action/webmcp",
+      "passed": true,
+      "detail": "public package must declare an approved SPDX license and include LICENSE"
+    }
+  ]
+}

--- a/release-evidence/v1.0.0-rc.0-preapproval-1/logs/inventory.log
+++ b/release-evidence/v1.0.0-rc.0-preapproval-1/logs/inventory.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 release:inventory /Users/junwoobang/workflow/context-action
+> node scripts/generate-release-inventory.mjs
+
+Wrote inventory for 10 publishable packages to reports/release/v1.0.0/package-inventory.json

--- a/release-evidence/v1.0.0-rc.0-preapproval-1/logs/manifest.log
+++ b/release-evidence/v1.0.0-rc.0-preapproval-1/logs/manifest.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 verify:v1-release-manifest /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-manifest.mjs
+
+{"status":"ok","manifest":"docs/releases/v1.0.0/release-manifest.json","stage":"candidate-unapproved"}

--- a/release-evidence/v1.0.0-rc.0-preapproval-1/logs/release-check.log
+++ b/release-evidence/v1.0.0-rc.0-preapproval-1/logs/release-check.log
@@ -1,0 +1,6229 @@
+
+> context-action-monorepo@1.0.1 release:check /Users/junwoobang/workflow/context-action
+> pnpm verify:all && pnpm release:roadmap:check && pnpm docs:api && pnpm docs:sync && pnpm docs:build && pnpm test:canonical-example && git diff --exit-code -- docs/en/api docs/.vitepress/config/api-spec.ts
+
+
+> context-action-monorepo@1.0.1 verify:all /Users/junwoobang/workflow/context-action
+> pnpm build:live-code-editor && pnpm build && pnpm test:ai-sdk-integration && pnpm verify:doc-snippets && pnpm verify:core-artifact-parity && pnpm verify:react-artifact-boundary && pnpm verify:package-exports && pnpm verify:package-tarballs && pnpm package-boundary:check && pnpm package-boundary:test && pnpm verify:local-tool-consumers && pnpm verify:v1-lifecycle && pnpm verify:v1-release-manifest && pnpm verify:v1-supply-chain && pnpm tool-durable:test:evidence && pnpm lint && pnpm convention:check && pnpm docs:management && pnpm llms:check && pnpm type-check && pnpm test && pnpm --filter example check && pnpm --filter example build && pnpm docs:build && pnpm verify:private-tools
+
+
+> context-action-monorepo@1.0.1 build:live-code-editor /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/live-code-editor build
+
+
+> @context-action/live-code-editor@0.0.0 build /Users/junwoobang/workflow/context-action/packages/live-code-editor
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/live-code-editor/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24.11.0
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+
+ WARN  We recommend using the ESM format instead of CommonJS.
+The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+
+ℹ Cleaning 8 files
+ℹ [CJS] dist/index.cjs       72.86 kB │ gzip: 16.05 kB
+ℹ [CJS] dist/index.cjs.map  144.26 kB │ gzip: 30.79 kB
+ℹ [CJS] 2 files, total: 217.12 kB
+ℹ [CJS] dist/index.d.cts.map   3.01 kB │ gzip: 1.21 kB
+ℹ [CJS] dist/index.d.cts      13.00 kB │ gzip: 2.98 kB
+ℹ [CJS] 2 files, total: 16.02 kB
+✔ Build complete in 468ms
+ℹ [ESM] dist/index.js         72.01 kB │ gzip: 15.91 kB
+ℹ [ESM] dist/index.js.map    144.26 kB │ gzip: 30.78 kB
+ℹ [ESM] dist/index.d.ts.map    3.01 kB │ gzip:  1.21 kB
+ℹ [ESM] dist/index.d.ts       13.00 kB │ gzip:  2.98 kB
+ℹ [ESM] 4 files, total: 232.28 kB
+✔ Build complete in 471ms
+
+> context-action-monorepo@1.0.1 build /Users/junwoobang/workflow/context-action
+> lerna run build
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target build for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:build
+
+
+> @context-action/mutative-core:build
+
+
+> @context-action/tool-durable-operations:build
+
+
+> @context-action/typedoc-vitepress-sync:build
+
+@context-action/tool-protocol: (node:63937) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:63945) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:63946) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:63948) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:64068) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:64070) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:64069) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:64079) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 build /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsdown
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0-rc.0 build /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsdown
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 build /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > tsdown
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 build /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > tsdown
+@context-action/mutative-core: (node:64230) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:64214) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:64224) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:64255) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/tool-durable-operations: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/tool-protocol: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/mutative-core: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/mutative-core/tsdown.config.ts[24m 
+@context-action/mutative-core: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/mutative-core: [34mℹ[39m target: [34mnode14.0.0[39m
+@context-action/mutative-core: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/tool-durable-operations: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/tool-durable-operations/tsdown.config.ts[24m 
+@context-action/mutative-core: [34mℹ[39m Build start
+@context-action/tool-durable-operations: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/tool-durable-operations: [34mℹ[39m target: [34mes2020[39m
+@context-action/tool-durable-operations: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/tool-durable-operations: [34mℹ[39m Build start
+@context-action/tool-protocol: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/tool-protocol/tsdown.config.ts[24m 
+@context-action/mutative-core: [34mℹ[39m Cleaning 8 files
+@context-action/tool-protocol: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/tool-protocol: [34mℹ[39m target: [34mes2020[39m
+@context-action/tool-protocol: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/tool-protocol: [34mℹ[39m Build start
+@context-action/tool-durable-operations: [34mℹ[39m Cleaning 7 files
+@context-action/tool-protocol: [34mℹ[39m Cleaning 7 files
+@context-action/typedoc-vitepress-sync: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync/tsdown.config.ts[24m 
+@context-action/typedoc-vitepress-sync: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m target: [34mnode24[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m Build start
+@context-action/typedoc-vitepress-sync: [34mℹ[39m Cleaning 4 files
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m42.71 kB[22m [2m│ gzip: 9.85 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m 1 files, total: 42.71 kB
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m      [2m 63.12 kB[22m [2m│ gzip: 13.16 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.cjs.map  [2m132.13 kB[22m [2m│ gzip: 29.66 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m 2 files, total: 195.25 kB
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m41.89 kB[22m [2m│ gzip: 11.34 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m 1 files, total: 41.89 kB
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m42.14 kB[22m [2m│ gzip:  9.77 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m94.85 kB[22m [2m│ gzip: 20.86 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 3.70 kB[22m [2m│ gzip:  1.28 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m14.77 kB[22m [2m│ gzip:  2.34 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m 4 files, total: 155.46 kB
+@context-action/tool-durable-operations: [32m✔[39m Build complete in [32m1153ms[39m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 3.70 kB[22m [2m│ gzip: 1.28 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m14.77 kB[22m [2m│ gzip: 2.35 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m 2 files, total: 18.47 kB
+@context-action/tool-durable-operations: [32m✔[39m Build complete in [32m1156ms[39m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m40.37 kB[22m [2m│ gzip: 11.14 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m89.50 kB[22m [2m│ gzip: 22.52 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 4.04 kB[22m [2m│ gzip:  1.51 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m19.63 kB[22m [2m│ gzip:  4.10 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m 4 files, total: 153.53 kB
+@context-action/tool-protocol: [32m✔[39m Build complete in [32m1170ms[39m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 4.04 kB[22m [2m│ gzip: 1.51 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m19.63 kB[22m [2m│ gzip: 4.10 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m 2 files, total: 23.66 kB
+@context-action/tool-protocol: [32m✔[39m Build complete in [32m1175ms[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22m[1mindex.js[22m        [2m 63.03 kB[22m [2m│ gzip: 15.72 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22mindex.js.map    [2m124.42 kB[22m [2m│ gzip: 29.50 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22mindex.d.ts.map  [2m  3.66 kB[22m [2m│ gzip:  1.31 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 11.80 kB[22m [2m│ gzip:  2.91 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m 4 files, total: 202.92 kB
+@context-action/typedoc-vitepress-sync: [32m✔[39m Build complete in [32m1174ms[39m
+
+> @context-action/webmcp:build
+
+
+> @context-action/core:build
+
+
+> @context-action/ai-sdk:build
+
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 2.95 kB[22m [2m│ gzip: 1.01 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m11.86 kB[22m [2m│ gzip: 2.62 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m 2 files, total: 14.81 kB
+@context-action/mutative-core: [32m✔[39m Build complete in [32m1232ms[39m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m 62.79 kB[22m [2m│ gzip: 13.09 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m132.12 kB[22m [2m│ gzip: 29.66 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m  2.95 kB[22m [2m│ gzip:  1.01 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 11.86 kB[22m [2m│ gzip:  2.62 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m 4 files, total: 209.72 kB
+@context-action/mutative-core: [32m✔[39m Build complete in [32m1236ms[39m
+
+> @context-action/mutative:build
+
+@context-action/webmcp: (node:64289) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:64291) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:64290) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:64295) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:64314) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:64315) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:64316) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:64323) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: > @context-action/core@1.0.0-rc.0 build /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsdown
+@context-action/webmcp: > @context-action/webmcp@0.1.0-rc.0 build /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsdown
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 build /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsdown
+@context-action/mutative: > @context-action/mutative@0.8.8 build /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > tsdown
+@context-action/ai-sdk: (node:64397) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:64401) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:64393) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/webmcp: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/core: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/mutative: (node:64442) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/webmcp/tsdown.config.ts[24m 
+@context-action/ai-sdk: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/ai-sdk/tsdown.config.ts[24m 
+@context-action/core: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/core/tsdown.config.ts[24m 
+@context-action/webmcp: [34mℹ[39m entry: [34msrc/index.ts, src/profiles/chrome-legacy.ts[39m
+@context-action/webmcp: [34mℹ[39m target: [34mes2022[39m
+@context-action/webmcp: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/webmcp: [34mℹ[39m Build start
+@context-action/ai-sdk: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/ai-sdk: [34mℹ[39m target: [34mes2022[39m
+@context-action/mutative: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/ai-sdk: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/core: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/core: [34mℹ[39m target: [34mes2020[39m
+@context-action/core: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/ai-sdk: [34mℹ[39m Build start
+@context-action/core: [34mℹ[39m Build start
+@context-action/webmcp: [34mℹ[39m Cleaning 15 files
+@context-action/core: [34mℹ[39m Cleaning 7 files
+@context-action/ai-sdk: [34mℹ[39m Cleaning 7 files
+@context-action/mutative: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/mutative/tsdown.config.ts[24m 
+@context-action/mutative: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/mutative: [34mℹ[39m target: [34mnode24.11.0[39m
+@context-action/mutative: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/mutative: [34mℹ[39m Build start
+@context-action/mutative: [43m WARN [49m We recommend using the ESM format instead of CommonJS.
+@context-action/mutative: The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+@context-action/mutative: Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+@context-action/mutative: [34mℹ[39m Cleaning 8 files
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m      [2m24.81 kB[22m [2m│ gzip:  5.82 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.cjs.map  [2m48.54 kB[22m [2m│ gzip: 11.22 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m 2 files, total: 73.35 kB
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m113.21 kB[22m [2m│ gzip: 24.71 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m 1 files, total: 113.21 kB
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m                   [2m10.01 kB[22m [2m│ gzip: 3.23 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mprofiles/chrome-legacy.cjs[22m  [2m 0.79 kB[22m [2m│ gzip: 0.45 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m 2 files, total: 10.80 kB
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map                   [2m0.77 kB[22m [2m│ gzip: 0.41 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22mprofiles/chrome-legacy.d.cts.map  [2m0.18 kB[22m [2m│ gzip: 0.16 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m                       [2m3.47 kB[22m [2m│ gzip: 0.99 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mprofiles/chrome-legacy.d.cts[22m[39m      [2m0.52 kB[22m [2m│ gzip: 0.28 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m 4 files, total: 4.93 kB
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m23.43 kB[22m [2m│ gzip:  5.69 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m48.65 kB[22m [2m│ gzip: 11.23 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 2.22 kB[22m [2m│ gzip:  0.89 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m10.65 kB[22m [2m│ gzip:  3.00 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m 4 files, total: 84.95 kB
+@context-action/webmcp: [32m✔[39m Build complete in [32m969ms[39m
+@context-action/mutative: [32m✔[39m Build complete in [32m909ms[39m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                         [2m 9.84 kB[22m [2m│ gzip: 3.18 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mprofiles/chrome-legacy.js[22m        [2m 0.74 kB[22m [2m│ gzip: 0.42 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map                     [2m23.00 kB[22m [2m│ gzip: 6.81 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mprofiles/chrome-legacy.js.map    [2m 1.48 kB[22m [2m│ gzip: 0.72 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map                   [2m 0.76 kB[22m [2m│ gzip: 0.41 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mprofiles/chrome-legacy.d.ts.map  [2m 0.17 kB[22m [2m│ gzip: 0.16 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m                       [2m 3.46 kB[22m [2m│ gzip: 0.99 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mprofiles/chrome-legacy.d.ts[22m[39m      [2m 0.52 kB[22m [2m│ gzip: 0.27 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m 8 files, total: 39.98 kB
+@context-action/webmcp: [32m✔[39m Build complete in [32m972ms[39m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 2.22 kB[22m [2m│ gzip: 0.89 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m10.65 kB[22m [2m│ gzip: 3.00 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m 2 files, total: 12.88 kB
+@context-action/mutative: [32m✔[39m Build complete in [32m912ms[39m
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 6.06 kB[22m [2m│ gzip: 2.10 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m19.81 kB[22m [2m│ gzip: 4.50 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m 2 files, total: 25.87 kB
+@context-action/core: [32m✔[39m Build complete in [32m1014ms[39m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m112.71 kB[22m [2m│ gzip: 24.64 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m268.68 kB[22m [2m│ gzip: 62.76 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m  6.06 kB[22m [2m│ gzip:  2.10 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 19.81 kB[22m [2m│ gzip:  4.49 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m 4 files, total: 407.25 kB
+@context-action/core: [32m✔[39m Build complete in [32m1021ms[39m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m6.34 kB[22m [2m│ gzip: 2.21 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m 1 files, total: 6.34 kB
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m0.49 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m2.36 kB[22m [2m│ gzip: 0.74 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m 2 files, total: 2.85 kB
+@context-action/ai-sdk: [32m✔[39m Build complete in [32m1036ms[39m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m 6.14 kB[22m [2m│ gzip: 2.16 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m14.63 kB[22m [2m│ gzip: 4.78 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 0.49 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 2.36 kB[22m [2m│ gzip: 0.74 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m 4 files, total: 23.62 kB
+@context-action/ai-sdk: [32m✔[39m Build complete in [32m1036ms[39m
+
+> @context-action/react:build
+
+@context-action/react: (node:64450) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:64457) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0-rc.0 build /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > NODE_ENV=production tsdown
+@context-action/react: (node:64486) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/react: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/react/tsdown.config.ts[24m 
+@context-action/react: [34mℹ[39m entry: [34msrc/index.ts, src/advanced.ts, src/utils.ts, src/react18.ts, src/tools/index.ts, src/webmcp.ts[39m
+@context-action/react: [34mℹ[39m target: [34mes2022[39m
+@context-action/react: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/react: [34mℹ[39m Build start
+@context-action/react: [34mℹ[39m Cleaning 70 files
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m             [2m71.31 kB[22m [2m│ gzip: 14.27 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mtools/index.cjs[22m       [2m43.17 kB[22m [2m│ gzip:  9.19 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1madvanced.cjs[22m          [2m 6.26 kB[22m [2m│ gzip:  1.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mwebmcp.cjs[22m            [2m 3.75 kB[22m [2m│ gzip:  1.24 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mutils.cjs[22m             [2m 1.21 kB[22m [2m│ gzip:  0.34 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mreact18.cjs[22m           [2m 0.00 kB[22m [2m│ gzip:  0.02 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mStoreRegistry.cjs     [2m51.32 kB[22m [2m│ gzip: 13.45 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.cjs     [2m15.34 kB[22m [2m│ gzip:  3.62 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mcomparison.cjs        [2m 5.25 kB[22m [2m│ gzip:  1.36 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils2.cjs            [2m 3.57 kB[22m [2m│ gzip:  1.12 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrolldown-runtime.cjs  [2m 1.09 kB[22m [2m│ gzip:  0.53 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m 11 files, total: 202.25 kB
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map                [2m 6.45 kB[22m [2m│ gzip: 2.23 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mtools/index.d.cts.map          [2m 1.74 kB[22m [2m│ gzip: 0.70 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.d.cts.map        [2m 1.25 kB[22m [2m│ gzip: 0.62 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.types.d.cts.map  [2m 1.23 kB[22m [2m│ gzip: 0.51 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mtypes.d.cts.map                [2m 1.19 kB[22m [2m│ gzip: 0.50 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mStore.d.cts.map                [2m 0.96 kB[22m [2m│ gzip: 0.50 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils.d.cts.map                [2m 0.74 kB[22m [2m│ gzip: 0.39 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22madvanced.d.cts.map             [2m 0.39 kB[22m [2m│ gzip: 0.25 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mwebmcp.d.cts.map               [2m 0.19 kB[22m [2m│ gzip: 0.17 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m                    [2m19.34 kB[22m [2m│ gzip: 4.07 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mtools/index.d.cts[22m[39m              [2m 5.91 kB[22m [2m│ gzip: 1.54 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1madvanced.d.cts[22m[39m                 [2m 2.61 kB[22m [2m│ gzip: 0.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mutils2.d.cts[22m[39m                   [2m 1.02 kB[22m [2m│ gzip: 0.40 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mwebmcp.d.cts[22m[39m                   [2m 0.63 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mreact18.d.cts[22m[39m                  [2m 0.08 kB[22m [2m│ gzip: 0.08 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mActionContext.d.cts[39m            [2m 4.37 kB[22m [2m│ gzip: 1.38 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes.d.cts[39m                    [2m 4.07 kB[22m [2m│ gzip: 1.35 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mStore.d.cts[39m                    [2m 3.19 kB[22m [2m│ gzip: 1.12 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mActionContext.types.d.cts[39m      [2m 3.11 kB[22m [2m│ gzip: 0.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mutils.d.cts[39m                    [2m 1.79 kB[22m [2m│ gzip: 0.77 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m 20 files, total: 60.26 kB
+@context-action/react: [32m✔[39m Build complete in [32m943ms[39m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                      [2m 68.72 kB[22m [2m│ gzip: 14.06 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mtools/index.js[22m                [2m 39.97 kB[22m [2m│ gzip:  9.02 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1madvanced.js[22m                   [2m  5.11 kB[22m [2m│ gzip:  1.78 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mwebmcp.js[22m                     [2m  3.65 kB[22m [2m│ gzip:  1.20 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mutils.js[22m                      [2m  0.40 kB[22m [2m│ gzip:  0.19 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mreact18.js[22m                    [2m  0.00 kB[22m [2m│ gzip:  0.02 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map                  [2m156.58 kB[22m [2m│ gzip: 33.44 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStoreRegistry.js.map          [2m103.54 kB[22m [2m│ gzip: 27.95 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtools/index.js.map            [2m 79.57 kB[22m [2m│ gzip: 17.99 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStoreRegistry.js              [2m 48.55 kB[22m [2m│ gzip: 13.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.js.map          [2m 32.51 kB[22m [2m│ gzip:  8.24 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.js              [2m 14.70 kB[22m [2m│ gzip:  3.54 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mcomparison.js.map             [2m 11.82 kB[22m [2m│ gzip:  3.59 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22madvanced.js.map               [2m  9.37 kB[22m [2m│ gzip:  3.25 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mwebmcp.js.map                 [2m  7.09 kB[22m [2m│ gzip:  2.36 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map                [2m  6.45 kB[22m [2m│ gzip:  2.23 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mcomparison.js                 [2m  4.68 kB[22m [2m│ gzip:  1.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils2.js.map                 [2m  4.14 kB[22m [2m│ gzip:  1.20 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils2.js                     [2m  3.55 kB[22m [2m│ gzip:  1.11 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtools/index.d.ts.map          [2m  1.74 kB[22m [2m│ gzip:  0.70 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.d.ts.map        [2m  1.25 kB[22m [2m│ gzip:  0.62 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.types.d.ts.map  [2m  1.23 kB[22m [2m│ gzip:  0.51 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtypes.d.ts.map                [2m  1.18 kB[22m [2m│ gzip:  0.50 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStore.d.ts.map                [2m  0.95 kB[22m [2m│ gzip:  0.50 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils.d.ts.map                [2m  0.74 kB[22m [2m│ gzip:  0.38 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22madvanced.d.ts.map             [2m  0.39 kB[22m [2m│ gzip:  0.25 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mwebmcp.d.ts.map               [2m  0.19 kB[22m [2m│ gzip:  0.17 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m                    [2m 19.34 kB[22m [2m│ gzip:  4.06 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mtools/index.d.ts[22m[39m              [2m  5.90 kB[22m [2m│ gzip:  1.54 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1madvanced.d.ts[22m[39m                 [2m  2.61 kB[22m [2m│ gzip:  0.90 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mutils2.d.ts[22m[39m                   [2m  1.02 kB[22m [2m│ gzip:  0.39 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mwebmcp.d.ts[22m[39m                   [2m  0.62 kB[22m [2m│ gzip:  0.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mreact18.d.ts[22m[39m                  [2m  0.08 kB[22m [2m│ gzip:  0.08 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mActionContext.d.ts[39m            [2m  4.37 kB[22m [2m│ gzip:  1.38 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes.d.ts[39m                    [2m  4.06 kB[22m [2m│ gzip:  1.35 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mStore.d.ts[39m                    [2m  3.19 kB[22m [2m│ gzip:  1.12 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mActionContext.types.d.ts[39m      [2m  3.11 kB[22m [2m│ gzip:  0.91 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mutils.d.ts[39m                    [2m  1.82 kB[22m [2m│ gzip:  0.78 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m 38 files, total: 654.23 kB
+@context-action/react: [32m✔[39m Build complete in [32m953ms[39m
+
+> @context-action/llms-generator:build
+
+@context-action/llms-generator: (node:64835) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:64848) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 build /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > tsdown
+@context-action/llms-generator: (node:64882) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/llms-generator: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/llms-generator/tsdown.config.ts[24m 
+@context-action/llms-generator: [34mℹ[39m entry: [34msrc/index.ts, src/cli/index.ts[39m
+@context-action/llms-generator: [34mℹ[39m target: [34mnode24[39m
+@context-action/llms-generator: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/llms-generator: [34mℹ[39m Build start
+@context-action/llms-generator: [34mℹ[39m Cleaning 10 files
+@context-action/llms-generator: [34mℹ[39m Granting execute permission to [4mdist/cli/index.js[24m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[1mcli/index.js[22m        [2m186.78 kB[22m [2m│ gzip: 41.50 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[1mindex.js[22m            [2m  0.13 kB[22m [2m│ gzip:  0.11 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mcli/index.js.map    [2m377.59 kB[22m [2m│ gzip: 82.14 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22msrc.js.map          [2m 36.89 kB[22m [2m│ gzip:  7.87 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22msrc.js              [2m 20.92 kB[22m [2m│ gzip:  4.89 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mindex.d.ts.map      [2m  1.76 kB[22m [2m│ gzip:  0.60 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mcli/index.d.ts.map  [2m  0.11 kB[22m [2m│ gzip:  0.12 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m          [2m  7.05 kB[22m [2m│ gzip:  2.06 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[32m[1mcli/index.d.ts[22m[39m      [2m  0.14 kB[22m [2m│ gzip:  0.13 kB[22m
+@context-action/llms-generator: [34mℹ[39m 9 files, total: 631.36 kB
+@context-action/llms-generator: [32m✔[39m Build complete in [32m681ms[39m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target build for 10 projects
+
+
+
+> context-action-monorepo@1.0.1 test:ai-sdk-integration /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/tool-protocol build && pnpm --filter @context-action/ai-sdk build && node scripts/verify-ai-sdk-runtime.mjs
+
+
+> @context-action/tool-protocol@1.0.0-rc.0 build /Users/junwoobang/workflow/context-action/packages/tool-protocol
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/tool-protocol/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2020
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  41.89 kB │ gzip: 11.34 kB
+ℹ [CJS] 1 files, total: 41.89 kB
+ℹ [ESM] dist/index.js        40.37 kB │ gzip: 11.14 kB
+ℹ [ESM] dist/index.js.map    89.50 kB │ gzip: 22.52 kB
+ℹ [ESM] dist/index.d.ts.map   4.04 kB │ gzip:  1.51 kB
+ℹ [ESM] dist/index.d.ts      19.63 kB │ gzip:  4.10 kB
+ℹ [ESM] 4 files, total: 153.53 kB
+ℹ [CJS] dist/index.d.cts.map   4.04 kB │ gzip: 1.51 kB
+ℹ [CJS] dist/index.d.cts      19.63 kB │ gzip: 4.10 kB
+ℹ [CJS] 2 files, total: 23.66 kB
+✔ Build complete in 630ms
+✔ Build complete in 630ms
+
+> @context-action/ai-sdk@0.1.0 build /Users/junwoobang/workflow/context-action/packages/ai-sdk
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/ai-sdk/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2022
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  6.34 kB │ gzip: 2.21 kB
+ℹ [CJS] 1 files, total: 6.34 kB
+ℹ [CJS] dist/index.d.cts.map  0.49 kB │ gzip: 0.32 kB
+ℹ [CJS] dist/index.d.cts      2.36 kB │ gzip: 0.74 kB
+ℹ [CJS] 2 files, total: 2.85 kB
+✔ Build complete in 666ms
+ℹ [ESM] dist/index.js         6.14 kB │ gzip: 2.16 kB
+ℹ [ESM] dist/index.js.map    14.63 kB │ gzip: 4.78 kB
+ℹ [ESM] dist/index.d.ts.map   0.49 kB │ gzip: 0.32 kB
+ℹ [ESM] dist/index.d.ts       2.36 kB │ gzip: 0.74 kB
+ℹ [ESM] 4 files, total: 23.62 kB
+✔ Build complete in 667ms
+AI SDK runtime integration passed
+
+> context-action-monorepo@1.0.1 verify:doc-snippets /Users/junwoobang/workflow/context-action
+> node scripts/verify-doc-snippets.mjs
+
+Documentation snippets compiled: 2
+
+> context-action-monorepo@1.0.1 verify:core-artifact-parity /Users/junwoobang/workflow/context-action
+> node scripts/verify-core-artifact-parity.mjs
+
+Verified core ESM/CJS runtime parity for diagnostics, limits, conditions, and timeout validation.
+
+> context-action-monorepo@1.0.1 verify:react-artifact-boundary /Users/junwoobang/workflow/context-action
+> node scripts/verify-react-artifact-boundary.mjs
+
+Verified React production artifact boundaries: default entry is tool-free and tools entry is explicit.
+
+> context-action-monorepo@1.0.1 verify:package-exports /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-exports.mjs
+
+
+@context-action/ai-sdk
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/core
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/llms-generator
+  ✓ . import -> ./dist/index.js [ESM loaded]
+  ✓ . types -> ./dist/index.d.ts
+  ✓ ./cli import -> ./dist/cli/index.js [ESM loaded]
+  ✓ ./cli types -> ./dist/cli/index.d.ts
+
+@context-action/mutative
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/mutative-core
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/react
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+  ✓ ./advanced import/types -> ./dist/advanced.d.ts
+  ✓ ./advanced import/default -> ./dist/advanced.js [ESM loaded]
+  ✓ ./advanced require/types -> ./dist/advanced.d.cts
+  ✓ ./advanced require/default -> ./dist/advanced.cjs [CJS loaded]
+  ✓ ./utils import/types -> ./dist/utils.d.ts
+  ✓ ./utils import/default -> ./dist/utils.js [ESM loaded]
+  ✓ ./utils require/types -> ./dist/utils.d.cts
+  ✓ ./utils require/default -> ./dist/utils.cjs [CJS loaded]
+  ✓ ./react18 import/types -> ./dist/react18.d.ts
+  ✓ ./react18 import/default -> ./dist/react18.js [ESM loaded]
+  ✓ ./react18 require/types -> ./dist/react18.d.cts
+  ✓ ./react18 require/default -> ./dist/react18.cjs [CJS loaded]
+  ✓ ./tools import/types -> ./dist/tools/index.d.ts
+  ✓ ./tools import/default -> ./dist/tools/index.js [ESM loaded]
+  ✓ ./tools require/types -> ./dist/tools/index.d.cts
+  ✓ ./tools require/default -> ./dist/tools/index.cjs [CJS loaded]
+  ✓ ./webmcp import/types -> ./dist/webmcp.d.ts
+  ✓ ./webmcp import/default -> ./dist/webmcp.js [ESM loaded]
+  ✓ ./webmcp require/types -> ./dist/webmcp.d.cts
+  ✓ ./webmcp require/default -> ./dist/webmcp.cjs [CJS loaded]
+
+@context-action/tool-durable-operations
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/tool-protocol
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/typedoc-vitepress-sync
+  ✓ . import -> ./dist/index.js [ESM loaded]
+  ✓ . types -> ./dist/index.d.ts
+  ✓ ./cli import -> ./bin/cli.js [runtime load skipped: executable CLI]
+
+@context-action/webmcp
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+  ✓ ./profiles/chrome-legacy import/types -> ./dist/profiles/chrome-legacy.d.ts
+  ✓ ./profiles/chrome-legacy import/default -> ./dist/profiles/chrome-legacy.js [ESM loaded]
+  ✓ ./profiles/chrome-legacy require/types -> ./dist/profiles/chrome-legacy.d.cts
+  ✓ ./profiles/chrome-legacy require/default -> ./dist/profiles/chrome-legacy.cjs [CJS loaded]
+
+Verified 10 packages, 63 export targets, and 31 runtime loads.
+
+> context-action-monorepo@1.0.1 verify:package-tarballs /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-tarballs.mjs
+
+
+@context-action/ai-sdk
+  ✓ context-action-ai-sdk-0.1.0.tgz (10 files, 7 manifest targets)
+
+@context-action/core
+  ✓ context-action-core-1.0.0-rc.0.tgz (10 files, 7 manifest targets)
+
+@context-action/llms-generator
+  ✓ context-action-llms-generator-0.8.7.tgz (17 files, 7 manifest targets)
+
+@context-action/mutative
+  ✓ context-action-mutative-0.8.8.tgz (11 files, 7 manifest targets)
+
+@context-action/mutative-core
+  ✓ context-action-mutative-core-0.8.8.tgz (13 files, 7 manifest targets)
+
+@context-action/react
+  ✓ context-action-react-1.0.0-rc.0.tgz (72 files, 27 manifest targets)
+
+@context-action/tool-durable-operations
+  ✓ context-action-tool-durable-operations-0.1.1.tgz (20 files, 8 manifest targets)
+
+@context-action/tool-protocol
+  ✓ context-action-tool-protocol-1.0.0-rc.0.tgz (11 files, 7 manifest targets)
+
+@context-action/typedoc-vitepress-sync
+  ✓ context-action-typedoc-vitepress-sync-0.8.8.tgz (8 files, 6 manifest targets)
+
+@context-action/webmcp
+  ✓ context-action-webmcp-0.1.0-rc.0.tgz (17 files, 11 manifest targets)
+
+Verified 10 npm package tarballs against their package publication contracts.
+
+> context-action-monorepo@1.0.1 package-boundary:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-boundaries.mjs
+
+Workspace package-boundary verification
+- workspace packages: 13
+- integration hosts: 2
+- source files scanned: 949
+- workspace imports checked: 300
+- violations: 0
+
+> context-action-monorepo@1.0.1 package-boundary:test /Users/junwoobang/workflow/context-action
+> node --test scripts/verify-package-boundaries.test.mjs
+
+✔ accepts declared workspace imports through exported entry points (206.689916ms)
+✔ rejects missing declarations and private workspace subpath imports (180.125375ms)
+✔ allows development-only imports in tests but rejects them from runtime source (363.447ms)
+✔ rejects relative imports that escape an owning package (178.645792ms)
+ℹ tests 4
+ℹ suites 0
+ℹ pass 4
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 983.916042
+
+> context-action-monorepo@1.0.1 verify:local-tool-consumers /Users/junwoobang/workflow/context-action
+> node scripts/verify-published-tool-consumers.cjs --local
+
+
+added 20 packages in 2s
+published tool package consumer imports passed: @context-action/core, @context-action/mutative-core, @context-action/mutative, @context-action/tool-protocol, @context-action/tool-durable-operations, @context-action/react/tools, @context-action/ai-sdk, @context-action/webmcp
+Local tarball tool package consumer smoke test passed: file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-ZAeC7d/local-packages/context-action-core-1.0.0-rc.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-ZAeC7d/local-packages/context-action-mutative-core-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-ZAeC7d/local-packages/context-action-mutative-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-ZAeC7d/local-packages/context-action-tool-protocol-1.0.0-rc.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-ZAeC7d/local-packages/context-action-tool-durable-operations-0.1.1.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-ZAeC7d/local-packages/context-action-react-1.0.0-rc.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-ZAeC7d/local-packages/context-action-ai-sdk-0.1.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-ZAeC7d/local-packages/context-action-webmcp-0.1.0-rc.0.tgz, react@19.2.8, ai@7.0.34, typescript@6.0.3
+
+> context-action-monorepo@1.0.1 verify:v1-lifecycle /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-lifecycle-contract.mjs
+
+Wrote passed lifecycle report to reports/release/v1.0.0/test-results/lifecycle-report.json
+
+> context-action-monorepo@1.0.1 verify:v1-release-manifest /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-manifest.mjs
+
+{"status":"ok","manifest":"docs/releases/v1.0.0/release-manifest.json","stage":"candidate-unapproved"}
+
+> context-action-monorepo@1.0.1 verify:v1-supply-chain /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-supply-chain.mjs
+
+Wrote passed supply-chain report to reports/release/v1.0.0/security-report.json
+
+> context-action-monorepo@1.0.1 tool-durable:test:evidence /Users/junwoobang/workflow/context-action
+> node --test scripts/verify-durable-operation-evidence-schema.test.mjs
+
+✔ complete evidence passes the strict deployment gate (80.158542ms)
+✔ schema-valid incomplete evidence is rejected by the strict gate (156.238458ms)
+ℹ tests 2
+ℹ suites 0
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 282.176708
+
+> context-action-monorepo@1.0.1 lint /Users/junwoobang/workflow/context-action
+> biome lint packages/core/src packages/tool-protocol/src packages/ai-sdk/src packages/webmcp/src packages/tool-durable-operations/src packages/react/src packages/mutative-core/src packages/mutative/src packages/llms-generator/src packages/typedoc-vitepress-sync/src scripts/security-audit.mjs scripts/verify-private-tools.mjs scripts/verify-package-boundaries.mjs scripts/verify-package-boundaries.test.mjs scripts/verify-durable-operation-evidence-schema.mjs scripts/verify-durable-operation-evidence-schema.test.mjs scripts/verify-ai-sdk-runtime.mjs scripts/verify-doc-snippets.mjs scripts/verify-react-compatibility.mjs scripts/verify-react-artifact-boundary.mjs scripts/verify-core-artifact-parity.mjs scripts/write-release-evidence.mjs scripts/verify-release-evidence.mjs scripts/release-evidence.test.mjs scripts/generate-release-inventory.mjs scripts/verify-v1-release-roadmap-alignment.mjs scripts/verify-react-webmcp-isolation.mjs scripts/verify-v1-core-migration-fixture.mjs scripts/verify-v1-lifecycle-contract.mjs scripts/verify-v1-release-manifest.mjs scripts/verify-v1-supply-chain.mjs
+
+Checked 161 files in 86ms. No fixes applied.
+
+> context-action-monorepo@1.0.1 convention:check /Users/junwoobang/workflow/context-action
+> node scripts/check-context-layered-conventions.mjs
+
+Context-Layered convention check
+- transitional direct registrations: 0 file(s)
+- stale transitional allowlist entries: 0 file(s)
+- invalid direct registrations: 0 file(s)
+- provider-order violations: 0 occurrence(s)
+- canonical layered roots: 31
+- layer-path/name violations: 0 occurrence(s)
+- classified non-canonical handler roots: 2 (advanced 1, compatibility 1)
+- migration classification violations: 0 occurrence(s)
+
+> context-action-monorepo@1.0.1 docs:management /Users/junwoobang/workflow/context-action
+> node scripts/verify-documentation-management.mjs
+
+Documentation management verification
+- paired directories checked: 3
+- issue forms checked: 3
+- convention discovery links checked: en, ko
+- change-management metadata and handoff checklist checked: en, ko
+- decision-record home and package-boundary gate checked: en, ko
+
+> context-action-monorepo@1.0.1 llms:check /Users/junwoobang/workflow/context-action
+> node packages/llms-generator/dist/cli/index.js detect-mismatches --check-only --fail-on-mismatch
+
+
+> context-action-monorepo@1.0.1 type-check /Users/junwoobang/workflow/context-action
+> lerna run type-check
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target type-check for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:type-check
+
+
+> @context-action/mutative-core:type-check
+
+
+> @context-action/tool-durable-operations:type-check
+
+
+> @context-action/typedoc-vitepress-sync:type-check
+
+@context-action/mutative-core: (node:67139) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:67141) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:67138) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:67140) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:67168) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:67165) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:67169) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:67166) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 type-check /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0-rc.0 type-check /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > tsc --noEmit
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > tsc --noEmit
+@context-action/tool-protocol: (node:67296) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:67295) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 type-check:src /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsc --noEmit
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0-rc.0 type-check:src /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsc --noEmit
+
+> @context-action/mutative:type-check
+
+@context-action/mutative: (node:67367) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:67374) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:67381) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 test:type-check /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0-rc.0 test:type-check /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/mutative: (node:67388) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: > @context-action/mutative@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > tsc --noEmit
+
+> @context-action/core:type-check
+
+
+> @context-action/webmcp:type-check
+
+
+> @context-action/ai-sdk:type-check
+
+@context-action/ai-sdk: (node:67490) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:67489) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:67488) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:67510) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:67511) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:67513) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/webmcp: > @context-action/webmcp@0.1.0-rc.0 type-check /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/core: > @context-action/core@1.0.0-rc.0 type-check /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/ai-sdk: (node:67612) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:67611) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:67610) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: > @context-action/webmcp@0.1.0-rc.0 type-check:src /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsc --noEmit
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 type-check:src /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsc --noEmit
+@context-action/core: > @context-action/core@1.0.0-rc.0 type-check:src /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsc --noEmit
+@context-action/core: (node:67722) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:67728) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: > @context-action/core@1.0.0-rc.0 test:type-check /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/ai-sdk: (node:67735) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: > @context-action/webmcp@0.1.0-rc.0 test:type-check /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 test:type-check /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsc -p __tests__/tsconfig.json --pretty false
+
+> @context-action/react:type-check
+
+@context-action/react: (node:68082) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:68171) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0-rc.0 type-check /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/react: (node:68221) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0-rc.0 type-check:src /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > tsc --noEmit
+@context-action/react: (node:68290) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0-rc.0 test:type-check /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > tsc -p __tests__/tsconfig.json --pretty false
+
+> @context-action/llms-generator:type-check
+
+@context-action/llms-generator: (node:68329) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:68336) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 type-check /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > tsc --noEmit
+
+
+
+ Lerna (powered by Nx)   Successfully ran target type-check for 10 projects
+
+
+
+> context-action-monorepo@1.0.1 test /Users/junwoobang/workflow/context-action
+> lerna run test
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target test for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:test
+
+
+> @context-action/mutative-core:test
+
+
+> @context-action/tool-durable-operations:test
+
+
+> @context-action/typedoc-vitepress-sync:test
+
+@context-action/tool-protocol: (node:68500) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68503) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:68502) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:68501) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68525) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:68521) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:68531) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:68533) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 test /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > jest
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 test /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0-rc.0 test /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 test /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > vitest run --config vitest.config.ts
+@context-action/mutative-core: (node:68637) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:68605) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68562) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:68612) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core:  RUN  v4.1.10 /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: (node:68850) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:68849) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:68851) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68856) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68855) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:68852) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68859) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68854) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68857) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68858) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68861) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68853) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:68860) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: [1mTest Suites: [22m[1m[32m5 passed[39m[22m, 5 total
+@context-action/tool-protocol: [1mTests:       [22m[1m[32m57 passed[39m[22m, 57 total
+@context-action/tool-protocol: [1mSnapshots:   [22m0 total
+@context-action/tool-protocol: [1mTime:[22m        0.922 s, estimated 1 s
+@context-action/tool-protocol: [2mRan all test suites[22m[2m.[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Package directory not found: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat SidebarGenerator.warn [as parseApiStructure] ([22m[2msrc/processors/SidebarGenerator.ts[2m:37:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.parseApiStructure [as sync] ([22m[2msrc/index.ts[2m:184:50)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:96:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.06s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 0
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/source/packages/test-package/test.md: Error: EACCES: permission denied, mkdir '/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test'[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:116:9)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Package directory not found: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat SidebarGenerator.warn [as parseApiStructure] ([22m[2msrc/processors/SidebarGenerator.ts[2m:37:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.parseApiStructure [as sync] ([22m[2msrc/index.ts[2m:184:50)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:116:9)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/source/packages/test-package/test.md: ENOSPC: no space left on device[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Recovery: No space left on device
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] 💡 Tip: Free up disk space and try again[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.error [as action] ([22m[2msrc/core/ErrorHandler.ts[2m:33:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.action [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:83:23)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-hanging/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/source/packages/test-package/huge.md: Markdown file exceeds the 8388608 byte processing limit: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/source/packages/test-package/huge.md[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:177:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 2 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 2
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.03s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 2
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: ./reports/typedoc-vitepress-sync-metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.07s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: ./reports/typedoc-vitepress-sync-metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.07s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/mutative-core:  Test Files  4 passed (4)
+@context-action/mutative-core:       Tests  29 passed (29)
+@context-action/mutative-core:    Start at  12:44:39
+@context-action/mutative-core:    Duration  973ms (transform 2.02s, setup 78ms, import 2.47s, tests 48ms, environment 1ms)
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest loaded: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 3
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 50.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 3
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+
+> @context-action/core:test
+
+
+> @context-action/webmcp:test
+
+
+> @context-action/ai-sdk:test
+
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest loaded: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed 1 stale generated API file(s) from .test-sync/target/test
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 2 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 2
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 40.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 2
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+
+> @context-action/mutative:test
+
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 4 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 4
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 4
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:310:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in .test-sync/target/test/problematic.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/TypeDocVitePressSync.test.ts[39m[0m[2m:196:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 4 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 4
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 4
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in .test-sync/target/test/bad.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-0.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-1.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🧹 Cleaning cache and generated files...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache cleared
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed target directory: .test-sync/target
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed sidebar config: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] ✅ Cleanup completed
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-10.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-11.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-12.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Auto-configured parallel processing: batchSize=18, maxWorkers=8
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Auto-optimization configured
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-13.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-14.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-15.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-16.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-17.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-18.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-19.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-2.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-20.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-21.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-22.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-23.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-24.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-25.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-26.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-27.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-28.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-29.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-3.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-30.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-31.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-32.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-33.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-34.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-35.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-36.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-37.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-38.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-39.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-4.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-40.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-41.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-42.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-43.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-44.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-45.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-46.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-47.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-48.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-49.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-5.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-50.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-51.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-52.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-53.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-54.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-55.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-56.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-57.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-58.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-59.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-6.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-60.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-61.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-62.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-63.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-64.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-65.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-66.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-67.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-68.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-69.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-7.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/core: (node:68870) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-70.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-71.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-72.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-73.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-74.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-75.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-76.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-77.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-78.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-79.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-8.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/webmcp: (node:68871) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:68872) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-80.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-81.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/mutative: (node:68873) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-82.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-83.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-84.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-85.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-86.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-87.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-88.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-89.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-9.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-90.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-91.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-92.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-93.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-94.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-95.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-96.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-97.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-98.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test-99.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 100 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 100
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.23s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 100
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 100
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/tool-durable-operations: [1mTest Suites: [22m[1m[32m9 passed[39m[22m, 9 total
+@context-action/tool-durable-operations: [1mTests:       [22m[1m[33m2 skipped[39m[22m, [1m[32m43 passed[39m[22m, 45 total
+@context-action/tool-durable-operations: [1mSnapshots:   [22m0 total
+@context-action/tool-durable-operations: [1mTime:[22m        1.45 s
+@context-action/tool-durable-operations: [2mRan all test suites[22m[2m.[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 50 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 50
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.04s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 50
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Transient write failure for /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test.md; retrying (1/3)[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.warn [as writeFileWithRetry] ([22m[2msrc/core/FileProcessor.ts[2m:281:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.writeFileWithRetry [as processFile] ([22m[2msrc/core/FileProcessor.ts[2m:104:12)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:404:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Transient write failure for /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/target/test/test.md; retrying (2/3)[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.warn [as writeFileWithRetry] ([22m[2msrc/core/FileProcessor.ts[2m:281:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.writeFileWithRetry [as processFile] ([22m[2msrc/core/FileProcessor.ts[2m:104:12)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:404:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/source/packages/test-package/test.md: EACCES: permission denied[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:439:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Recovery: Permission denied
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] 💡 Tip: Check file permissions or run with appropriate privileges[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.warn [as action] ([22m[2msrc/core/ErrorHandler.ts[2m:26:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.action [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:83:23)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:439:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/source/packages/test-package/valid.md: Simulated failure[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:471:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-68855/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/core: (node:68889) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:68902) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:68905) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:68906) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: > @context-action/core@1.0.0-rc.0 test /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 test /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > jest --runInBand
+@context-action/mutative: > @context-action/mutative@0.8.8 test /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > vitest run
+@context-action/webmcp: > @context-action/webmcp@0.1.0-rc.0 test /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > jest --runInBand
+@context-action/mutative: (node:68997) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:68963) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:69013) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:68948) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative:  RUN  v4.1.10 /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/typedoc-vitepress-sync: [1mTest Suites: [22m[1m[33m1 skipped[39m[22m, [1m[32m8 passed[39m[22m, 8 of 9 total
+@context-action/typedoc-vitepress-sync: [1mTests:       [22m[1m[33m15 skipped[39m[22m, [1m[32m113 passed[39m[22m, 128 total
+@context-action/typedoc-vitepress-sync: [1mSnapshots:   [22m0 total
+@context-action/typedoc-vitepress-sync: [1mTime:[22m        1.965 s, estimated 2 s
+@context-action/typedoc-vitepress-sync: [2mRan all test suites[22m[2m.[22m
+@context-action/mutative: (node:69197) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:69198) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:69191) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:69196) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: [1mTest Suites: [22m[1m[32m1 passed[39m[22m, 1 total
+@context-action/ai-sdk: [1mTests:       [22m[1m[32m15 passed[39m[22m, 15 total
+@context-action/ai-sdk: [1mSnapshots:   [22m0 total
+@context-action/ai-sdk: [1mTime:[22m        0.282 s, estimated 1 s
+@context-action/ai-sdk: [2mRan all test suites[22m[2m.[22m
+@context-action/mutative:  Test Files  4 passed (4)
+@context-action/mutative:       Tests  40 passed (40)
+@context-action/mutative:    Start at  12:44:41
+@context-action/mutative:    Duration  367ms (transform 298ms, setup 0ms, import 395ms, tests 33ms, environment 0ms)
+@context-action/webmcp: [1mTest Suites: [22m[1m[32m2 passed[39m[22m, 2 total
+@context-action/webmcp: [1mTests:       [22m[1m[32m18 passed[39m[22m, 18 total
+@context-action/webmcp: [1mSnapshots:   [22m0 total
+@context-action/webmcp: [1mTime:[22m        0.333 s, estimated 1 s
+@context-action/webmcp: [2mRan all test suites[22m[2m.[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:47.804Z] [DebugRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'parallel',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:47.808Z] [DebugRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.197Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.199Z] [ConcurrencyTest] Handler registered: updateUser {
+@context-action/core:       handlerId: 'updateUser_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.201Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.202Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.203Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.203Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.204Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.205Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.205Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.206Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.207Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.208Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.210Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.211Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.212Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.212Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.213Z] [ConcurrencyTest] Handler registered: updateUI { handlerId: 'ui-updater', priority: 60, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.214Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.214Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.215Z] [ConcurrencyTest] Handler registered: searchUsers { handlerId: 'user-search', priority: 80, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.217Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.218Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.219Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.220Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.220Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.221Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.236Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.237Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.237Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-0', priority: undefined, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.238Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-1', priority: undefined, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.238Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-2', priority: undefined, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.239Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-0', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.239Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-1', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.239Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-2', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.240Z] [ConcurrencyTest] Pipeline lookup for 'test' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.240Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.242Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.243Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.247Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.248Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.248Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.249Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.251Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Sequential: 0.00ms, Parallel: 0.00ms
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-docs-simple.test.ts[39m[0m[2m:456:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.252Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.253Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.254Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: 50,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.254Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_2',
+@context-action/core:       priority: 100,
+@context-action/core:       totalHandlers: 2
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.255Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.255Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.256Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler1', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.256Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler2', priority: 200, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.256Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler3', priority: 50, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.257Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.399Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.402Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.403Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.404Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.404Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.405Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.406Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.406Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.407Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.409Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.410Z] [WarningTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.411Z] [WarningTestRegister] Pipeline lookup for 'userLogout' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.411Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.414Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.415Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.415Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.417Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.418Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.418Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.419Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.420Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.420Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.421Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.422Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.422Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.422Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.422Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.423Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.424Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.424Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.425Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.426Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.427Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.428Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.428Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.429Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.498Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.501Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.503Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.504Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.504Z] [TypeOnlyTestRegister] Pipeline lookup for 'anotherTypeOnly' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.505Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.506Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.507Z] [TypeOnlyTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.509Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.510Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.511Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.512Z] [TypeOnlyTestRegister] Handler registered: userLogout { handlerId: 'logout-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.512Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin', 'userLogout' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.513Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.514Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.514Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.515Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.515Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.520Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.521Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.522Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.523Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.523Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.524Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.525Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.526Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.527Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.528Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.576Z] [ActionRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.578Z] [ActionRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.688Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.690Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Starting Promise.all operations...
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:48:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 completed { id: 1, timestamp: 1786247088692 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 completed { id: 2, timestamp: 1786247088693 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 completed { id: 3, timestamp: 1786247088693 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.694Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.695Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.695Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.696Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.697Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.697Z] [AsyncConcurrencyTest] Handler registered: syncTest { handlerId: 'sync-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.698Z] [AsyncConcurrencyTest] Handler registered: asyncTest { handlerId: 'async-handler', priority: 50, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.698Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.699Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.701Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T03:44:48.702Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [1mTest Suites: [22m[1m[32m34 passed[39m[22m, 34 total
+@context-action/core: [1mTests:       [22m[1m[32m766 passed[39m[22m, 766 total
+@context-action/core: [1mSnapshots:   [22m0 total
+@context-action/core: [1mTime:[22m        7.194 s, estimated 8 s
+@context-action/core: [2mRan all test suites[22m[2m.[22m
+
+> @context-action/react:test
+
+@context-action/react: (node:69222) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69229) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0-rc.0 test /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > jest
+@context-action/react: (node:69257) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69338) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69334) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69335) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69339) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69331) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69332) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69341) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69340) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69333) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69336) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:69337) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Performance Test Results:
+@context-action/react:           - setValue approach: 3 re-renders
+@context-action/react:           - notifyPath approach: 2 re-renders
+@context-action/react:           - Reduction: 33%
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:97:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Selective Re-rendering Proof:
+@context-action/react:           - user.name path: 2 renders (updated)
+@context-action/react:           - user.email path: 1 render (not updated)
+@context-action/react:           - ui.loading path: 1 render (not updated)
+@context-action/react:           - Efficiency: Only affected paths re-render
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:153:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ RAF Batching Proof:
+@context-action/react:           - notifyPath calls: 3
+@context-action/react:           - Re-renders after initial: 0 (batched)
+@context-action/react:           - Batching: Working
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:195:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ notifyPaths Batching Proof:
+@context-action/react:           - Paths notified: 3
+@context-action/react:           - RAF cycles: 1
+@context-action/react:           - Each subscriber: 2 total renders (1 initial + 1 batched)
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:248:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Event Loop Control Proof:
+@context-action/react:           - Total re-renders: 2
+@context-action/react:           - Loading state: notified without re-render
+@context-action/react:           - Final data: single re-render
+@context-action/react:           - Efficiency: Minimal render cycles
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:295:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Business Logic Separation Proof:
+@context-action/react:           - Validation: Pure function, no dependencies
+@context-action/react:           - Upload: Async operation with callbacks
+@context-action/react:           - Progress tracking: 11 updates
+@context-action/react:           - Result: file_1786247091895
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:203:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Infinite Loop Prevention Proof:
+@context-action/react:           - Subscription calls: 1 (not infinite)
+@context-action/react:           - Processing calls: 1
+@context-action/react:           - Method: Direct mutation + notifyPath
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:338:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           🔄 Batched vs Immediate Mode Comparison:
+@context-action/react:     
+@context-action/react:           Batched Mode (RAF):
+@context-action/react:           - Render count: 1
+@context-action/react:           - Behavior: Multiple notifyPath calls batched into single RAF frame
+@context-action/react:           - Use case: High-frequency updates, animations, smooth UI
+@context-action/react:     
+@context-action/react:           Immediate Mode:
+@context-action/react:           - Render count: 1
+@context-action/react:           - Behavior: Each notifyPath triggers immediate notification
+@context-action/react:           - Use case: Critical updates, testing, predictable timing
+@context-action/react:     
+@context-action/react:           Difference: 0 additional renders in immediate mode
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:398:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           📊 Performance Benchmark (100 iterations):
+@context-action/react:     
+@context-action/react:           setValue Approach:
+@context-action/react:           - Total renders: 101
+@context-action/react:           - Time: 3200.00ms
+@context-action/react:     
+@context-action/react:           notifyPath Approach:
+@context-action/react:           - Total renders: 101
+@context-action/react:           - Time: 3200.00ms
+@context-action/react:     
+@context-action/react:           Improvements:
+@context-action/react:           - Render reduction: 0.0%
+@context-action/react:           - Time improvement: 0.0%
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:480:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Async State Machine Proof:
+@context-action/react:           - State transitions: validating → uploading → processing → complete
+@context-action/react:           - Progress updates: 11 notifications
+@context-action/react:           - State renders: 5
+@context-action/react:           - Progress renders: 12
+@context-action/react:           - Status renders: 6
+@context-action/react:           - Pattern: Direct mutation + notifyPath for selective updates
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:305:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Progress-Only Update Proof:
+@context-action/react:           - Progress updates: 10
+@context-action/react:           - Progress renders: 10 (selective)
+@context-action/react:           - State renders: 0 (not affected)
+@context-action/react:           - Efficiency: 100% (no wasted renders)
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:361:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Modular Business Logic Integration Proof:
+@context-action/react:     
+@context-action/react:           Business Logic Layer:
+@context-action/react:           - FileUploadService: Pure business logic (validation, upload, processing)
+@context-action/react:           - No React/store dependencies in business code
+@context-action/react:     
+@context-action/react:           State Management Layer:
+@context-action/react:           - TimeTravelStore with mutable mode
+@context-action/react:           - Direct mutation + notifyPath pattern
+@context-action/react:           - Path-based selective updates
+@context-action/react:     
+@context-action/react:           Rendering Efficiency:
+@context-action/react:           - Files list renders: 3 (only when files change)
+@context-action/react:           - Active upload renders: 8 (only when active upload changes)
+@context-action/react:           - Progress updates: 5 (no files list re-renders)
+@context-action/react:     
+@context-action/react:           Architecture Benefits:
+@context-action/react:           - ✅ Business logic testable in isolation
+@context-action/react:           - ✅ State management decoupled from business logic
+@context-action/react:           - ✅ Selective re-rendering prevents wasted renders
+@context-action/react:           - ✅ Batch updates with notifyPaths for efficiency
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:483:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Error State Management Proof:
+@context-action/react:           - Business logic validation: File size check
+@context-action/react:           - State transition: idle → error
+@context-action/react:           - Error message: "File size exceeds 10MB limit"
+@context-action/react:           - Selective rendering: Only state + error paths updated
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:563:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Complex Multi-file Upload Queue Proof:
+@context-action/react:     
+@context-action/react:           Queue Management:
+@context-action/react:           - Files processed: 3
+@context-action/react:           - Failed uploads: 0
+@context-action/react:           - Queue size: 3
+@context-action/react:     
+@context-action/react:           State Updates:
+@context-action/react:           - Per-file state transitions: idle → uploading → complete
+@context-action/react:           - Per-file progress updates: 5 updates per file
+@context-action/react:           - Global processing state: true → false
+@context-action/react:           - Current index tracking: -1 → 0 → 1 → 2 → -1
+@context-action/react:     
+@context-action/react:           Performance Benefits:
+@context-action/react:           - Selective path updates (queue[i].progress only)
+@context-action/react:           - Batch updates with notifyPaths
+@context-action/react:           - No unnecessary re-renders of other queue items
+@context-action/react:     
+@context-action/react:           Business Logic:
+@context-action/react:           - Queue orchestration separated from UI
+@context-action/react:           - State machine per file
+@context-action/react:           - Progress tracking independent of state changes
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:673:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Dispatch references: [ '0: function', '1: function', '2: function' ]
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/actions/dispatch-stability.test.tsx[39m[0m[2m:209:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Unique dispatch references: 1
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/actions/dispatch-stability.test.tsx[39m[0m[2m:214:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🔄 [useMouseEventsLogic] Container unmounted, handlers deactivated
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:254:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🎯 [useMouseEventsLogic] Container mounted via reactive state
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:249:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🚀 [useMouseEventsLogic] Handlers are now ready
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:252:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Store references across Provider re-creations:
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:291:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     0: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     1: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     2: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:     🏪 Store 동시성 문제 분석 결과:
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:198:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     총 테스트: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:199:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Critical 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:200:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     High 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:201:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Medium 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:202:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     ✅ Immediate mode: Listeners triggered synchronously
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:56:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     ✅ Batched mode: Listeners deferred to RAF and batched
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:93:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:     📊 Mode Comparison Results:
+@context-action/react:     - Immediate mode: 5 notifications (5 notifyPath calls = 5 notifications)
+@context-action/react:     - Batched mode before RAF: 0 notifications
+@context-action/react:     - Batched mode after RAF: 1 notifications (5 notifyPath calls = 1 batched notification)
+@context-action/react:     - Difference: 4x more notifications in immediate mode
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:141:13)[22m[2m[22m
+@context-action/react: [1mTest Suites: [22m[1m[32m52 passed[39m[22m, 52 total
+@context-action/react: [1mTests:       [22m[1m[32m688 passed[39m[22m, 688 total
+@context-action/react: [1mSnapshots:   [22m0 total
+@context-action/react: [1mTime:[22m        [1m[33m3.753 s[39m[22m
+@context-action/react: [2mRan all test suites[22m[2m.[22m
+
+> @context-action/llms-generator:test
+
+@context-action/llms-generator: (node:69357) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:69364) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 test /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > jest
+@context-action/llms-generator: (node:69392) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: [1mTest Suites: [22m[1m[32m15 passed[39m[22m, 15 total
+@context-action/llms-generator: [1mTests:       [22m[1m[32m224 passed[39m[22m, 224 total
+@context-action/llms-generator: [1mSnapshots:   [22m0 total
+@context-action/llms-generator: [1mTime:[22m        1.508 s
+@context-action/llms-generator: [2mRan all test suites[22m[2m.[22m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target test for 10 projects
+
+
+
+> example@1.0.0 check /Users/junwoobang/workflow/context-action/example
+> biome check src && pnpm run verify:catalog && pnpm run verify:approval && pnpm run verify:trace && pnpm run verify:usecase && pnpm run verify:conditional && pnpm run verify:mouse-action && pnpm run verify:mouse-pattern && pnpm run verify:mouse-enhanced
+
+Checked 536 files in 226ms. No fixes applied.
+
+> example@1.0.0 verify:catalog /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-mcp-function-calling-catalog.mjs
+
+MCP/function-calling catalog contract check
+- UI catalog tool references checked: 7
+- standalone catalog tool references checked: 12
+- Live Code Editor catalog tool references checked: 8
+- realtime web-coding catalog tool references checked: 7
+- AI runner response-message history checked: 2 showcases
+- realtime local-agent source/mode contract checked
+- example tools/list/tools/call trace methods checked
+- example agent.request trace lifecycle checked
+- live editor agent/discovery trace lifecycle checked
+- live editor action/presentation boundary checked
+- live editor observability/settings/export boundaries checked
+- live editor document mutation/preview boundary checked
+- live editor workspace/document observability boundary checked
+- live editor reset approval boundary checked
+- realtime web-coding handler/action/presentation boundary checked
+- realtime web-coding observability/trace export boundary checked
+- realtime web-coding workspace action boundary checked
+- realtime web-coding shared document action boundary checked
+- realtime web-coding reset approval boundary checked
+
+> example@1.0.0 preverify:approval /Users/junwoobang/workflow/context-action/example
+> pnpm --filter @context-action/core build
+
+
+> @context-action/core@1.0.0-rc.0 build /Users/junwoobang/workflow/context-action/packages/core
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/core/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2020
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  113.21 kB │ gzip: 24.71 kB
+ℹ [CJS] 1 files, total: 113.21 kB
+ℹ [CJS] dist/index.d.cts.map   6.06 kB │ gzip: 2.10 kB
+ℹ [CJS] dist/index.d.cts      19.81 kB │ gzip: 4.50 kB
+ℹ [CJS] 2 files, total: 25.87 kB
+✔ Build complete in 840ms
+ℹ [ESM] dist/index.js        112.71 kB │ gzip: 24.64 kB
+ℹ [ESM] dist/index.js.map    268.68 kB │ gzip: 62.76 kB
+ℹ [ESM] dist/index.d.ts.map    6.06 kB │ gzip:  2.10 kB
+ℹ [ESM] dist/index.d.ts       19.81 kB │ gzip:  4.49 kB
+ℹ [ESM] 4 files, total: 407.25 kB
+✔ Build complete in 848ms
+
+> example@1.0.0 verify:approval /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-example-live-editor-approval.mjs
+
+Verified Live Code Editor filesystem approval lifecycle.
+
+> example@1.0.0 verify:trace /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-example-tool-call-trace.mjs
+
+Verified example tool trace provenance and no-raw-payload projection.
+
+> example@1.0.0 verify:usecase /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-live-usecase-conventions.mjs
+
+Live Code Editor usecase convention check
+- contexts: action + store providers
+- business: pure validation, packet, and activity functions
+- handlers: registry orchestration only
+- facade: reactive view model + stable commands
+- recipe: facade-driven presentation only
+
+> example@1.0.0 verify:conditional /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-conditional-permission-conventions.mjs
+
+Conditional permission usecase convention check
+- contexts: Action → Store provider boundary
+- business: pure role/action permission evaluation
+- actions: semantic check and secure-operation commands
+- handlers: Registry orchestration with fail-secure guard
+- page: facade-driven presentation and store subscriptions
+
+> example@1.0.0 verify:mouse-action /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-context-store-action-mouse-conventions.mjs
+
+Context-store action-based mouse convention check
+- contexts: Action + Store contracts and Provider boundary
+- business: pure path, velocity, and activity calculations
+- actions: typed handler factories using business rules
+- handlers: six action registrations in one Registry
+- compatibility: legacy store path re-export retained
+
+> example@1.0.0 verify:mouse-pattern /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-context-store-pattern-conventions.mjs
+
+Context-store pattern convention check
+- contexts: canonical boundary with legacy bridge isolated
+- provider: Action → Store → Registry composition
+- handlers: six mouse action registrations
+- consumers: no direct legacy context imports
+
+> example@1.0.0 verify:mouse-enhanced /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-enhanced-context-store-conventions.mjs
+
+Enhanced context-store convention check
+- contexts: typed Store, Action, and Ref contracts
+- business: pure movement, click, activity, and metric rules
+- actions: semantic mouse command facade
+- provider: Action → Store → Ref → Registry composition
+- handlers: five action registrations outside the View
+- compatibility: legacy model path re-export retained
+
+> example@1.0.0 prebuild /Users/junwoobang/workflow/context-action/example
+> pnpm --filter @context-action/openrouter-browser-storage check && pnpm --filter @context-action/openrouter-browser-storage build
+
+
+> @context-action/openrouter-browser-storage@0.0.0 check /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage
+> pnpm exec biome check src
+
+Checked 1 file in 5ms. No fixes applied.
+
+> @context-action/openrouter-browser-storage@0.0.0 build /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24.11.0
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+
+ WARN  We recommend using the ESM format instead of CommonJS.
+The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+
+ℹ Cleaning 8 files
+ℹ [CJS] dist/index.cjs      2.80 kB │ gzip: 0.93 kB
+ℹ [CJS] dist/index.cjs.map  4.00 kB │ gzip: 1.43 kB
+ℹ [CJS] 2 files, total: 6.80 kB
+ℹ [CJS] dist/index.d.cts.map  0.13 kB │ gzip: 0.13 kB
+ℹ [CJS] dist/index.d.cts      0.57 kB │ gzip: 0.27 kB
+ℹ [CJS] 2 files, total: 0.70 kB
+✔ Build complete in 416ms
+ℹ [ESM] dist/index.js        2.55 kB │ gzip: 0.87 kB
+ℹ [ESM] dist/index.js.map    4.00 kB │ gzip: 1.43 kB
+ℹ [ESM] dist/index.d.ts.map  0.13 kB │ gzip: 0.13 kB
+ℹ [ESM] dist/index.d.ts      0.57 kB │ gzip: 0.26 kB
+ℹ [ESM] 4 files, total: 7.25 kB
+✔ Build complete in 418ms
+
+> example@1.0.0 build /Users/junwoobang/workflow/context-action/example
+> tsc && vite build
+
+vite v8.1.5 building client environment for production...
+[2Ktransforming...✓ 617 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/index.html                                                   2.23 kB │ gzip:   0.97 kB
+dist/assets/ChatPage-ubcKJM2V.css                                 1.21 kB │ gzip:   0.49 kB
+dist/assets/LiveCodeEditorPage-BGn3uVXL.css                       3.00 kB │ gzip:   1.07 kB
+dist/assets/PriorityPerformancePage-BJCO70AV.css                  4.87 kB │ gzip:   1.21 kB
+dist/assets/ToolContextAIDemo-ByChMvQp.css                        7.79 kB │ gzip:   1.91 kB
+dist/assets/LiveWebCodingPage-C_ERQ4ZK.css                       10.75 kB │ gzip:   2.83 kB
+dist/assets/tool-result-format-D5ejSXo7.css                      17.45 kB │ gzip:   4.07 kB
+dist/assets/index-BhQagSdA.css                                  103.05 kB │ gzip:  15.27 kB
+dist/assets/github-DKNKrW6Q.js                                    0.33 kB │ gzip:   0.23 kB
+dist/assets/rolldown-runtime-b3L32Ng1.js                          0.69 kB │ gzip:   0.42 kB
+dist/assets/useSourceLinkRegistration-CWVhPFw4.js                 0.87 kB │ gzip:   0.51 kB
+dist/assets/Container-Ccwmkx4I.js                                 0.97 kB │ gzip:   0.60 kB
+dist/assets/Status-1r9AZ6wY.js                                    1.26 kB │ gzip:   0.70 kB
+dist/assets/useRegisterSourceFile-WayGyomj.js                     1.53 kB │ gzip:   0.74 kB
+dist/assets/Card-BPUJpjf_.js                                      2.68 kB │ gzip:   0.97 kB
+dist/assets/SourceLink-HdIYjwXn.js                                2.69 kB │ gzip:   1.22 kB
+dist/assets/MemoizationPerformancePage-DBHqXQ12.js                2.93 kB │ gzip:   1.12 kB
+dist/assets/logger-C85UoTAn.js                                    3.45 kB │ gzip:   1.22 kB
+dist/assets/TimeTravelStore-DUxQtGfA.js                           4.61 kB │ gzip:   1.42 kB
+dist/assets/ActionGuardIndexPage-DclMNWOi.js                      5.38 kB │ gzip:   2.21 kB
+dist/assets/FoundationsOverview-C5z1NGuM.js                       5.46 kB │ gzip:   1.51 kB
+dist/assets/ActionLifecycleWorkbenchPage-CkAqq7QL.js              6.29 kB │ gzip:   2.65 kB
+dist/assets/ActionContext-ioSZTSlF.js                             6.67 kB │ gzip:   2.55 kB
+dist/assets/PerformanceOverview-Cyc5AM2e.js                       7.20 kB │ gzip:   1.78 kB
+dist/assets/WarningDemoPage-C8Jiv7II.js                           7.71 kB │ gzip:   2.75 kB
+dist/assets/time-travel-store-pattern-r--jf3PW.js                 7.83 kB │ gzip:   2.92 kB
+dist/assets/EnhancedContextStoreProvider-CC8zaAhl.js              7.93 kB │ gzip:   3.05 kB
+dist/assets/createRefContext-BK0td0DI.js                          8.26 kB │ gzip:   2.94 kB
+dist/assets/FormValidation-BdAR14LC.js                            8.30 kB │ gzip:   2.60 kB
+dist/assets/MouseEventsIndexPage-DoBxPp8m.js                      9.18 kB │ gzip:   2.32 kB
+dist/assets/WorkflowSteps-B7OdYVi7.js                             9.34 kB │ gzip:   3.01 kB
+dist/assets/ImplementationScenarioLibraryPage-Bedm-EDh.js         9.79 kB │ gzip:   3.10 kB
+dist/assets/UtilitiesOverview-Ce2DP4eI.js                        10.85 kB │ gzip:   2.63 kB
+dist/assets/TimeTravelTestPage-DGcvP6av.js                       11.02 kB │ gzip:   4.18 kB
+dist/assets/BasicsPage-BBArJN4n.js                               11.43 kB │ gzip:   4.18 kB
+dist/assets/DemoPage-DtEroLmR.js                                 11.45 kB │ gzip:   3.85 kB
+dist/assets/IntegrationsOverview-B0fTzzHV.js                     11.55 kB │ gzip:   3.30 kB
+dist/assets/ToastConfigPage-BERvzVel.js                          11.80 kB │ gzip:   3.99 kB
+dist/assets/ConditionalPatternsIndex-DzOPHhLP.js                 12.18 kB │ gzip:   3.38 kB
+dist/assets/FormBuilderPage-6QVcOZ1c.js                          12.65 kB │ gzip:   3.35 kB
+dist/assets/ToolContextAIDemo-Biag6pSw.js                        13.21 kB │ gzip:   5.09 kB
+dist/assets/FeatureToggle-BZoiazvN.js                            13.28 kB │ gzip:   4.10 kB
+dist/assets/ui-CvdPn6tv.js                                       13.33 kB │ gzip:   4.35 kB
+dist/assets/EnhancedAbortableSearchExample-CBzX7RLm.js           13.47 kB │ gzip:   4.62 kB
+dist/assets/ActionGuardOverview-us-0PrP4.js                      13.68 kB │ gzip:   3.10 kB
+dist/assets/ConcurrentActionsPage-C1AFQOdg.js                    13.81 kB │ gzip:   4.91 kB
+dist/assets/ExamplesUtilitiesOverview-ClN-Oer2.js                13.94 kB │ gzip:   3.33 kB
+dist/assets/ActionGuardContextStoreMouseEventsPage-CQNwmtBw.js   14.88 kB │ gzip:   5.18 kB
+dist/assets/HomePage-DzoTMJd1.js                                 14.94 kB │ gzip:   4.50 kB
+dist/assets/LegacyMouseEventsPage-CRKMFp_z.js                    15.07 kB │ gzip:   5.35 kB
+dist/assets/PatternsOverview-D4kq4gyt.js                         15.55 kB │ gzip:   3.40 kB
+dist/assets/AdvancedFilteringPage-Dv-zR17G.js                    16.40 kB │ gzip:   4.71 kB
+dist/assets/BasicsPage-CYdbuL4F.js                               17.00 kB │ gzip:   5.17 kB
+dist/assets/HooksPage-qfxHrtZv.js                                17.35 kB │ gzip:   6.02 kB
+dist/assets/tool-call-trace-BdnAafEP.js                          18.53 kB │ gzip:   6.57 kB
+dist/assets/UseRefMountStateTestPage-5xAQ3Ed-.js                 18.73 kB │ gzip:   5.94 kB
+dist/assets/AdvancedPage-c67NV9TB.js                             20.26 kB │ gzip:   6.25 kB
+dist/assets/ContextPage-BqGJU8nn.js                              21.38 kB │ gzip:   6.55 kB
+dist/assets/RefsIndexPage-DAhs-IcG.js                            21.50 kB │ gzip:   5.30 kB
+dist/assets/ProviderPage-C6H-ZiKP.js                             21.63 kB │ gzip:   5.64 kB
+dist/assets/WaitForRefsPerformancePage-DsiLKZQt.js               22.45 kB │ gzip:   5.35 kB
+dist/assets/DemosIndexPage-C7Ju5663.js                           24.14 kB │ gzip:   7.16 kB
+dist/assets/PermissionBasedExecution-PtudIGRv.js                 24.14 kB │ gzip:   7.48 kB
+dist/assets/CanvasRefDemoPage-Dl5tKKqC.js                        24.24 kB │ gzip:   6.33 kB
+dist/assets/SourceLinkDirectory-DUaL6tcx.js                      25.02 kB │ gzip:   7.64 kB
+dist/assets/CoreConceptsOverview-BvXdwCT6.js                     25.17 kB │ gzip:   5.80 kB
+dist/assets/LogMonitor-D_SjJVh3.js                               25.52 kB │ gzip:   8.26 kB
+dist/assets/ImmutabilityTestPage-BsyfyQ33.js                     26.83 kB │ gzip:   8.44 kB
+dist/assets/TimeTravelContextTestPage-DxuETKtW.js                27.02 kB │ gzip:   7.36 kB
+dist/assets/AccessRequestExamplePage-CKmkLdZj.js                 28.22 kB │ gzip:   7.93 kB
+dist/assets/RenewalRiskReviewExamplePage-D_lJsRHg.js             28.88 kB │ gzip:   8.13 kB
+dist/assets/ContextStoreActionPage-DJ6Agu_8.js                   29.90 kB │ gzip:   8.25 kB
+dist/assets/McpFunctionCallingCatalog-KuSQ1M9_.js                30.04 kB │ gzip:   7.92 kB
+dist/assets/IncidentEscalationExamplePage-CoMsHgN3.js            30.14 kB │ gzip:   8.22 kB
+dist/assets/FlowControlPlaygroundPageV2-Cwz6qLTx.js              30.76 kB │ gzip:   8.89 kB
+dist/assets/BusinessLogicPage-CehACubk.js                        31.39 kB │ gzip:   9.24 kB
+dist/assets/LoggerPage-CRglWGrQ.js                               31.69 kB │ gzip:   9.71 kB
+dist/assets/NonReactiveContextStorePage-B6N8Ss2P.js              32.81 kB │ gzip:   9.28 kB
+dist/assets/ChatPage-fIJqm76h.js                                 34.69 kB │ gzip:  10.86 kB
+dist/assets/LiveWebCodingPage-t--pAXbY.js                        36.17 kB │ gzip:  12.66 kB
+dist/assets/CanonicalOrderExamplePage-BqZ9uIOd.js                36.36 kB │ gzip:   9.69 kB
+dist/assets/EnhancedContextStorePage-6PLFBuO1.js                 37.54 kB │ gzip:  10.79 kB
+dist/assets/DemoPage-CWGEWOSG.js                                 38.12 kB │ gzip:  10.53 kB
+dist/assets/ThrottleComparisonPageRefactored-D54R_A9u.js         38.45 kB │ gzip:  10.04 kB
+dist/assets/ScrollPageRefactored-DajJO-7y.js                     38.80 kB │ gzip:   9.35 kB
+dist/assets/ApiBlockingPageRefactored-B6MynotF.js                42.05 kB │ gzip:  10.64 kB
+dist/assets/SearchPageRefactored-BqdewG0L.js                     43.50 kB │ gzip:  10.62 kB
+dist/assets/UseActionWithResultPage-CykoOTMW.js                  44.36 kB │ gzip:  11.99 kB
+dist/assets/CanvasPage-DQ1sq0HU.js                               50.80 kB │ gzip:  15.04 kB
+dist/assets/ActionRegister-DYcTScvM.js                           50.99 kB │ gzip:  13.49 kB
+dist/assets/ActionGuardPageRefactored-DLqR9xZk.js                51.74 kB │ gzip:  14.38 kB
+dist/assets/PriorityPerformancePage-BOGP1BmW.js                  51.75 kB │ gzip:  16.03 kB
+dist/assets/store-definition-DDz1VMMq.js                         58.54 kB │ gzip:  17.46 kB
+dist/assets/LayeredArchitecturePage-CZfwM0ie.js                  58.59 kB │ gzip:  15.62 kB
+dist/assets/ImperativeRefPage-CqUA0kVr.js                        87.04 kB │ gzip:  23.02 kB
+dist/assets/index-DJoCrtX8.js                                    87.17 kB │ gzip:  23.43 kB
+dist/assets/LiveCodeEditorPage-PvL-mEBg.js                       89.69 kB │ gzip:  30.29 kB
+dist/assets/tool-result-format-D7TCD8Nj.js                      144.61 kB │ gzip:  47.90 kB
+dist/assets/react-vendor-DmnbxDi2.js                            239.43 kB │ gzip:  77.60 kB
+dist/assets/openrouter-models-C5bSTcxO.js                       570.87 kB │ gzip: 140.43 kB
+
+[33m[PLUGIN_TIMINGS] [0mYour build spent significant time in plugin `@rolldown/plugin-babel`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.
+
+✓ built in 13.77s
+
+> context-action-monorepo@1.0.1 docs:build /Users/junwoobang/workflow/context-action
+> vitepress build docs
+
+
+  vitepress v1.6.4
+
+- building client + server bundles...
+[32m✓[0m building client + server bundles...
+- rendering pages...
+[32m✓[0m rendering pages...
+build complete in 45.35s.
+
+> context-action-monorepo@1.0.1 verify:private-tools /Users/junwoobang/workflow/context-action
+> node scripts/verify-private-tools.mjs
+
+
+> @context-action/style-testing@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/style-testing
+> tsc --noEmit
+
+
+> @context-action/style-testing@0.1.0 test /Users/junwoobang/workflow/context-action/packages/style-testing
+> pnpm run build && node --test test/*.test.mjs
+
+
+> @context-action/style-testing@0.1.0 build /Users/junwoobang/workflow/context-action/packages/style-testing
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/style-testing/tsdown.config.ts 
+ℹ entry: src/index.ts, src/cli/index.ts, src/analyzers/babel-plugin.ts
+ℹ target: node24
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 14 files
+ℹ Granting execute permission to dist/cli/index.js
+ℹ dist/cli/index.js                      4.08 kB │ gzip: 1.53 kB
+ℹ dist/analyzers/babel-plugin.js         1.21 kB │ gzip: 0.54 kB
+ℹ dist/index.js                          0.31 kB │ gzip: 0.19 kB
+ℹ dist/reporter-_x_EL2or.js.map         37.03 kB │ gzip: 9.68 kB
+ℹ dist/reporter-_x_EL2or.js             17.45 kB │ gzip: 4.84 kB
+ℹ dist/cli/index.js.map                  7.58 kB │ gzip: 2.52 kB
+ℹ dist/analyzers/babel-plugin.js.map     3.22 kB │ gzip: 1.21 kB
+ℹ dist/index.d.ts.map                    0.94 kB │ gzip: 0.49 kB
+ℹ dist/analyzers/babel-plugin.d.ts.map   0.17 kB │ gzip: 0.16 kB
+ℹ dist/index.d.ts                        3.42 kB │ gzip: 1.18 kB
+ℹ dist/analyzers/babel-plugin.d.ts       0.41 kB │ gzip: 0.26 kB
+ℹ dist/cli/index.d.ts                    0.01 kB │ gzip: 0.03 kB
+ℹ 12 files, total: 75.83 kB
+✔ Build complete in 689ms
+
+> @context-action/style-testing@0.1.0 postbuild /Users/junwoobang/workflow/context-action/packages/style-testing
+> pnpm verify:exports
+
+
+> @context-action/style-testing@0.1.0 verify:exports /Users/junwoobang/workflow/context-action/packages/style-testing
+> node scripts/verify-exports.mjs
+
+Verified 6 style-testing export artifacts.
+✔ the Babel plugin creates stable IDs and preserves explicitly supplied IDs (34.819708ms)
+✔ the extractor and diff engine agree on Tailwind-derived styles (4.5615ms)
+ℹ tests 2
+ℹ suites 0
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 338.391125
+Verified workspace-only tool package.
+
+> context-action-monorepo@1.0.1 release:roadmap:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-roadmap-alignment.mjs
+
+v1 release roadmaps aligned (6 invariants).
+
+> context-action-monorepo@1.0.1 docs:api /Users/junwoobang/workflow/context-action
+> typedoc --options ./typedoc.json
+
+[info] Loaded plugin typedoc-plugin-markdown
+[warning] The signature packages/core/src.ActionRegister.dispatch has an @param with name "payload", which was not used
+[warning] The signature packages/core/src.ActionRegister.dispatch has an @param with name "options", which was not used
+[warning] The signature packages/core/src.ActionRegister.dispatchWithResult has an @param with name "payload", which was not used
+[warning] The signature packages/core/src.ActionRegister.dispatchWithResult has an @param with name "options", which was not used
+[info] markdown generated at ./docs/api/generated
+[warning] Found 0 errors and 4 warnings
+
+> context-action-monorepo@1.0.1 docs:sync /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/typedoc-vitepress-sync build && node packages/typedoc-vitepress-sync/bin/cli.js sync --config ./typedoc-vitepress-sync.config.js
+
+
+> @context-action/typedoc-vitepress-sync@0.8.8 build /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 4 files
+ℹ dist/index.js         63.03 kB │ gzip: 15.72 kB
+ℹ dist/index.js.map    124.42 kB │ gzip: 29.50 kB
+ℹ dist/index.d.ts.map    3.66 kB │ gzip:  1.31 kB
+ℹ dist/index.d.ts       11.80 kB │ gzip:  2.91 kB
+ℹ 4 files, total: 202.92 kB
+✔ Build complete in 582ms
+- Initializing sync...
+[INFO] 🚀 TypeDoc VitePress Sync starting...
+[INFO] Cache manifest loaded: 304 entries
+[INFO] 📦 Processing package: core
+[INFO] 📦 Processing package: tool-protocol
+[INFO] 📦 Processing package: ai-sdk
+[INFO] 📦 Processing package: webmcp
+[INFO] 📦 Processing package: tool-durable-operations
+[INFO] 📦 Processing package: react
+[INFO] 🔍 Generating sidebar configuration...
+[INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+[INFO] Cache manifest saved: 304 entries
+[INFO] 📊 Metrics saved: ./reports/api-sync-metrics.json
+[INFO] 
+============================================================
+✅ TypeDoc VitePress Sync Complete!
+============================================================
+📄 Files processed: 0
+⏭️  Files skipped: 304
+⏱️  Processing time: 0.05s
+
+📊 Cache Statistics:
+  - Hit rate: 100.00%
+  - Hits: 304
+  - Misses: 0
+  - Expired: 0
+
+📋 Reports:
+  - Metrics: ./reports/api-sync-metrics.json
+✔ Documentation sync completed!
+
+📊 Sync Results:
+  Files Processed: 0
+  Files Skipped: 304 (cache hits)
+  Processing Time: 0.05s
+
+💾 Cache Performance:
+  Hit Rate: 100.00%
+  Cache Hits: 304
+  Cache Misses: 0
+
+⚡ Performance: Excellent
+  Average time per file: 0.16ms
+
+> context-action-monorepo@1.0.1 docs:build /Users/junwoobang/workflow/context-action
+> vitepress build docs
+
+
+  vitepress v1.6.4
+
+- building client + server bundles...
+[32m✓[0m building client + server bundles...
+- rendering pages...
+[32m✓[0m rendering pages...
+build complete in 42.76s.
+
+> context-action-monorepo@1.0.1 test:canonical-example /Users/junwoobang/workflow/context-action
+> pnpm --dir packages/react test:canonical-example
+
+
+> @context-action/react@1.0.0-rc.0 test:canonical-example /Users/junwoobang/workflow/context-action/packages/react
+> jest --runInBand __tests__/patterns/implementation-playbook.integration.test.tsx
+
+Test Suites: 1 passed, 1 total
+Tests:       4 passed, 4 total
+Snapshots:   0 total
+Time:        1.223 s
+Ran all test suites matching __tests__/patterns/implementation-playbook.integration.test.tsx.

--- a/release-evidence/v1.0.0-rc.0-preapproval-1/logs/roadmap.log
+++ b/release-evidence/v1.0.0-rc.0-preapproval-1/logs/roadmap.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 release:roadmap:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-roadmap-alignment.mjs
+
+v1 release roadmaps aligned (6 invariants).

--- a/release-evidence/v1.0.0-rc.0-preapproval-1/manifest.json
+++ b/release-evidence/v1.0.0-rc.0-preapproval-1/manifest.json
@@ -1,0 +1,98 @@
+{
+  "schemaVersion": "context-action-release-evidence.v1",
+  "release": "context-action-v1.0.0",
+  "stage": "v1.0.0-rc.0-preapproval-1",
+  "commit": "05a57d526cad64bad78526fededa9df567840fe1",
+  "roadmapRevision": "v1-r2",
+  "status": "recorded",
+  "generatedAt": "2026-08-09T03:47:17.751Z",
+  "workingTree": "clean",
+  "environment": {
+    "node": "v24.19.0",
+    "pnpm": "10.30.3",
+    "typescript": "6.0.3"
+  },
+  "commands": [
+    {
+      "id": "release-check",
+      "command": "pnpm release:check",
+      "startedAt": "2026-08-09T03:43:57.429Z",
+      "completedAt": "2026-08-09T03:47:05.942Z",
+      "durationMs": 188505,
+      "exitCode": 0,
+      "status": "passed",
+      "log": {
+        "path": "logs/release-check.log",
+        "sha256": "56e8e4eb8bf0dc02bd306e1917f94507bea4c212e9f886742507bca93af29512"
+      }
+    },
+    {
+      "id": "inventory",
+      "command": "pnpm release:inventory",
+      "startedAt": "2026-08-09T03:47:05.947Z",
+      "completedAt": "2026-08-09T03:47:17.177Z",
+      "durationMs": 11230,
+      "exitCode": 0,
+      "status": "passed",
+      "log": {
+        "path": "logs/inventory.log",
+        "sha256": "83e43a96e88509e6c1c9d13d13d3e29f56790a410c9cb758ad6c4c40dcb1917a"
+      }
+    },
+    {
+      "id": "manifest",
+      "command": "pnpm verify:v1-release-manifest",
+      "startedAt": "2026-08-09T03:47:17.178Z",
+      "completedAt": "2026-08-09T03:47:17.481Z",
+      "durationMs": 303,
+      "exitCode": 0,
+      "status": "passed",
+      "log": {
+        "path": "logs/manifest.log",
+        "sha256": "c5d2c42c377d9e7ba5a0e25bcbf914f3465afe92ac98d572b54b6dccb2d7462b"
+      }
+    },
+    {
+      "id": "roadmap",
+      "command": "pnpm release:roadmap:check",
+      "startedAt": "2026-08-09T03:47:17.482Z",
+      "completedAt": "2026-08-09T03:47:17.732Z",
+      "durationMs": 250,
+      "exitCode": 0,
+      "status": "passed",
+      "log": {
+        "path": "logs/roadmap.log",
+        "sha256": "a6397257031ab3026f8acee7dc889c475ed02913f65f01dc4702c589cf422b6a"
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "sourcePath": "docs/releases/v1.0.0/release-manifest.json",
+      "path": "artifacts/01-release-manifest.json",
+      "sha256": "46546df8bbff845a104b0e49ae9fb283d4dec53771c6da207fd83722dbe112ea",
+      "bytes": 886
+    },
+    {
+      "sourcePath": "reports/release/v1.0.0/package-inventory.json",
+      "path": "artifacts/02-package-inventory.json",
+      "sha256": "b1576aa0f57dd5532ec02e351564fc93050ea63d79926423578b9fd348d47ab2",
+      "bytes": 18393
+    },
+    {
+      "sourcePath": "reports/release/v1.0.0/test-results/lifecycle-report.json",
+      "path": "artifacts/03-lifecycle-report.json",
+      "sha256": "c8087710d9483d9473f6a36ca83d917091c9675b5c3e970bbd1a7f6389ea8213",
+      "bytes": 1617
+    },
+    {
+      "sourcePath": "reports/release/v1.0.0/security-report.json",
+      "path": "artifacts/04-security-report.json",
+      "sha256": "c24fd61a7231271e0257598e03920a8b40d44dc39a282de270bd36696402f0aa",
+      "bytes": 3351
+    }
+  ],
+  "notes": [
+    "Clean pre-approval verification for the latest RC-preparation HEAD; the manifest remains candidate-unapproved and this does not authorize publication."
+  ]
+}

--- a/scripts/verify-published-tool-consumers.cjs
+++ b/scripts/verify-published-tool-consumers.cjs
@@ -115,15 +115,15 @@ function publishedVersion(name, tag) {
   return output;
 }
 
-function waitForPublishedVersion(spec) {
+function waitForPublishedVersion(name, tag) {
   const attempts = 30;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      publishedVersion(spec);
+      const version = publishedVersion(name, tag);
       if (attempt > 1) {
         process.stdout.write(`npm metadata became visible after ${attempt} attempts.\n`);
       }
-      return;
+      return version;
     } catch (error) {
       if (attempt === attempts) throw error;
       process.stdout.write(`Waiting for npm metadata (${attempt}/${attempts - 1})...\n`);
@@ -251,10 +251,9 @@ function main() {
     const packageSpecs = local
       ? createLocalPackageSpecs(consumerRoot).filter(({ name }) => selectedPackages.some(pkg => pkg.name === name))
       : selectedPackages.map(({ name }) => {
-          const version = publishedVersion(name, tag);
+          const version = waitForPublishedVersion(name, tag);
           return { name, spec: `${name}@${version}` };
         });
-    if (!local) packageSpecs.forEach(({ spec }) => waitForPublishedVersion(spec));
     packageSpecs.push(...consumerRuntimeDependencies);
 
     writeFileSync(
@@ -279,7 +278,10 @@ function main() {
       ),
     );
     const npmConfigPath = path.join(consumerRoot, '.npmrc');
-    writeFileSync(npmConfigPath, 'ignore-scripts=true\naudit=false\nfund=false\n');
+    const npmAuth = process.env.NODE_AUTH_TOKEN
+      ? '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}\n'
+      : '';
+    writeFileSync(npmConfigPath, `${npmAuth}ignore-scripts=true\naudit=false\nfund=false\n`);
     execFileSync(
       'npm',
       [


### PR DESCRIPTION
Preserves the workflow token in the isolated consumer npm config when supplied and retries dist-tag resolution before installation. This handles npm metadata propagation after a new prerelease publish without changing any published version.