### PR TITLE
docs(release): record WebMCP token permission blocker

### DIFF
--- a/docs/releases/v1.0.0/known-limitations.md
+++ b/docs/releases/v1.0.0/known-limitations.md
@@ -20,6 +20,11 @@
   canonical v1.0.0 notes are this release document set and the GitHub release.
   Runtime and declaration artifacts are unaffected. A stricter artifact-docs
   policy requires a corrected patch cohort rather than silent promotion.
+- The accidental WebMCP RC `latest` tag remains because the protected
+  automation token can authenticate but is not authorized to remove that
+  package's dist-tag (`E403` in run `31328975435`). The release remains blocked
+  until a token with that explicit package permission performs the guarded
+  cleanup and its before/after evidence is recorded.
 
 Report any newly discovered P0/P1 issue in the issue ledger and reopen the
 affected gate before approving an RC.

--- a/docs/releases/v1.0.0/publish-runbook.md
+++ b/docs/releases/v1.0.0/publish-runbook.md
@@ -20,11 +20,14 @@ Before certification, clear the accidental `@context-action/webmcp@0.1.0-rc.0`
 requires the exact confirmation `remove-rc-latest`, verifies that `latest` is
 the known RC and `next` is `0.1.0`, removes only `latest`, then uploads before
 and after tag evidence. This operation requires the repository `NPM_TOKEN`
-automation secret: npm trusted-publishing OIDC credentials authenticate package
-publication but did not authorize a `dist-tag rm` request in the rehearsal on
-2026-08-10. The workflow runs `npm whoami` with that token before any mutation
-and fails closed when it is unavailable. Do not run a broad dist-tag command
-from a local shell.
+automation secret with permission to manage this package's dist-tags: npm
+trusted-publishing OIDC credentials authenticate package publication but did
+not authorize a `dist-tag rm` request in the rehearsal on 2026-08-10. Run
+`31328975435` proved the configured token's identity with `npm whoami`, then
+failed closed with `E403` on the deletion; no tag changed. Replace or grant the
+token the package-level tag-management permission before retrying. The workflow
+runs `npm whoami` before any mutation and fails closed when authentication is
+unavailable. Do not run a broad dist-tag command from a local shell.
 
 1. Confirm G0–G9, a clean strict evidence manifest, and exact tarball hashes
    for the approved release commit. Record the accepted pre-publication audit
@@ -123,10 +126,12 @@ lockfile/log snapshot to Git merely to refresh a status record.
 Before promotion, run a no-op or intentionally failing deployment to
 `npm-stable` using distinct identities and record the outcome in the approval
 evidence. A 2026-08-10 protected hygiene rehearsal confirmed that the
-owner-authorized self-review exception can approve the environment, then failed
-closed at `npm dist-tag rm` with `E401` because no usable `NPM_TOKEN` was
-configured; it made no registry mutation. The normal promotion policy remains
-separated identities:
+owner-authorized self-review exception can approve the environment. The first
+run (`31328409822`) failed with `E401` under OIDC-only credentials; the
+token-gated retry (`31328975435`) authenticated successfully but failed with
+`E403` because that token lacks WebMCP dist-tag management permission. Neither
+run made a registry mutation. The normal promotion policy remains separated
+identities:
 
 | Role | Required separation |
 | --- | --- |

--- a/docs/releases/v1.0.0/readiness.md
+++ b/docs/releases/v1.0.0/readiness.md
@@ -82,9 +82,10 @@ metadata. A release defect requires a corrected patch version.
    recorded source commit.
 2. Complete the hashed G0/G1 scope, public-contract, and legacy-ledger owner
    record in [release-approval.md](./release-approval.md).
-3. Configure a repository `NPM_TOKEN` automation secret permitted to remove
-   the WebMCP `latest` dist-tag; the protected-environment rehearsal already
-   demonstrated that OIDC alone fails closed for this operation.
+3. Grant or replace the repository `NPM_TOKEN` with permission to remove the
+   WebMCP `latest` dist-tag. The protected-environment rehearsal showed both
+   that OIDC alone fails closed and that the current token authenticates but is
+   rejected with `E403` for this package mutation.
 4. Clear the WebMCP RC `latest` tag, record registry-hygiene evidence, and run
    a separated-actor `npm-stable` rehearsal for the normal promotion policy.
 5. Generate and record strict evidence for the final governance commit and

--- a/docs/releases/v1.0.0/status.md
+++ b/docs/releases/v1.0.0/status.md
@@ -71,17 +71,20 @@ release owner authorized and applied the narrow exception
 and administrator-bypass prohibition remain in force. This exception is an
 owner risk acceptance, not proof of independent audit.
 
-The protected WebMCP hygiene rehearsal run
-`31328409822` reached the exact tag precondition, then failed closed with npm
-`E401` on `dist-tag rm`; before-tag evidence shows that no npm tag changed.
-The workflow now requires a repository `NPM_TOKEN` automation secret and runs
-`npm whoami` before any mutation. OIDC trusted publishing alone is not an
-authorized path for this tag-removal operation.
+The protected WebMCP hygiene rehearsal run `31328409822` reached the exact tag
+precondition, then failed closed with npm `E401` on `dist-tag rm`; before-tag
+evidence shows that no npm tag changed. The token-gated retry `31328975435`
+passed `npm whoami` but failed closed with `E403` on the same deletion. The
+repository `NPM_TOKEN` therefore exists but lacks WebMCP dist-tag management
+permission. The workflow performs this authentication preflight before any
+mutation; OIDC trusted publishing alone is not an authorized path for this
+tag-removal operation.
 
 ## Immediate next work
 
-1. Configure the repository `NPM_TOKEN` automation secret, rerun the guarded
-   WebMCP tag cleanup, and record its before/after registry-hygiene evidence.
+1. Grant or replace the repository `NPM_TOKEN` with WebMCP dist-tag management
+   permission, rerun the guarded tag cleanup, and record before/after
+   registry-hygiene evidence.
 2. Refresh strict clean evidence for the final committed token-gated hygiene
    workflow and record its promotion-governance fingerprint.
 3. Obtain an independent audit of the exact registry-installed `next` artifact


### PR DESCRIPTION
## WebMCP npm authorization evidence

Records the guarded workflow results under **CA-1X-RELEASE-001**: OIDC run `31328409822` failed with `E401`; token-authenticated run `31328975435` passed `npm whoami` but failed `dist-tag rm` with `E403`. Both runs preserved the registry tags.

The remaining action requires external npm authorization: grant the repository token explicit WebMCP dist-tag management permission, then rerun the protected cleanup. No release certification or independent-audit gate is relaxed.