### PR TITLE
fix(release): harden promotion verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,8 @@ jobs:
 
       - name: Verify React package
         run: |
+          pnpm --filter @context-action/mutative-core build
+          pnpm --filter @context-action/mutative build
           pnpm --filter @context-action/core build
           pnpm --filter @context-action/react build
           node scripts/verify-react-compatibility.mjs \

--- a/.github/workflows/promote-v1-to-latest.yml
+++ b/.github/workflows/promote-v1-to-latest.yml
@@ -42,10 +42,13 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Verify governance and published-artifact commits
+        env:
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
         run: |
+          [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           test "$GITHUB_REF" = "refs/heads/main"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          git merge-base --is-ancestor "${{ inputs.release_commit }}" origin/main
+          git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main
 
       - name: Clear npm config before registry setup
         run: |
@@ -80,12 +83,14 @@ jobs:
             --output reports/npm-v1-provenance-verification.json
 
       - name: Verify promotion authorization
+        env:
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
         run: |
           pnpm verify:v1-promotion-authorization -- \
-            --commit "${{ inputs.release_commit }}" \
+            --commit "$RELEASE_COMMIT" \
             --governance-commit "$GITHUB_SHA"
 
-      - name: Promote the complete cohort in dependency order
+      - name: Promote the complete cohort and verify latest consumers
         env:
           NODE_AUTH_TOKEN: ${{ inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}
         run: |
@@ -128,13 +133,8 @@ jobs:
             npm dist-tag add "${packages[$index]}" latest
             promoted+=("${packages[$index]}")
           done
-          trap - EXIT
-
-      - name: Verify latest consumer matrix
-        env:
-          NODE_AUTH_TOKEN: ${{ inputs.publish_auth == 'token' && secrets.NPM_TOKEN || '' }}
-        run: |
           pnpm verify:published-tool-consumers -- --tag latest --packages "$STABLE_CANDIDATE_PACKAGES"
+          trap - EXIT
 
       - name: Capture promotion registry evidence
         run: |

--- a/.github/workflows/publish-v1-stable-candidate.yml
+++ b/.github/workflows/publish-v1-stable-candidate.yml
@@ -42,10 +42,13 @@ jobs:
           ref: ${{ inputs.release_commit }}
 
       - name: Verify approved main release commit
+        env:
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
         run: |
+          [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           test "$GITHUB_REF" = "refs/heads/main"
-          test "$(git rev-parse HEAD)" = "${{ inputs.release_commit }}"
-          git merge-base --is-ancestor "${{ inputs.release_commit }}" origin/main
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main
 
       - name: Clear npm config before registry setup
         run: |
@@ -106,7 +109,9 @@ jobs:
           NODE
 
       - name: Verify stable publish authorization
-        run: pnpm verify:stable-publish-authorization -- --commit "${{ inputs.release_commit }}"
+        env:
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+        run: pnpm verify:stable-publish-authorization -- --commit "$RELEASE_COMMIT"
 
       - name: Run release gate
         run: pnpm release:check

--- a/docs/releases/v1.0.0/publish-runbook.md
+++ b/docs/releases/v1.0.0/publish-runbook.md
@@ -18,7 +18,10 @@ then use the guarded promotion workflow or publish a corrected patch.
 1. Confirm G0–G9, a clean strict evidence manifest, and exact tarball hashes
    for the approved release commit. Record the accepted pre-publication audit
    and move `release-manifest.json` to `candidate-approved-for-publish` before
-   invoking `Publish V1 Stable Candidate`.
+   invoking `Publish V1 Stable Candidate`. Its `prePublicationAudit.evidence`
+   must name the strict evidence manifest in the repository and
+   `evidenceSha256` must be the SHA-256 of that exact file; a bare hash is not
+   an authorization record.
 
    ```bash
    pnpm release:evidence:write -- \
@@ -35,7 +38,8 @@ then use the guarded promotion workflow or publish a corrected patch.
    ```
 
    Strict verification rejects a dirty source tree and an evidence commit that
-   does not match the checkout being verified.
+   does not match the checkout being verified. The stable publish authorization
+   repeats the path and digest check from the checked-out release commit.
    The release gate also runs `pnpm verify:v1-release-workflows`, which binds
    both workflows to their exact SHA roles, the complete cohort, `npm-stable`,
    main-branch ancestry, authorization-before-mutation ordering, and the
@@ -52,7 +56,10 @@ then use the guarded promotion workflow or publish a corrected patch.
    evidence artifact. Run `pnpm verify:v1-published-provenance` to verify each
    registry signature and provenance attestation before copying its integrity,
    SHA-256, tags, consumer result, and immutable commit into
-   `release-manifest.json` as `published-unapproved`.
+   `release-manifest.json` as `published-unapproved`. The promotion workflow
+   independently re-downloads every pinned tarball, compares its integrity and
+   SHA-256 with the recorded evidence, and verifies that the live `next` tag
+   still resolves to the approved version before any `latest` tag changes.
 4. Publish only the approved packages to `next` or `rc` with npm provenance
    enabled by the GitHub Actions `id-token: write` permission.
 5. In a clean external consumer, install the published versions and run CJS,
@@ -64,8 +71,9 @@ then use the guarded promotion workflow or publish a corrected patch.
    external smoke and approval succeed. It promotes the manifest's complete
    cohort in dependency order, reruns the `latest` consumer matrix, and uploads
    promotion evidence. Before changing a tag it records each package's prior
-   `latest` value; if a promotion command fails, it restores tags already
-   changed in that run. This is compensating recovery rather than a
+   `latest` value; if a promotion command or the required `latest` consumer
+   matrix fails, it restores tags already changed in that run. This is
+   compensating recovery rather than a
    cross-package npm transaction, so operators must still inspect the uploaded
    evidence after a failed run. Commit the resulting verified tags and
    `promoted` manifest state before declaring the release complete.

--- a/docs/releases/v1.0.0/release-manifest.schema.json
+++ b/docs/releases/v1.0.0/release-manifest.schema.json
@@ -31,11 +31,12 @@
     "prePublicationAudit": {
       "type": ["object", "null"],
       "additionalProperties": false,
-      "required": ["status", "rcCommit", "evidenceManifest"],
+      "required": ["status", "rcCommit", "evidence", "evidenceSha256"],
       "properties": {
         "status": { "const": "accepted" },
         "rcCommit": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
-        "evidenceManifest": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+        "evidence": { "type": "string", "minLength": 1 },
+        "evidenceSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
       }
     },
     "packages": { "type": "object", "additionalProperties": { "type": "string" } },

--- a/scripts/verify-react-compatibility.mjs
+++ b/scripts/verify-react-compatibility.mjs
@@ -18,6 +18,13 @@ if (!reactVersion || !reactTypesVersion || !reactDomTypesVersion) {
   throw new Error('Expected --react-version, --react-types, and --react-dom-types.');
 }
 
+function buildPackage(packageName) {
+  execFileSync('pnpm', ['--filter', packageName, 'build'], {
+    cwd: root,
+    stdio: 'inherit',
+  });
+}
+
 function isolatedNpmEnvironment() {
   return Object.fromEntries(Object.entries(process.env).filter(
     ([key]) => !/^(npm_config|pnpm_config)_/iu.test(key),
@@ -26,6 +33,20 @@ function isolatedNpmEnvironment() {
 
 const consumer = mkdtempSync(join(tmpdir(), 'context-action-react-compat-'));
 try {
+  // npm pack only includes files that already exist. Build the complete
+  // runtime dependency chain so this verifier works from a clean checkout.
+  for (const packageName of [
+    '@context-action/mutative-core',
+    '@context-action/mutative',
+    '@context-action/core',
+    '@context-action/tool-protocol',
+    '@context-action/tool-durable-operations',
+    '@context-action/webmcp',
+    '@context-action/react',
+  ]) {
+    buildPackage(packageName);
+  }
+
   const candidatePackages = [
     'core',
     'mutative-core',

--- a/scripts/verify-stable-publish-authorization.mjs
+++ b/scripts/verify-stable-publish-authorization.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -15,6 +16,31 @@ function option(name) {
 
 function currentCommit() {
   return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repositoryRoot, encoding: 'utf8' }).trim();
+}
+
+async function verifyPrePublicationAudit(audit, expectedCommit) {
+  const errors = [];
+  if (audit?.status !== 'accepted') return ['An accepted pre-publication audit is required'];
+  if (audit.rcCommit !== expectedCommit) errors.push('Pre-publication audit is not bound to the requested release commit');
+  if (typeof audit.evidence !== 'string' || typeof audit.evidenceSha256 !== 'string'
+    || !/^[a-f0-9]{64}$/u.test(audit.evidenceSha256)) {
+    errors.push('Pre-publication audit requires an evidence path and SHA-256');
+    return errors;
+  }
+  const resolved = path.resolve(repositoryRoot, audit.evidence);
+  if (resolved !== repositoryRoot && !resolved.startsWith(`${repositoryRoot}${path.sep}`)) {
+    errors.push('Pre-publication audit evidence must stay within the repository');
+    return errors;
+  }
+  try {
+    const evidence = await readFile(resolved);
+    if (createHash('sha256').update(evidence).digest('hex') !== audit.evidenceSha256) {
+      errors.push('Pre-publication audit evidence hash does not match');
+    }
+  } catch {
+    errors.push('Pre-publication audit evidence is missing');
+  }
+  return errors;
 }
 
 async function main() {
@@ -34,11 +60,7 @@ async function main() {
   if (currentCommit() !== expectedCommit) {
     errors.push('Checked-out commit does not match the requested release commit');
   }
-  if (manifest.prePublicationAudit?.status !== 'accepted'
-    || manifest.prePublicationAudit.rcCommit !== expectedCommit
-    || !/^[a-f0-9]{64}$/u.test(manifest.prePublicationAudit.evidenceManifest ?? '')) {
-    errors.push('An accepted pre-publication audit bound to this commit and evidence hash is required');
-  }
+  errors.push(...await verifyPrePublicationAudit(manifest.prePublicationAudit, expectedCommit));
   if (manifest.distTag !== null || manifest.registryEvidence !== null || manifest.audit !== null) {
     errors.push('Pre-publication authorization must not include published-artifact evidence');
   }

--- a/scripts/verify-v1-published-provenance.mjs
+++ b/scripts/verify-v1-published-provenance.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import os from 'node:os';
@@ -47,6 +48,32 @@ function outputPath(value) {
   return resolved;
 }
 
+async function verifyRegistryEvidence(name, version, evidence, distTag) {
+  if (!evidence || typeof evidence !== 'object') {
+    throw new Error(`Release manifest has no registry evidence for ${name}@${version}`);
+  }
+  const metadata = JSON.parse(run('npm', [
+    'view', `${name}@${version}`, 'dist', '--json', '--registry=https://registry.npmjs.org',
+  ], repositoryRoot));
+  const distTags = JSON.parse(run('npm', [
+    'view', name, 'dist-tags', '--json', '--registry=https://registry.npmjs.org',
+  ], repositoryRoot));
+  if (!metadata?.tarball || !metadata?.integrity) {
+    throw new Error(`npm registry metadata is incomplete for ${name}@${version}`);
+  }
+  const response = await fetch(metadata.tarball);
+  if (!response.ok) throw new Error(`Could not download ${name}@${version}: HTTP ${response.status}`);
+  const tarballSha256 = createHash('sha256').update(Buffer.from(await response.arrayBuffer())).digest('hex');
+  if (evidence.integrity !== metadata.integrity
+    || evidence.tarball !== metadata.tarball
+    || evidence.sha256 !== tarballSha256) {
+    throw new Error(`Live npm artifact does not match recorded registry evidence for ${name}@${version}`);
+  }
+  if (distTags?.[distTag] !== version) {
+    throw new Error(`Live npm ${distTag} tag does not resolve to ${name}@${version}`);
+  }
+}
+
 async function main() {
   const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
   const packageEntries = Object.entries(manifest.packages ?? {});
@@ -73,6 +100,7 @@ async function main() {
     const verified = new Map((audit.verified ?? []).map(entry => [`${entry.name}@${entry.version}`, entry]));
     const results = [];
     for (const [name, version] of packageEntries) {
+      await verifyRegistryEvidence(name, version, manifest.registryEvidence?.[name], manifest.distTag);
       const entry = verified.get(`${name}@${version}`);
       if (!entry) throw new Error(`npm audit signatures did not verify ${name}@${version}`);
       const slsa = entry.attestationBundles?.find(bundle => bundle.predicateType === 'https://slsa.dev/provenance/v1');

--- a/scripts/verify-v1-release-manifest.mjs
+++ b/scripts/verify-v1-release-manifest.mjs
@@ -48,6 +48,32 @@ async function validateAcceptedAudit(audit, manifestCommit) {
   return errors;
 }
 
+async function validateAcceptedPrePublicationAudit(audit, manifestCommit) {
+  const errors = [];
+  if (audit?.status !== 'accepted') return ['accepted pre-publication audit is required'];
+  if (audit.rcCommit !== manifestCommit) {
+    errors.push('pre-publication audit must bind the manifest commit');
+  }
+  if (typeof audit.evidence !== 'string' || typeof audit.evidenceSha256 !== 'string'
+    || !/^[a-f0-9]{64}$/u.test(audit.evidenceSha256)) {
+    errors.push('pre-publication audit requires an evidence path and SHA-256');
+    return errors;
+  }
+  const resolved = path.resolve(repositoryRoot, audit.evidence);
+  if (resolved !== repositoryRoot && !resolved.startsWith(`${repositoryRoot}${path.sep}`)) {
+    errors.push('pre-publication audit evidence must stay within the repository');
+    return errors;
+  }
+  try {
+    if (sha256(await readFile(resolved)) !== audit.evidenceSha256) {
+      errors.push('pre-publication audit evidence hash does not match');
+    }
+  } catch {
+    errors.push('pre-publication audit evidence is missing');
+  }
+  return errors;
+}
+
 async function validateReleaseApproval(approval, manifestCommit) {
   const errors = [];
   if (approval?.status !== 'accepted') return ['G0/G1 release approval is not accepted'];
@@ -159,10 +185,8 @@ async function main() {
     if (typeof manifest.commit !== 'string' || !/^[a-f0-9]{40}$/u.test(manifest.commit)) {
       errors.push('Publish-approved candidate requires a 40-character Git commit');
     }
-    if (prePublicationAudit?.status !== 'accepted'
-      || prePublicationAudit.rcCommit !== manifest.commit
-      || !/^[a-f0-9]{64}$/u.test(prePublicationAudit.evidenceManifest ?? '')) {
-      errors.push('Publish-approved candidate requires an accepted audit bound to the manifest commit and evidence hash');
+    for (const error of await validateAcceptedPrePublicationAudit(prePublicationAudit, manifest.commit)) {
+      errors.push(`Publish-approved candidate requires ${error}`);
     }
     if (manifest.distTag !== null || registryEvidence !== null || audit !== null) {
       errors.push('Publish-approved candidate must not claim registry evidence or a published-artifact audit');

--- a/scripts/verify-v1-release-workflows.mjs
+++ b/scripts/verify-v1-release-workflows.mjs
@@ -38,12 +38,14 @@ async function main() {
     requireText(errors, source, 'id-token: write', `${name} workflow must permit npm provenance through OIDC`);
     requireText(errors, source, 'name: npm-stable', `${name} workflow must use the npm-stable environment`);
     requireText(errors, source, 'test "$GITHUB_REF" = "refs/heads/main"', `${name} workflow must reject runs outside main`);
-    requireText(errors, source, 'git merge-base --is-ancestor "${{ inputs.release_commit }}" origin/main', `${name} workflow must require a main-ancestry artifact source`);
+    requireText(errors, source, 'RELEASE_COMMIT: ${{ inputs.release_commit }}', `${name} workflow must pass the requested release commit through a shell-safe environment variable`);
+    requireText(errors, source, '[[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]', `${name} workflow must require a full immutable commit SHA`);
+    requireText(errors, source, 'git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main', `${name} workflow must require a main-ancestry artifact source`);
   }
 
   requireText(errors, stableCandidate, 'ref: ${{ inputs.release_commit }}', 'Stable candidate workflow must checkout the requested immutable artifact source');
-  requireText(errors, stableCandidate, 'test "$(git rev-parse HEAD)" = "${{ inputs.release_commit }}"', 'Stable candidate workflow must bind checkout to the requested artifact source');
-  requireText(errors, stableCandidate, 'pnpm verify:stable-publish-authorization -- --commit "${{ inputs.release_commit }}"', 'Stable candidate workflow must verify publish authorization for the requested artifact source');
+  requireText(errors, stableCandidate, 'test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"', 'Stable candidate workflow must bind checkout to the requested artifact source');
+  requireText(errors, stableCandidate, 'pnpm verify:stable-publish-authorization -- --commit "$RELEASE_COMMIT"', 'Stable candidate workflow must verify publish authorization for the requested artifact source');
   requireOrder(errors, stableCandidate, 'pnpm verify:stable-publish-authorization', 'pnpm publish:packages', 'Stable candidate authorization must occur before publication');
   requireText(errors, stableCandidate, '--dist-tag next', 'Stable candidate workflow must publish only to next');
   requireText(errors, stableCandidate, 'verify:published-tool-consumers -- --tag next', 'Stable candidate workflow must rerun the next-tag consumer matrix');
@@ -55,6 +57,8 @@ async function main() {
   requireOrder(errors, promotion, 'pnpm verify:v1-published-provenance', 'pnpm verify:v1-promotion-authorization', 'Promotion must verify provenance before authorization');
   requireOrder(errors, promotion, 'pnpm verify:v1-promotion-authorization', 'npm dist-tag add "${packages[$index]}" latest', 'Promotion authorization must occur before any latest dist-tag mutation');
   requireText(errors, promotion, 'verify:published-tool-consumers -- --tag latest', 'Promotion workflow must rerun the latest-tag consumer matrix');
+  requireOrder(errors, promotion, 'trap rollback EXIT', 'verify:published-tool-consumers -- --tag latest', 'Promotion must preserve rollback until the latest consumer matrix passes');
+  requireOrder(errors, promotion, 'verify:published-tool-consumers -- --tag latest', 'trap - EXIT', 'Promotion may clear rollback only after the latest consumer matrix passes');
 
   const expectedOrder = [
     '@context-action/tool-protocol',


### PR DESCRIPTION
## Summary

- Build the complete packed React consumer dependency chain in CI.
- Validate release SHAs through environment variables and preserve rollback through the latest consumer matrix.
- Bind pre-publication and live npm registry evidence to verified files and digests.

## Traceability

CA-1X-RELEASE-001

## Validation

- React 18.3.1 and 19.2.8 packed-consumer compatibility checks
- `pnpm lint`
- `pnpm test`
- Release-manifest, workflow-contract, and published-provenance verification