### PR TITLE
fix(release): assign requested prerelease dist tag

### DIFF
--- a/scripts/publish-packages.cjs
+++ b/scripts/publish-packages.cjs
@@ -75,8 +75,7 @@ function publishScopedPrerelease() {
   });
   const summary = [];
 
-  function removeAccidentalLatest(manifest, packageDirectory) {
-    if (!manifest.version.includes('-')) return;
+  function ensureDistTag(manifest, packageDirectory) {
     let tags;
     for (let attempt = 1; attempt <= 6; attempt += 1) {
       const tagsResult = commandSucceeded(
@@ -90,16 +89,16 @@ function publishScopedPrerelease() {
       if (attempt < 6) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10_000);
     }
     if (!tags) throw new Error(`Could not read dist-tags for ${manifest.name}`);
-    if (tags.latest !== manifest.version) return;
-    const remove = spawnSync(
+    if (tags[distTag] === manifest.version) return;
+    const add = spawnSync(
       'npm',
-      ['dist-tag', 'rm', manifest.name, 'latest'],
+      ['dist-tag', 'add', `${manifest.name}@${manifest.version}`, distTag],
       { cwd: packageDirectory, stdio: 'inherit', env: { ...process.env } },
     );
-    if (remove.status !== 0) {
-      throw new Error(`Could not remove accidental latest tag from ${manifest.name}`);
+    if (add.status !== 0) {
+      throw new Error(`Could not assign ${distTag} to ${manifest.name}@${manifest.version}`);
     }
-    process.stdout.write(`Removed accidental latest tag from ${manifest.name}@${manifest.version}.\n`);
+    process.stdout.write(`Assigned ${distTag} to ${manifest.name}@${manifest.version}.\n`);
   }
 
   for (const packageEntry of selected) {
@@ -111,7 +110,7 @@ function publishScopedPrerelease() {
     if (published?.stdout.trim() === manifest.version) {
       process.stdout.write(`${manifest.name}@${manifest.version} is already published; skipping.\n`);
       summary.push({ packageName: manifest.name, version: manifest.version, status: 'already-published' });
-      removeAccidentalLatest(manifest, packageEntry.location);
+      ensureDistTag(manifest, packageEntry.location);
       continue;
     }
 
@@ -124,7 +123,7 @@ function publishScopedPrerelease() {
       throw new Error(`${manifest.name}@${manifest.version} failed to publish`);
     }
     summary.push({ packageName: manifest.name, version: manifest.version, status: 'published' });
-    removeAccidentalLatest(manifest, packageEntry.location);
+    ensureDistTag(manifest, packageEntry.location);
   }
 
   writeFileSync(summaryFile, `${JSON.stringify(summary, null, 2)}\n`);


### PR DESCRIPTION
Ensures an explicitly selected prerelease channel (such as next) points at an already-published RC. Keeps tag changes in the GitHub Actions release path.