### PR TITLE
docs(release): record WebMCP hygiene evidence

### DIFF
--- a/docs/releases/v1.0.0/known-limitations.md
+++ b/docs/releases/v1.0.0/known-limitations.md
@@ -20,11 +20,13 @@
   canonical v1.0.0 notes are this release document set and the GitHub release.
   Runtime and declaration artifacts are unaffected. A stricter artifact-docs
   policy requires a corrected patch cohort rather than silent promotion.
-- The accidental WebMCP RC `latest` tag remains until the protected
-  `@context-action/webmcp@0.1.1` hygiene patch is published. Direct tag deletion
-  is intentionally not used: it failed under OIDC (`E401`) and the configured
-  automation token (`E403` in run `31328975435`). The v1 candidate then needs a
-  WebMCP provenance and audit re-baseline before any stable promotion.
+- The accidental WebMCP RC `latest` tag has been replaced by the protected
+  `@context-action/webmcp@0.1.1` hygiene patch. Run `31341251251` recorded
+  `latest=0.1.1`, `next=0.1.0`, `rc=0.1.0-rc.0`, and a passing external
+  consumer check. Direct tag deletion is intentionally not used: it failed
+  under OIDC (`E401`) and the configured automation token (`E403` in run
+  `31328975435`). The old v1 candidate still needs a WebMCP provenance and
+  audit re-baseline before any stable promotion.
 
 Report any newly discovered P0/P1 issue in the issue ledger and reopen the
 affected gate before approving an RC.

--- a/docs/releases/v1.0.0/publish-runbook.md
+++ b/docs/releases/v1.0.0/publish-runbook.md
@@ -15,7 +15,7 @@ release approvals are still missing. Do not invoke the stable-candidate
 workflow again for these versions. Complete the remaining audit and approvals,
 then use the guarded promotion workflow or publish a corrected patch.
 
-The accidental `@context-action/webmcp@0.1.0-rc.0` `latest` tag is corrected
+The accidental `@context-action/webmcp@0.1.0-rc.0` `latest` tag was corrected
 by publishing `@context-action/webmcp@0.1.1` through **Publish WebMCP Hygiene
 Patch**, not by deleting a dist-tag. The protected workflow requires the exact
 confirmation `publish-webmcp-0.1.1`, an immutable main commit, and a successful
@@ -23,7 +23,10 @@ confirmation `publish-webmcp-0.1.1`, an immutable main commit, and a successful
 normal npm `latest` publish behavior. It then verifies that `latest` is
 `0.1.1`, preserves the existing `next`/`rc` records for `0.1.0`, and uploads
 registry and consumer evidence. Do not run a broad dist-tag command from a
-local shell.
+local shell. Publication run `31340779674` completed the versioned publish;
+evidence run `31341251251` then passed the idempotent tag check and stored the
+captured evidence at
+`release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json`.
 
 The existing `0.1.0` v1 candidate remains immutable evidence for the published
 `next` cohort. After the hygiene patch succeeds, that candidate is superseded

--- a/docs/releases/v1.0.0/readiness.md
+++ b/docs/releases/v1.0.0/readiness.md
@@ -56,10 +56,13 @@ strict `--require-success` verification at that checkout. It verifies the
 guarded workflow and release-process configuration; it does not retroactively
 alter or certify the immutable npm tarballs published before those controls.
 
-The 2026-08-10 WebMCP tag-hygiene rehearsal identified a missing
-automation-token prerequisite for `dist-tag rm`; this bundle covers the
-resulting token-gated workflow update. It still cannot clear the registry
-hygiene blocker until the repository automation token is configured.
+The 2026-08-10 WebMCP tag-hygiene rehearsals showed that `dist-tag rm` is not
+an authorized recovery mechanism. The protected `0.1.1` hygiene patch was
+published instead, and workflow run `31341251251` subsequently captured its
+converged tags and passing external-consumer result in
+`release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json`.
+This clears registry tag hygiene but does not certify the older immutable
+`0.1.0` v1 candidate.
 
 ## Published candidate state
 
@@ -82,15 +85,13 @@ metadata. A release defect requires a corrected patch version.
    recorded source commit.
 2. Complete the hashed G0/G1 scope, public-contract, and legacy-ledger owner
    record in [release-approval.md](./release-approval.md).
-3. Publish the protected WebMCP `0.1.1` hygiene patch to replace the RC
-   `latest` tag. The prior rehearsal showed that direct tag deletion is not an
-   authorized path; the new workflow uses a normal versioned publish instead.
-4. Record the hygiene-patch registry/provenance evidence and re-baseline the
-   WebMCP leg of the v1 candidate before any future stable promotion.
-5. Generate and record strict evidence for the final governance commit and
+3. Re-baseline the WebMCP leg of the v1 candidate to the separate `0.1.1`
+   hygiene-patch provenance and audit. Do not use cleared tag hygiene as an
+   approval for the old `0.1.0` candidate.
+4. Generate and record strict evidence for the final governance commit and
    promotion-governance fingerprint; this documents the release process but
    does not alter the immutable published tarballs.
-6. Only then move the manifest through `audited` and `approved-for-stable`
+5. Only then move the manifest through `audited` and `approved-for-stable`
    before the guarded `latest` promotion.
 
 No status in this report authorizes a release to `latest`.

--- a/docs/releases/v1.0.0/release-manifest.json
+++ b/docs/releases/v1.0.0/release-manifest.json
@@ -86,9 +86,9 @@
   },
   "promotionEvidence": null,
   "registryHygiene": {
-    "status": "blocked",
-    "evidence": "Read-only npm dist-tag check on 2026-08-10 confirmed that @context-action/webmcp latest remains 0.1.0-rc.0 while next is 0.1.0; remove the accidental prerelease latest tag before certification.",
-    "checkedAt": "2026-08-10T00:00:00.000Z"
+    "status": "cleared",
+    "evidence": "Protected workflow run 31341251251 verified @context-action/webmcp@0.1.1 at latest, preserved next=0.1.0 and rc=0.1.0-rc.0, and passed the latest external-consumer check. Evidence: release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json. This clears tag hygiene only; the immutable 0.1.0 v1 candidate remains superseded for WebMCP pending provenance and audit re-baselining.",
+    "checkedAt": "2026-08-09T23:11:34.289Z"
   },
   "packages": {
     "@context-action/core": "1.0.0",
@@ -124,7 +124,7 @@
     "@context-action/webmcp": "latest"
   },
   "requiredBeforeCertification": [
-    "Clear the WebMCP prerelease latest-tag hygiene blocker.",
+    "Re-baseline the WebMCP leg to the separate 0.1.1 hygiene-patch provenance and independent audit; the immutable 0.1.0 next candidate is superseded for that leg.",
     "Obtain the independent published-artifact audit.",
     "Approve the G0/G1 scope and public-contract record."
   ],

--- a/docs/releases/v1.0.0/status.md
+++ b/docs/releases/v1.0.0/status.md
@@ -1,7 +1,7 @@
 # Context-Action v1.0.0 Release Status
 
 **Status:** `NOT READY`<br>
-**Baseline commit:** `eef7af18639dc2431e95e2f68b4489bb368a2c16` (token-gated governance controls; strict evidence recorded)<br>
+**Baseline commit:** `c75ba0be023805c5dd7268752cfe1b8f9f19b2b5` (WebMCP hygiene-evidence retry; new strict governance evidence is still required)<br>
 **Roadmap revision:** `v1-r2`<br>
 **Last synchronized:** 2026-08-10
 
@@ -32,10 +32,11 @@ and command results/artifact hashes belong in
 - Registry evidence records the published `next` cohort from
   `63f790a521e3428a7a2825677747338f8f05ccf3`. The npm CLI cryptographically
   verified all four registry signatures and SLSA provenance bundles; the
-  independent adversarial audit is still required. `@context-action/webmcp@0.1.0-rc.0`
-  still owns `latest`; publish the dedicated `0.1.1` hygiene patch to replace
-  it. The existing candidate must then be re-baselined for WebMCP before the
-  manifest can reach `approved-for-stable`.
+  independent adversarial audit is still required. The protected hygiene
+  workflow has replaced the accidental WebMCP RC `latest` tag with
+  `@context-action/webmcp@0.1.1`. The immutable `0.1.0` candidate is now
+  superseded for the WebMCP leg and must be re-baselined with the patch's
+  provenance and audit before the manifest can reach `approved-for-stable`.
 - Legacy API candidate outcomes await public-contract approval.
 - The published consumer matrix and provenance verification are recorded, but
   the published artifact has not received the required independent audit.
@@ -44,8 +45,9 @@ and command results/artifact hashes belong in
   exception, and disallows administrator bypass. It is the protected
   stable-release environment used by both guarded publication workflows.
 - Existing strict evidence ends at an earlier governance commit. The current
-  promotion-governance controls require a fresh clean evidence bundle and a
-  recorded file fingerprint before approval; past bundles remain historical.
+  promotion-governance controls, including the hygiene-patch workflow, require
+  a fresh clean evidence bundle and a recorded file fingerprint before
+  approval; past bundles remain historical.
 - `@context-action/tool-protocol@1.0.0` has the accepted bundled-CHANGELOG
   limitation recorded in the manifest and known-limitations document. A patch
   cohort is required if bundled release notes are a certification requirement.
@@ -59,8 +61,11 @@ and command results/artifact hashes belong in
 On 2026-08-10, read-only npm and GitHub API checks confirmed the recorded
 external state:
 
-- `@context-action/webmcp`: `latest` is still `0.1.0-rc.0`, while `next` is
-  `0.1.0`; registry hygiene remains blocked.
+- `@context-action/webmcp`: `latest` is `0.1.1`, while `next` is `0.1.0` and
+  `rc` is `0.1.0-rc.0`; registry tag hygiene is cleared. Protected workflow
+  run `31341251251` also passed the `latest` external-consumer check; its
+  captured evidence is
+  `release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json`.
 - `npm-stable` allows only `main`, requires review by `mineclover`, permits the
   owner-authorized self-review exception, and disallows administrator bypass.
 
@@ -75,22 +80,26 @@ The protected WebMCP hygiene rehearsals `31328409822` and `31328975435`
 confirmed that direct `dist-tag rm` is not a viable repair path (OIDC failed
 with `E401`; the configured token failed with `E403`). The repair is now the
 versioned `@context-action/webmcp@0.1.1` hygiene patch, published through a
-separate protected workflow. Its token preflight and exact-version validation
+separate protected workflow. Run `31340779674` published it, and rerun
+`31341251251` completed the deferred tag, consumer, and registry-evidence
+checks without republishing. Its token preflight and exact-version validation
 remain fail-closed before any publication attempt.
 
 ## Immediate next work
 
-1. Publish the protected `@context-action/webmcp@0.1.1` hygiene patch to
-   `latest`, then record its registry and consumer evidence.
-2. Re-baseline the WebMCP leg of the v1 manifest, provenance audit, and strict
-   governance evidence before any future stable promotion.
+1. Re-baseline the WebMCP leg of the v1 manifest and provenance audit to the
+   separately published `0.1.1` hygiene patch; do not approve the old `0.1.0`
+   candidate as if it were the `latest` package.
+2. Generate and record strict governance evidence for the current controls and
+   updated fingerprint before any future stable promotion.
 3. Obtain an independent audit of the exact registry-installed `next` artifact
-   with the traceable GitHub approval record.
+   and the separately published WebMCP patch with a traceable GitHub approval
+   record.
 4. Complete the hashed G0/G1 owner record in
    [release-approval.md](./release-approval.md) for the target map, M1
    candidates, and M2 legacy decisions.
 5. Run an `npm-stable` no-op or intentionally failing dry run with separate
-   dispatcher and reviewer identities before any `latest` promotion.
+   dispatcher and reviewer identities before any v1 `latest` promotion.
 
 ## Development evidence
 

--- a/release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json
+++ b/release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "context-action-published-release-evidence.v1",
+  "capturedAt": "2026-08-09T23:11:34.289Z",
+  "distTag": "latest",
+  "packages": {
+    "@context-action/webmcp": {
+      "version": "0.1.1",
+      "integrity": "sha512-ncE8ioSgrlmwMW8jHmQP+rszU3nEiqP7Ca+QvSi5LaeHZl5nt17UMTXWu/+sHQ5LGbq+72632sHrH5V1cvsfOg==",
+      "tarball": "https://registry.npmjs.org/@context-action/webmcp/-/webmcp-0.1.1.tgz",
+      "sha256": "2e5165a23fc99fbf78e758bcb26fdcab480d184b460db8d582977f334eae962f",
+      "publishedAt": "2026-08-09T23:00:35.690Z",
+      "distTags": {
+        "rc": "0.1.0-rc.0",
+        "latest": "0.1.1",
+        "next": "0.1.0"
+      },
+      "provenance": {
+        "status": "pending-verification",
+        "sourceCommit": null
+      },
+      "externalConsumer": {
+        "status": "passed"
+      }
+    }
+  },
+  "notes": [
+    "Tarball SHA-256 and registry metadata were read after publication.",
+    "Provenance status remains pending until the npm attestation source commit is independently verified."
+  ]
+}


### PR DESCRIPTION
## WebMCP hygiene evidence

Records the successful protected evidence run **31341251251** under **CA-1X-RELEASE-001**. The run confirmed `@context-action/webmcp@0.1.1` at `latest`, preserved `next=0.1.0` and `rc=0.1.0-rc.0`, and passed the external consumer check.

The v1 manifest remains `published-unapproved`: this clears tag hygiene only and explicitly preserves the required WebMCP provenance/audit re-baseline and all independent approval blockers.