### PR TITLE
test(release): preserve stable prepublish evidence

### DIFF
--- a/release-evidence/v1.0.0-stable-prepublish-3/artifacts/01-release-manifest.json
+++ b/release-evidence/v1.0.0-stable-prepublish-3/artifacts/01-release-manifest.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "./release-manifest.schema.json",
+  "schemaVersion": "context-action-v1-release-manifest.v2",
+  "status": "candidate-unapproved",
+  "release": "context-action-v1.0.0",
+  "commit": null,
+  "distTag": null,
+  "registryEvidence": null,
+  "audit": null,
+  "packages": {
+    "@context-action/core": "1.0.0",
+    "@context-action/react": "1.0.0",
+    "@context-action/tool-protocol": "1.0.0",
+    "@context-action/webmcp": "0.1.0"
+  },
+  "stableSurfaces": [
+    "@context-action/core",
+    "@context-action/react",
+    "@context-action/tool-protocol"
+  ],
+  "experimentalSurfaces": [
+    "@context-action/webmcp",
+    "@context-action/react/webmcp"
+  ],
+  "requiredBeforeCertification": [
+    "Set the immutable RC commit for the published candidate.",
+    "Record provenance and external-consumer results for the published candidate.",
+    "Obtain the independent adversarial audit required for RC certification."
+  ]
+}

--- a/release-evidence/v1.0.0-stable-prepublish-3/artifacts/02-pnpm-lock.yaml
+++ b/release-evidence/v1.0.0-stable-prepublish-3/artifacts/02-pnpm-lock.yaml
@@ -1,0 +1,14105 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  esbuild@<=0.24.2: 0.25.0
+  esbuild@>=0.27.3 <0.28.1: 0.28.1
+  '@types/react': 19.2.17
+  preact@>=10.27.0 <10.27.3: 10.27.3
+  js-yaml@<4.0.0: 3.15.1
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  mdast-util-to-hast@>=13.0.0 <13.2.1: 13.2.1
+  rollup@>=4.0.0 <4.59.0: 4.59.0
+  handlebars@>=4.0.0 <4.7.9: 4.7.9
+  brace-expansion@<5.0.9: 5.0.9
+  lodash-es@<=4.17.23: 4.18.0
+  defu@<=6.1.4: 6.1.5
+  vitepress>vite: 6.4.3
+  vitest>vite: 8.0.16
+  follow-redirects@<=1.15.11: 1.16.0
+  dompurify@<3.4.13: 3.4.13
+  axios@>=1.0.0 <1.18.0: 1.18.0
+  fast-uri@<3.1.5: 3.1.5
+  ip-address@<10.3.1: 10.3.1
+  nx@<22.7.7: 22.7.7
+  postcss@<8.5.23: 8.5.26
+  ws@>=8.0.0 <8.21.0: 8.21.0
+  uuid@<11.1.1: 11.1.1
+  react-router@>=7.0.0 <8.0.0: 7.18.1
+  mermaid@>=11.0.0-alpha.1 <11.16.1: 11.16.1
+  yaml@<2.8.3: 2.9.0
+  tmp@<0.2.7: 0.2.7
+  form-data@>=4.0.0 <4.0.6: 4.0.6
+  tar@<=7.5.20: 7.5.21
+  '@babel/core@<=7.29.0': 7.29.7
+  markdown-it@<=14.1.1: 14.2.0
+  '@sigstore/core@<=3.2.0': 3.2.1
+  linkify-it@<=5.0.0: 5.0.1
+  sigstore@<=4.1.0: 4.1.1
+  '@sigstore/verify@3.1.0': 3.1.1
+
+importers:
+
+  .:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.5
+        version: 2.5.5
+      '@tailwindcss/typography':
+        specifier: 0.5.20
+        version: 0.5.20(tailwindcss@4.3.2)
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      ajv:
+        specifier: 8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: 3.0.1
+        version: 3.0.1(ajv@8.20.0)
+      ansis:
+        specifier: 4.3.1
+        version: 4.3.1
+      autoprefixer:
+        specifier: 10.5.4
+        version: 10.5.4(postcss@8.5.26)
+      comment-parser:
+        specifier: 1.4.7
+        version: 1.4.7
+      husky:
+        specifier: 9.1.7
+        version: 9.1.7
+      lerna:
+        specifier: ^9.0.7
+        version: 9.0.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)
+      mermaid:
+        specifier: 11.16.1
+        version: 11.16.1
+      postcss:
+        specifier: 8.5.26
+        version: 8.5.26
+      shiki:
+        specifier: 4.3.1
+        version: 4.3.1
+      tailwindcss:
+        specifier: 4.3.2
+        version: 4.3.2
+      typedoc:
+        specifier: 0.28.20
+        version: 0.28.20(typescript@6.0.3)
+      typedoc-plugin-markdown:
+        specifier: 4.12.0
+        version: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitepress:
+        specifier: 1.6.4
+        version: 1.6.4(@algolia/client-search@5.35.0)(@types/node@24.13.3)(@types/react@19.2.17)(axios@1.18.0)(jiti@2.6.1)(lightningcss@1.32.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(terser@5.43.1)(typescript@6.0.3)(yaml@2.9.0)
+      vue:
+        specifier: 3.5.40
+        version: 3.5.40(typescript@6.0.3)
+
+  demos/bolt-style-editor:
+    dependencies:
+      '@context-action/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@context-action/live-code-editor':
+        specifier: workspace:*
+        version: link:../../packages/live-code-editor
+      '@context-action/openrouter-browser-storage':
+        specifier: workspace:*
+        version: link:../../packages/openrouter-browser-storage
+      '@context-action/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@context-action/tool-durable-operations':
+        specifier: workspace:*
+        version: link:../../packages/tool-durable-operations
+      '@context-action/tool-protocol':
+        specifier: workspace:*
+        version: link:../../packages/tool-protocol
+      dexie:
+        specifier: 4.4.4
+        version: 4.4.4
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.5
+        version: 2.5.5
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 6.0.4
+        version: 6.0.4(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: 8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0)
+
+  example:
+    dependencies:
+      '@ai-sdk/openai-compatible':
+        specifier: 3.0.14
+        version: 3.0.14(zod@4.4.3)
+      '@context-action/ai-sdk':
+        specifier: workspace:*
+        version: link:../packages/ai-sdk
+      '@context-action/core':
+        specifier: workspace:*
+        version: link:../packages/core
+      '@context-action/live-code-editor':
+        specifier: workspace:*
+        version: link:../packages/live-code-editor
+      '@context-action/openrouter-browser-storage':
+        specifier: workspace:*
+        version: link:../packages/openrouter-browser-storage
+      '@context-action/react':
+        specifier: workspace:*
+        version: link:../packages/react
+      '@context-action/tool-durable-operations':
+        specifier: workspace:*
+        version: link:../packages/tool-durable-operations
+      '@context-action/tool-protocol':
+        specifier: workspace:*
+        version: link:../packages/tool-protocol
+      ai:
+        specifier: 7.0.34
+        version: 7.0.34(zod@4.4.3)
+      clsx:
+        specifier: 2.1.1
+        version: 2.1.1
+      dexie:
+        specifier: 4.4.4
+        version: 4.4.4
+      immer:
+        specifier: 11.1.15
+        version: 11.1.15
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
+      react-router-dom:
+        specifier: 7.18.1
+        version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@babel/core':
+        specifier: 7.29.7
+        version: 7.29.7
+      '@biomejs/biome':
+        specifier: 2.5.5
+        version: 2.5.5
+      '@rolldown/plugin-babel':
+        specifier: 0.2.3
+        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0))
+      '@types/babel__core':
+        specifier: 7.20.5
+        version: 7.20.5
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 6.0.4
+        version: 6.0.4(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0))
+      autoprefixer:
+        specifier: 10.5.4
+        version: 10.5.4(postcss@8.5.26)
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
+      postcss:
+        specifier: 8.5.26
+        version: 8.5.26
+      rolldown:
+        specifier: 1.2.0
+        version: 1.2.0
+      tailwindcss:
+        specifier: 3.4.19
+        version: 3.4.19(yaml@2.9.0)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: 8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0)
+      vite-bundle-analyzer:
+        specifier: 1.3.9
+        version: 1.3.9
+
+  packages/ai-sdk:
+    dependencies:
+      '@context-action/tool-protocol':
+        specifier: ^0.8.9
+        version: link:../tool-protocol
+    devDependencies:
+      '@swc/core':
+        specifier: 1.15.46
+        version: 1.15.46(@swc/helpers@0.5.23)
+      '@swc/jest':
+        specifier: 0.2.39
+        version: 0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      ai:
+        specifier: 7.0.34
+        version: 7.0.34(zod@4.4.3)
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2(@types/node@24.13.3)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+  packages/core:
+    devDependencies:
+      '@context-action/tool-protocol':
+        specifier: workspace:*
+        version: link:../tool-protocol
+      '@swc/core':
+        specifier: 1.15.46
+        version: 1.15.46(@swc/helpers@0.5.23)
+      '@swc/helpers':
+        specifier: 0.5.23
+        version: 0.5.23
+      '@swc/jest':
+        specifier: 0.2.39
+        version: 0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2(@types/node@24.13.3)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
+  packages/live-code-editor:
+    devDependencies:
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+  packages/llms-generator:
+    dependencies:
+      commander:
+        specifier: 15.0.0
+        version: 15.0.0
+      glob:
+        specifier: 13.0.6
+        version: 13.0.6
+      gray-matter:
+        specifier: 4.0.3
+        version: 4.0.3
+    devDependencies:
+      '@context-action/react':
+        specifier: workspace:*
+        version: link:../react
+      '@swc/core':
+        specifier: 1.15.46
+        version: 1.15.46(@swc/helpers@0.5.23)
+      '@swc/helpers':
+        specifier: 0.5.23
+        version: 0.5.23
+      '@swc/jest':
+        specifier: 0.2.39
+        version: 0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      ajv:
+        specifier: 8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: 3.0.1
+        version: 3.0.1(ajv@8.20.0)
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2(@types/node@24.13.3)
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+  packages/mutative:
+    dependencies:
+      '@context-action/mutative-core':
+        specifier: ^0.8.8
+        version: link:../mutative-core
+    devDependencies:
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(synckit@0.11.12))
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(jsdom@26.1.0)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0))
+
+  packages/mutative-core:
+    devDependencies:
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(jsdom@26.1.0)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0))
+
+  packages/openrouter-browser-storage:
+    devDependencies:
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+  packages/react:
+    dependencies:
+      '@context-action/core':
+        specifier: ^1.0.0
+        version: link:../core
+      '@context-action/mutative':
+        specifier: ^0.8.8
+        version: link:../mutative
+      '@context-action/tool-durable-operations':
+        specifier: ^0.1.1
+        version: link:../tool-durable-operations
+      '@context-action/tool-protocol':
+        specifier: ^1.0.0
+        version: link:../tool-protocol
+      '@context-action/webmcp':
+        specifier: ^0.1.0
+        version: link:../webmcp
+    devDependencies:
+      '@babel/core':
+        specifier: 7.29.7
+        version: 7.29.7
+      '@swc/core':
+        specifier: 1.15.46
+        version: 1.15.46(@swc/helpers@0.5.23)
+      '@swc/helpers':
+        specifier: 0.5.23
+        version: 0.5.23
+      '@swc/jest':
+        specifier: 0.2.39
+        version: 0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      '@testing-library/jest-dom':
+        specifier: 6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@testing-library/user-event':
+        specifier: 14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/babel__core':
+        specifier: 7.20.5
+        version: 7.20.5
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2(@types/node@24.13.3)
+      jest-environment-jsdom:
+        specifier: 30.4.1
+        version: 30.4.1
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      rolldown:
+        specifier: 1.2.0
+        version: 1.2.0
+      rollup-plugin-visualizer:
+        specifier: 7.0.1
+        version: 7.0.1(rolldown@1.2.0)(rollup@4.59.0)
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
+  packages/style-testing:
+    dependencies:
+      '@babel/core':
+        specifier: 7.29.7
+        version: 7.29.7
+      '@babel/parser':
+        specifier: ^7.29.2
+        version: 7.29.7
+      '@babel/traverse':
+        specifier: ^7.29.0
+        version: 7.29.7
+      '@babel/types':
+        specifier: ^7.29.0
+        version: 7.29.7
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      commander:
+        specifier: 15.0.0
+        version: 15.0.0
+      playwright:
+        specifier: 1.61.1
+        version: 1.61.1
+      tailwindcss:
+        specifier: 3.4.19
+        version: 3.4.19(yaml@2.9.0)
+    devDependencies:
+      '@types/babel__core':
+        specifier: 7.20.5
+        version: 7.20.5
+      '@types/babel__traverse':
+        specifier: 7.28.0
+        version: 7.28.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+  packages/tool-durable-operations:
+    devDependencies:
+      '@swc/core':
+        specifier: 1.15.46
+        version: 1.15.46(@swc/helpers@0.5.23)
+      '@swc/jest':
+        specifier: 0.2.39
+        version: 0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2(@types/node@24.13.3)
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
+      redis:
+        specifier: ^5.12.1
+        version: 5.12.1(@opentelemetry/api@1.9.0)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+  packages/tool-protocol:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@swc/core':
+        specifier: 1.15.46
+        version: 1.15.46(@swc/helpers@0.5.23)
+      '@swc/jest':
+        specifier: 0.2.39
+        version: 0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2(@types/node@24.13.3)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+  packages/typedoc-vitepress-sync:
+    dependencies:
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      commander:
+        specifier: 15.0.0
+        version: 15.0.0
+      ora:
+        specifier: 9.4.1
+        version: 9.4.1
+      typedoc:
+        specifier: ^0.28.20
+        version: 0.28.20(typescript@6.0.3)
+      vitepress:
+        specifier: ^1.6.4
+        version: 1.6.4(@algolia/client-search@5.35.0)(@types/node@24.13.3)(@types/react@19.2.17)(axios@1.18.0)(jiti@2.6.1)(lightningcss@1.32.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(terser@5.43.1)(typescript@6.0.3)(yaml@2.9.0)
+    devDependencies:
+      '@swc/core':
+        specifier: 1.15.46
+        version: 1.15.46(@swc/helpers@0.5.23)
+      '@swc/helpers':
+        specifier: 0.5.23
+        version: 0.5.23
+      '@swc/jest':
+        specifier: 0.2.39
+        version: 0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2(@types/node@24.13.3)
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+  packages/webmcp:
+    dependencies:
+      '@context-action/tool-protocol':
+        specifier: ^1.0.0
+        version: link:../tool-protocol
+    devDependencies:
+      '@swc/core':
+        specifier: 1.15.46
+        version: 1.15.46(@swc/helpers@0.5.23)
+      '@swc/jest':
+        specifier: 0.2.39
+        version: 0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2(@types/node@24.13.3)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsdown:
+        specifier: 0.22.13
+        version: 0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12))
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ai-sdk/gateway@4.0.26':
+    resolution: {integrity: sha512-b/nc3COKtk8IxzgcCi418IoZFky/Bw+Jg8+J0/SBBnu/mOXA4bkIKCu81coEtJAWuH2g5Fvvsa0ar7EpmzNWTw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@3.0.14':
+    resolution: {integrity: sha512-nUl7dBHUDTqcnuWGnEbKMwDDqL94BxRfibLwYv8uWp+kZn8Zqdxy7tUBt4sv2hpHQi+S2P6bUyqW18xmbykErw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.12':
+    resolution: {integrity: sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
+
+  '@algolia/abtesting@1.1.0':
+    resolution: {integrity: sha512-sEyWjw28a/9iluA37KLGu8vjxEIlb60uxznfTUmXImy7H5NvbpSO6yYgmgH5KiD7j+zTUUihiST0jEP12IoXow==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/autocomplete-core@1.17.7':
+    resolution: {integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==}
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
+    resolution: {integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==}
+    peerDependencies:
+      search-insights: '>= 1 < 3'
+
+  '@algolia/autocomplete-preset-algolia@1.17.7':
+    resolution: {integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/autocomplete-shared@1.17.7':
+    resolution: {integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/client-abtesting@5.35.0':
+    resolution: {integrity: sha512-uUdHxbfHdoppDVflCHMxRlj49/IllPwwQ2cQ8DLC4LXr3kY96AHBpW0dMyi6ygkn2MtFCc6BxXCzr668ZRhLBQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-analytics@5.35.0':
+    resolution: {integrity: sha512-SunAgwa9CamLcRCPnPHx1V2uxdQwJGqb1crYrRWktWUdld0+B2KyakNEeVn5lln4VyeNtW17Ia7V7qBWyM/Skw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-common@5.35.0':
+    resolution: {integrity: sha512-ipE0IuvHu/bg7TjT2s+187kz/E3h5ssfTtjpg1LbWMgxlgiaZIgTTbyynM7NfpSJSKsgQvCQxWjGUO51WSCu7w==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-insights@5.35.0':
+    resolution: {integrity: sha512-UNbCXcBpqtzUucxExwTSfAe8gknAJ485NfPN6o1ziHm6nnxx97piIbcBQ3edw823Tej2Wxu1C0xBY06KgeZ7gA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-personalization@5.35.0':
+    resolution: {integrity: sha512-/KWjttZ6UCStt4QnWoDAJ12cKlQ+fkpMtyPmBgSS2WThJQdSV/4UWcqCUqGH7YLbwlj3JjNirCu3Y7uRTClxvA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-query-suggestions@5.35.0':
+    resolution: {integrity: sha512-8oCuJCFf/71IYyvQQC+iu4kgViTODbXDk3m7yMctEncRSRV+u2RtDVlpGGfPlJQOrAY7OONwJlSHkmbbm2Kp/w==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-search@5.35.0':
+    resolution: {integrity: sha512-FfmdHTrXhIduWyyuko1YTcGLuicVbhUyRjO3HbXE4aP655yKZgdTIfMhZ/V5VY9bHuxv/fGEh3Od1Lvv2ODNTg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/ingestion@1.35.0':
+    resolution: {integrity: sha512-gPzACem9IL1Co8mM1LKMhzn1aSJmp+Vp434An4C0OBY4uEJRcqsLN3uLBlY+bYvFg8C8ImwM9YRiKczJXRk0XA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/monitoring@1.35.0':
+    resolution: {integrity: sha512-w9MGFLB6ashI8BGcQoVt7iLgDIJNCn4OIu0Q0giE3M2ItNrssvb8C0xuwJQyTy1OFZnemG0EB1OvXhIHOvQwWw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/recommend@5.35.0':
+    resolution: {integrity: sha512-AhrVgaaXAb8Ue0u2nuRWwugt0dL5UmRgS9LXe0Hhz493a8KFeZVUE56RGIV3hAa6tHzmAV7eIoqcWTQvxzlJeQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-browser-xhr@5.35.0':
+    resolution: {integrity: sha512-diY415KLJZ6x1Kbwl9u96Jsz0OstE3asjXtJ9pmk1d+5gPuQ5jQyEsgC+WmEXzlec3iuVszm8AzNYYaqw6B+Zw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-fetch@5.35.0':
+    resolution: {integrity: sha512-uydqnSmpAjrgo8bqhE9N1wgcB98psTRRQXcjc4izwMB7yRl9C8uuAQ/5YqRj04U0mMQ+fdu2fcNF6m9+Z1BzDQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-node-http@5.35.0':
+    resolution: {integrity: sha512-RgLX78ojYOrThJHrIiPzT4HW3yfQa0D7K+MQ81rhxqaNyNBu4F1r+72LNHYH/Z+y9I1Mrjrd/c/Ue5zfDgAEjQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-syntax-async-generators@7.8.4':
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-bigint@7.8.3':
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-class-properties@7.12.13':
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-class-static-block@7.14.5':
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-import-attributes@7.28.6':
+    resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-import-meta@7.10.4':
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-json-strings@7.8.3':
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4':
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3':
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3':
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3':
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5':
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-top-level-await@7.14.5':
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@biomejs/biome@2.5.5':
+    resolution: {integrity: sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.5.5':
+    resolution: {integrity: sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.5.5':
+    resolution: {integrity: sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
+    resolution: {integrity: sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.5.5':
+    resolution: {integrity: sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.5.5':
+    resolution: {integrity: sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.5.5':
+    resolution: {integrity: sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.5.5':
+    resolution: {integrity: sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.5.5':
+    resolution: {integrity: sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@docsearch/css@3.8.2':
+    resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
+
+  '@docsearch/js@3.8.2':
+    resolution: {integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==}
+
+  '@docsearch/react@3.8.2':
+    resolution: {integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==}
+    peerDependencies:
+      '@types/react': 19.2.17
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+      search-insights: '>= 1 < 3'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      search-insights:
+        optional: true
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
+  '@emnapi/core@1.4.5':
+    resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/runtime@1.4.5':
+    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
+
+  '@emnapi/wasi-threads@1.0.4':
+    resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
+
+  '@hutson/parse-repository-url@3.0.2':
+    resolution: {integrity: sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@iconify-json/simple-icons@1.2.49':
+    resolution: {integrity: sha512-nRLwrHzz+cTAQYBNQrcr4eWOmQIcHObTj/QSi7nj0SFwVh5MvBsgx8OhoDC/R8iGklNmMpmoE/NKU0cPXMlOZw==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.0':
+    resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
+
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@isaacs/string-locale-compare@1.1.0':
+    resolution: {integrity: sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==}
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
+    engines: {node: '>=8'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
+  '@jest/console@30.4.1':
+    resolution: {integrity: sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/core@30.4.2':
+    resolution: {integrity: sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/create-cache-key-function@30.4.1':
+    resolution: {integrity: sha512-R+xGEtzA95NIsvpXJSROG4t01956dDOt17KpamguY4XOnGvdHNFFXE7Er0C1OAsRjOwiIxpKqOvGlznIGZIQlQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/diff-sequences@30.0.1':
+    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/diff-sequences@30.4.0':
+    resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/environment-jsdom-abstract@30.4.1':
+    resolution: {integrity: sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+      jsdom: '*'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  '@jest/environment@30.4.1':
+    resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect-utils@30.4.1':
+    resolution: {integrity: sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect@30.4.1':
+    resolution: {integrity: sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/fake-timers@30.4.1':
+    resolution: {integrity: sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/globals@30.4.1':
+    resolution: {integrity: sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/pattern@30.4.0':
+    resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/reporters@30.4.1':
+    resolution: {integrity: sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/schemas@30.4.1':
+    resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/snapshot-utils@30.4.1':
+    resolution: {integrity: sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/source-map@30.0.1':
+    resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-result@30.4.1':
+    resolution: {integrity: sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-sequencer@30.4.1':
+    resolution: {integrity: sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/transform@30.4.1':
+    resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/types@30.4.1':
+    resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
+
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@napi-rs/wasm-runtime@0.2.4':
+    resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@npmcli/agent@4.0.0':
+    resolution: {integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/arborist@9.1.6':
+    resolution: {integrity: sha512-c5Pr3EG8UP5ollkJy2x+UdEQC5sEHe3H9whYn6hb2HJimAKS4zmoJkx5acCiR/g4P38RnCSMlsYQyyHnKYeLvQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  '@npmcli/fs@4.0.0':
+    resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/fs@5.0.0':
+    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/git@6.0.3':
+    resolution: {integrity: sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/git@7.0.2':
+    resolution: {integrity: sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/installed-package-contents@3.0.0':
+    resolution: {integrity: sha512-fkxoPuFGvxyrH+OQzyTkX2LUEamrF4jZSmxjAtPPHHGO0dqsQ8tTKjnIS8SAnPHdk2I03BDtSMR5K/4loKg79Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  '@npmcli/installed-package-contents@4.0.0':
+    resolution: {integrity: sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  '@npmcli/map-workspaces@5.0.3':
+    resolution: {integrity: sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/metavuln-calculator@9.0.3':
+    resolution: {integrity: sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/name-from-folder@3.0.0':
+    resolution: {integrity: sha512-61cDL8LUc9y80fXn+lir+iVt8IS0xHqEKwPu/5jCjxQTVoSCmkXvw4vbMrzAMtmghz3/AkiBjhHkDKUH+kf7kA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/name-from-folder@4.0.0':
+    resolution: {integrity: sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/node-gyp@4.0.0':
+    resolution: {integrity: sha512-+t5DZ6mO/QFh78PByMq1fGSAub/agLJZDRfJRMeOSNCt8s9YVlTjmGpIPwPhvXTGUIJk+WszlT0rQa1W33yzNA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/node-gyp@5.0.0':
+    resolution: {integrity: sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/package-json@7.0.2':
+    resolution: {integrity: sha512-0ylN3U5htO1SJTmy2YI78PZZjLkKUGg7EKgukb2CRi0kzyoDr0cfjHAzi7kozVhj2V3SxN1oyKqZ2NSo40z00g==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/promise-spawn@8.0.3':
+    resolution: {integrity: sha512-Yb00SWaL4F8w+K8YGhQ55+xE4RUNdMHV43WZGsiTM92gS+lC0mGsn7I4hLug7pbao035S6bj3Y3w0cUNGLfmkg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/promise-spawn@9.0.1':
+    resolution: {integrity: sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/query@4.0.1':
+    resolution: {integrity: sha512-4OIPFb4weUUwkDXJf4Hh1inAn8neBGq3xsH4ZsAaN6FK3ldrFkH7jSpCc7N9xesi0Sp+EBXJ9eGMDrEww2Ztqw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/redact@3.2.2':
+    resolution: {integrity: sha512-7VmYAmk4csGv08QzrDKScdzn11jHPFGyqJW39FyPgPuAp3zIaUmuCo1yxw9aGs+NEJuTGQ9Gwqpt93vtJubucg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/redact@4.0.0':
+    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/run-script@10.0.3':
+    resolution: {integrity: sha512-ER2N6itRkzWbbtVmZ9WKaWxVlKlOeBFF1/7xx+KA5J1xKa4JjUwBdb6tDpk0v1qA+d+VDwHI9qmLcXSWcmi+Rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@nx/devkit@22.6.2':
+    resolution: {integrity: sha512-XDSaapU6y75MLxvD68itwY0jzkzPhM8k5ZRngEl9eEQeBxDmwj9lDK85R58KuBl9F6j2FWULK27eAnH6nc9W6Q==}
+    peerDependencies:
+      nx: 22.7.7
+
+  '@nx/nx-darwin-arm64@22.7.7':
+    resolution: {integrity: sha512-HGu8Bc3DzmIFeKHzIEDBDScgI8/hOjVIj/EzJBE5289dUf+CQ5OSXc6kw2NL9SiCMAPKa0clqcJgLJLqP5t/DQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@nx/nx-darwin-x64@22.7.7':
+    resolution: {integrity: sha512-J7z/Hh+bEKB9xvHdmtO5sK7YytFx8Ry6YpvYI2PoSl2/xDBca7q69fzHKTtm4S/8FvA1Qoi/m//JTIMQUB7cKA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@nx/nx-freebsd-x64@22.7.7':
+    resolution: {integrity: sha512-9H4bbI3fBr8Ct+6xmF6dqDKEvER60XV3tanXTSVtUBxyAVw3cPmRh7aMAu5PNyN+ewzRAJvV6KI4Rx1kA+s9jw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@nx/nx-linux-arm-gnueabihf@22.7.7':
+    resolution: {integrity: sha512-QsGaaZ7PI18c7rFgvUe0F0UYa5oErSKY6Yff6HVXy2zAAWluM4F/TXIRYbtXlvSq++CHhFXxk29Xb3+/zGR/rg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@nx/nx-linux-arm64-gnu@22.7.7':
+    resolution: {integrity: sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@nx/nx-linux-arm64-musl@22.7.7':
+    resolution: {integrity: sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@nx/nx-linux-x64-gnu@22.7.7':
+    resolution: {integrity: sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@nx/nx-linux-x64-musl@22.7.7':
+    resolution: {integrity: sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@nx/nx-win32-arm64-msvc@22.7.7':
+    resolution: {integrity: sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@nx/nx-win32-x64-msvc@22.7.7':
+    resolution: {integrity: sha512-AHVjXkreXjVKAKpMNCsF5nQC/et6lpQcERRm8AYOCncI59hTjYOLpdCMBLrIHA3hgc6SUYU8n5+tMAbv7zXXiQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@octokit/auth-token@4.0.0':
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@5.2.2':
+    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@9.0.6':
+    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/graphql@7.1.1':
+    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@24.2.0':
+    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/plugin-enterprise-rest@6.0.1':
+    resolution: {integrity: sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw==}
+
+  '@octokit/plugin-paginate-rest@11.4.4-cjs.2':
+    resolution: {integrity: sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/plugin-request-log@4.0.1':
+    resolution: {integrity: sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1':
+    resolution: {integrity: sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': ^5
+
+  '@octokit/request-error@5.1.1':
+    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@8.4.1':
+    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/rest@20.1.2':
+    resolution: {integrity: sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@13.10.0':
+    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@oxc-project/types@0.140.0':
+    resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@quansync/fs@1.0.0':
+    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
+  '@redis/bloom@5.12.1':
+    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/client@5.12.1':
+    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@5.12.1':
+    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/search@5.12.1':
+    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/time-series@5.12.1':
+    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.11':
+    resolution: {integrity: sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.0':
+    resolution: {integrity: sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
+    resolution: {integrity: sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
+    resolution: {integrity: sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.11':
+    resolution: {integrity: sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.11':
+    resolution: {integrity: sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
+    resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
+    resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
+    resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
+    resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.2.0':
+    resolution: {integrity: sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.11':
+    resolution: {integrity: sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    resolution: {integrity: sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
+    resolution: {integrity: sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
+    resolution: {integrity: sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/plugin-babel@0.2.3':
+    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.11':
+    resolution: {integrity: sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@shikijs/core@2.5.0':
+    resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
+
+  '@shikijs/core@4.3.1':
+    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@2.5.0':
+    resolution: {integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==}
+
+  '@shikijs/engine-javascript@4.3.1':
+    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    resolution: {integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/engine-oniguruma@4.3.1':
+    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@2.5.0':
+    resolution: {integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/langs@4.3.1':
+    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.3.1':
+    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@2.5.0':
+    resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/themes@4.3.1':
+    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/transformers@2.5.0':
+    resolution: {integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==}
+
+  '@shikijs/types@2.5.0':
+    resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/types@4.3.1':
+    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sigstore/bundle@4.0.0':
+    resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/core@3.2.1':
+    resolution: {integrity: sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/protobuf-specs@0.5.0':
+    resolution: {integrity: sha512-MM8XIwUjN2bwvCg1QvrMtbBmpcSHrkhFSCu1D11NyPvDQ25HEc4oG5/OcQfd/Tlf/OxmKWERDj0zGE23jQaMwA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@sigstore/sign@4.1.1':
+    resolution: {integrity: sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/tuf@4.0.2':
+    resolution: {integrity: sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/verify@3.1.1':
+    resolution: {integrity: sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sinclair/typebox@0.34.40':
+    resolution: {integrity: sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==}
+
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@swc/core-darwin-arm64@1.15.46':
+    resolution: {integrity: sha512-IsISIT22EfktVJrlvIpnAxG2u/A9aob9l99HMlx80x72WlFmFPk1V3UhkEzx86eJP8hw049KTFv/RISho2cq2Q==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.46':
+    resolution: {integrity: sha512-4Tj4ppVIPCmUMpmGFiGtyEriwLyJ+yi/US4WfBrP/ok8COGddDZXLEzQETnKyK46mjvr1v0jevrS23zjoff7vA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.46':
+    resolution: {integrity: sha512-i8tUGnNjyOgMmfmgFSg4aeJLQoFyfpIHK5FjpQAwpRyQIqEUB2w1e8zIDQzY1WhOxx8NoS1S5iUL813Un4Sf5A==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.46':
+    resolution: {integrity: sha512-c0OnhqzdhfOvv6qhNCcByepB+sNYOGZyhtr2Qa6ZCHvAWTYhSRw4j/u92Stue9PbZ/6q74b9nHzi76+kVzqQHQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-musl@1.15.46':
+    resolution: {integrity: sha512-imyRpNEcUzFQFV2LE4jL68ErvmKEuZCbvZru77iQREunJ+bR4i658cupTgtG1mLYM3F1Tzy3Sb9xYb02KghWTg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-linux-ppc64-gnu@1.15.46':
+    resolution: {integrity: sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-s390x-gnu@1.15.46':
+    resolution: {integrity: sha512-DxlMdnt84TtRVTv7WL/thWyz9+QU8QZNNoAP9rrk0P68LziuhfePp8MjQ44zIprpTHTsEwyziIuGUUN5iSC1bQ==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.15.46':
+    resolution: {integrity: sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-musl@1.15.46':
+    resolution: {integrity: sha512-qj9T6B7bosI0VEsrWOVXZN1OXxS8Tp63ywyrLxNdOycnUtLdkgYcoBsN5y8ImnDDsnwrEWZOy1e+J4xSe7mA3Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-win32-arm64-msvc@1.15.46':
+    resolution: {integrity: sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.46':
+    resolution: {integrity: sha512-tUEnfr3Bn9u6FOjUb3PN9p+09qZC2j+wNDLKHzXXZn22rqGcUqR/ohCRSS+nG9B9+X+U+3FewNEHJkTmdIvMjQ==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.46':
+    resolution: {integrity: sha512-Vux7UDzBJYQggSuPfcl2w9iu+IJpgpRCxHzgCaVkELnAXAE4XZMOTX9HNcaNiwfeIDqdu2rkr69RuDm6wY8neA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.46':
+    resolution: {integrity: sha512-Ri3em2mBpq3h2zSPliCYl63otDGqek8PPEfv2nWgRQEbZ/VBCNyypVTVQ6cEbTCXBhy+WE2T3fQb08moIyuYaw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@swc/jest@0.2.39':
+    resolution: {integrity: sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
+
+  '@swc/types@0.1.27':
+    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
+
+  '@tailwindcss/typography@0.5.20':
+    resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': 19.2.17
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@tufjs/canonical-json@2.0.0':
+    resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  '@tufjs/models@4.1.0':
+    resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@tybys/wasm-util@0.9.0':
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@30.0.0':
+    resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
+
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/minimist@1.2.5':
+    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/normalize-package-data@2.4.4':
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vitejs/plugin-react@6.0.4':
+    resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
+
+  '@vue/compiler-sfc@3.5.40':
+    resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
+
+  '@vue/compiler-ssr@3.5.40':
+    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
+
+  '@vue/devtools-api@7.7.7':
+    resolution: {integrity: sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg==}
+
+  '@vue/devtools-kit@7.7.7':
+    resolution: {integrity: sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==}
+
+  '@vue/devtools-shared@7.7.7':
+    resolution: {integrity: sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==}
+
+  '@vue/reactivity@3.5.40':
+    resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
+
+  '@vue/runtime-core@3.5.40':
+    resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
+
+  '@vue/runtime-dom@3.5.40':
+    resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
+
+  '@vue/server-renderer@3.5.40':
+    resolution: {integrity: sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==}
+
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+
+  '@vueuse/core@12.8.2':
+    resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
+
+  '@vueuse/integrations@12.8.2':
+    resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
+    peerDependencies:
+      async-validator: ^4
+      axios: 1.18.0
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+
+  '@vueuse/metadata@12.8.2':
+    resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
+
+  '@vueuse/shared@12.8.2':
+    resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  '@yarnpkg/lockfile@1.1.0':
+    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
+
+  '@yuku-codegen/binding-darwin-arm64@0.7.3':
+    resolution: {integrity: sha512-hbssEr7iLNCWWdUbEt8cuOjUQ9loI+U/BVmdhNQ4CV1wAFGvWDO3niK9JD2WwTC9iib7E498qgZ3L/xJnoSb3A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-codegen/binding-darwin-x64@0.7.3':
+    resolution: {integrity: sha512-WqwST3vVcNBTd1zaT1vP6pU8NkjJlLWN37Kqomc2c6TG9eky6sbAfHIhZEjSSyqFrMqsAt3mIu0jQZAODi401g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-codegen/binding-freebsd-x64@0.7.3':
+    resolution: {integrity: sha512-mCci4UPkZXYflXuHnPGl5sDsotBPLaBryFylDwZcqposktmumoOBIKp2gpzEmxQL/XlGdVWksmpYw9IRY43FNQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-codegen/binding-linux-arm-gnu@0.7.3':
+    resolution: {integrity: sha512-F1QIaRH5SeahrYjZVrVvIb5nHCZQMF7+YWAy6yTJh0Y2r2wLgqOQuhbOWcoKk+AyBiTOO2nAsFHNpVqRq2GjGw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm-musl@0.7.3':
+    resolution: {integrity: sha512-JvkWNmN8MFbboX/5grRsAldGaB8ArRFgAaUYfQoohsqcuJZee8SLtc6itvwuntPbN9MGStn4GzdWk2lmSURqbA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-linux-arm64-gnu@0.7.3':
+    resolution: {integrity: sha512-DUnMTE/HCA7j1BAipWclGZCYfLZ/4SV5lldmV2kDmVMIywcw4PhtQ4Rfd/tO1K82JkjhQ+4a8XApcOIksOacnQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm64-musl@0.7.3':
+    resolution: {integrity: sha512-pNnXMnm9dlqd3V8C7nHaXgZnMLwP/CyM8B4mSAnkqVlhj2t3b8CMjesEV85SCbFlagzJk8FapfSghfxcXKuBow==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-linux-x64-gnu@0.7.3':
+    resolution: {integrity: sha512-o5GRppYvYvPl4UJbgRSZpXXDh6rOWQzX0yLB+tDzv31T7mOuLitU6zgQZxzw5rwhPJDffCt/AVKMbtizEo+UtA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-x64-musl@0.7.3':
+    resolution: {integrity: sha512-GdiyLD1bM3lhTUeGkA9ZZLjqU+xt5uVihgPm0e6TdBjCi6DMZORWe02oDlRbn9OZaV7AZosngXAq2jLk3TrBEw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-win32-arm64@0.7.3':
+    resolution: {integrity: sha512-uQrxQDBQFIAUgHJIxcB/FAAUk0Wkyj3xGpHrp/C258nXnCTAH0KDaqyK5RN/TCkVYrpH+uCl+rGnwDLSGnPBkQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-codegen/binding-win32-x64@0.7.3':
+    resolution: {integrity: sha512-UoF7tqMnVMUmIXPgDjFLhRezea6HaypwLDWNenCFxfJCzQNEa41lcHpxq1AN2Xl6GLzIDfAb+lQDi/O+zPCfyg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-parser/binding-darwin-arm64@0.7.3':
+    resolution: {integrity: sha512-JcFQSNEnjtyHQRjXO0G5rQt5xHq5MR+9nHqh+wt5MP30XIiccUYlcMIa3s7CBmj8E8WPGZC08k7LNGrA1OISTA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-parser/binding-darwin-x64@0.7.3':
+    resolution: {integrity: sha512-U0kNeI3VygP/+8sTOLTeLTjUyTYZfl9Wuq6xVKWPXHb2K7oI0sm8JXJ5xlhAbkUDQRi0N6yK5TKxS0sQT5M6UQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-parser/binding-freebsd-x64@0.7.3':
+    resolution: {integrity: sha512-Xc08FQTvxovy6pX+Co9fgv3N1H0OpLpph/ClbwnJkcdphY3kzN2GgIfir35kpPp8mOzlQgtAVQdeDyAYyjwx4w==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-parser/binding-linux-arm-gnu@0.7.3':
+    resolution: {integrity: sha512-6bHeDiUd+0bmoJJ5wZVG+PcJkXQUdjy/AzHsOVcOSUtHtRTX2H3Z5RIHyPAh5OveLtT4RHyqaO3fEQGnHGX5/Q==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm-musl@0.7.3':
+    resolution: {integrity: sha512-trGERNLJGvXkkyvdWBKspTOBATd4lcmpPFPcy5HI5kC3rC3ZMHQDJ356OMSVUsR2NQnl++F0ZTZQucao9hrbeQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.7.3':
+    resolution: {integrity: sha512-p1ELmzhqAX7SFUvH/tR5zSb8NsWZQ8ulw7PqatfXNmJMy34bkivtL0z2jPpVoMJXf5o2+TwBN29Z31CLL0wvkA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm64-musl@0.7.3':
+    resolution: {integrity: sha512-dZ79SrJ002ZXfBDmpQ47SF+06Q5bGOjFeoSK8xO97ter/bjLBgxSO4d7i9hhf+uj4xkrTPc/OFNVaeBAF3L4dA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-x64-gnu@0.7.3':
+    resolution: {integrity: sha512-LjT64hVGWWbOmOYS+Fd8qScgyRxgUbudhFJbw8aeUVnhiNR1np36KnE0VFWrJeu7rTdNxuzVyV5o9JLqhBDTVQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-x64-musl@0.7.3':
+    resolution: {integrity: sha512-5Nw3v5BqYbOi0ZdV+SImgVYa0KDBVAY/ZNPilTsJJU4phqa2cqEW4+aMgyieE/4bqpojt/B931kM+7pipazP9g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-win32-arm64@0.7.3':
+    resolution: {integrity: sha512-lFYXgHiq8tJKa6/e1/q8Su+IJVV4/CjoXbIJ7/GdPXPp9Hx0gh/8HqmGSsrwlY2w8/ohBcar9wxjm1rQ8D16bg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-parser/binding-win32-x64@0.7.3':
+    resolution: {integrity: sha512-wy/fs4OrHBhKW8LDyZJRMyMQ3QOfbSQDp0WtMbtzWCVui/vTQEUJMGnwvRCppjchS/qIQfbWzIw/HSjogJqZFA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-toolchain/types@0.7.3':
+    resolution: {integrity: sha512-ezarjq3dcl8Nx3iJ9VeAc7vhzvHyRoSvr7bLX76T+ljRq73IbZ11X2RFCblfK6YxW2DsjkzU6MPnr3JWDYqYYQ==}
+
+  '@zkochan/js-yaml@0.0.7':
+    resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
+    hasBin: true
+
+  JSONStream@1.3.5:
+    resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
+    hasBin: true
+
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  add-stream@1.0.0:
+    resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
+  ai@7.0.34:
+    resolution: {integrity: sha512-jDqclWYqPGFKcUG4CQiKcBiwi5XqVMqvYy6eJdujVpvE1SDoB6j7RtjrGYz3Bn5B1dzTj1StAlrOebY//WK9/Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  algoliasearch@5.35.0:
+    resolution: {integrity: sha512-Y+moNhsqgLmvJdgTsO4GZNgsaDWv8AOGAaPeIeHKlDn/XunoAqYbA+XNpBd1dW8GOXAUDyxC9Rxc7AV4kpFcIg==}
+    engines: {node: '>= 14.0.0'}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  ansis@4.3.1:
+    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
+    engines: {node: '>=14'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  aproba@2.0.0:
+    resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
+  arrify@1.0.1:
+    resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
+    engines: {node: '>=0.10.0'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  autoprefixer@10.5.4:
+    resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: 8.5.26
+
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
+
+  babel-jest@30.4.1:
+    resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  babel-plugin-istanbul@7.0.1:
+    resolution: {integrity: sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==}
+    engines: {node: '>=12'}
+
+  babel-plugin-jest-hoist@30.4.0:
+    resolution: {integrity: sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
+
+  babel-preset-current-node-syntax@1.2.0:
+    resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  babel-preset-jest@30.4.0:
+    resolution: {integrity: sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@babel/core': 7.29.7
+
+  balanced-match@4.0.3:
+    resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
+    engines: {node: 20 || >=22}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+
+  bin-links@5.0.0:
+    resolution: {integrity: sha512-sdleLVfCjBtgO5cNjA2HVRvWBJAHs4zwenaCPMNJAJU0yNxpzj80IpjOIimkpkr+mhlA+how5poQtt53PygbHA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  birpc@2.9.0:
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.6:
+    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  byte-size@8.1.1:
+    resolution: {integrity: sha512-tUkzZWK0M/qdoLEqikxBWe4kumyuwjl3HO6zHTr4yEI23EojPtLYXdG1+AQY7MN0cGyNDvEaJ8wiYQm6P2bPxg==}
+    engines: {node: '>=12.17'}
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
+
+  cacache@20.0.4:
+    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
+  camelcase-keys@6.2.2:
+    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
+    engines: {node: '>=8'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.0:
+    resolution: {integrity: sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==}
+    engines: {node: '>=10'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  ci-info@4.3.1:
+    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
+    engines: {node: '>=8'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.6.1:
+    resolution: {integrity: sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==}
+    engines: {node: '>=6'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
+  cmd-shim@6.0.3:
+    resolution: {integrity: sha512-FMabTRlc5t5zjdenF6mS0MBeFZm0XqHqeOkcskKFb/LYCcRQ5fVgLOHVc4Lq9CqABd9zhjwPjMBCJvMCziSVtA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  cmd-shim@7.0.0:
+    resolution: {integrity: sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  collect-v8-coverage@1.0.3:
+    resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
+  columnify@1.6.0:
+    resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}
+    engines: {node: '>=8.0.0'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  comment-parser@1.4.7:
+    resolution: {integrity: sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==}
+    engines: {node: '>= 12.0.0'}
+
+  common-ancestor-path@1.0.1:
+    resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
+
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+
+  conventional-changelog-angular@7.0.0:
+    resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
+    engines: {node: '>=16'}
+
+  conventional-changelog-core@5.0.1:
+    resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
+    engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
+
+  conventional-changelog-preset-loader@3.0.0:
+    resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
+    engines: {node: '>=14'}
+
+  conventional-changelog-writer@6.0.1:
+    resolution: {integrity: sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  conventional-commits-filter@3.0.0:
+    resolution: {integrity: sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==}
+    engines: {node: '>=14'}
+
+  conventional-commits-parser@4.0.0:
+    resolution: {integrity: sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  conventional-recommended-bump@7.0.1:
+    resolution: {integrity: sha512-Ft79FF4SlOFvX4PkwFDRnaNiIVX7YbmqGU0RwccUaiGvgp3S0a8ipR2/Qxk31vclDNM+GSdJOVs2KrsUCjblVA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  cosmiconfig@9.0.0:
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dargs@7.0.0:
+    resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
+    engines: {node: '>=8'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  dateformat@3.0.3:
+    resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decamelize-keys@1.1.1:
+    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
+    engines: {node: '>=0.10.0'}
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dedent@1.5.3:
+    resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dexie@4.4.4:
+    resolution: {integrity: sha512-jIwsYI8Os2hgnqc6O49YwFDKGc5v5QjGx0wPVp543ip1F53VFAKMLthV2pQosQcVTv3eAskTWYspOx195PM0FQ==}
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
+
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  dts-resolver@3.0.0:
+    resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
+  ejs@5.0.1:
+    resolution: {integrity: sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==}
+    engines: {node: '>=0.12.18'}
+    hasBin: true
+
+  electron-to-chromium@1.5.389:
+    resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+
+  emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
+
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enquirer@2.3.6:
+    resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
+    engines: {node: '>=8.6'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  envinfo@7.13.0:
+    resolution: {integrity: sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  execa@5.0.0:
+    resolution: {integrity: sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==}
+    engines: {node: '>=10'}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  exit-x@0.2.2:
+    resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
+    engines: {node: '>= 0.8.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  expect@30.4.1:
+    resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+
+  filelist@1.0.6:
+    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@2.1.0:
+    resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
+    engines: {node: '>=4'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
+  focus-trap@7.6.5:
+    resolution: {integrity: sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-extra@11.3.4:
+    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
+
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+
+  get-pkg-repo@4.2.1:
+    resolution: {integrity: sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==}
+    engines: {node: '>=6.9.0'}
+    hasBin: true
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@6.0.0:
+    resolution: {integrity: sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==}
+    engines: {node: '>=10'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
+
+  git-raw-commits@3.0.0:
+    resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
+    engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    hasBin: true
+
+  git-remote-origin-url@2.0.0:
+    resolution: {integrity: sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==}
+    engines: {node: '>=4'}
+
+  git-semver-tags@5.0.1:
+    resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
+    engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    hasBin: true
+
+  git-up@7.0.0:
+    resolution: {integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==}
+
+  git-url-parse@14.0.0:
+    resolution: {integrity: sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==}
+
+  gitconfiglocal@1.0.0:
+    resolution: {integrity: sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
+  hard-rejection@2.1.0:
+    resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
+    engines: {node: '>=6'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  hosted-git-info@4.1.0:
+    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
+    engines: {node: '>=10'}
+
+  hosted-git-info@8.1.0:
+    resolution: {integrity: sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  hosted-git-info@9.0.2:
+    resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore-walk@8.0.0:
+    resolution: {integrity: sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  immer@11.1.15:
+    resolution: {integrity: sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-local@3.1.0:
+    resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  import-without-cache@0.4.0:
+    resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@5.0.0:
+    resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  init-package-json@8.2.2:
+    resolution: {integrity: sha512-pXVMn67Jdw2hPKLCuJZj62NC9B2OIDd1R3JwZXTHXuEnfN3Uq5kJbKOSld6YEU+KOGfMD82EzxFTYz5o0SSJoA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  inquirer@12.9.6:
+    resolution: {integrity: sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
+    engines: {node: '>= 12'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-ci@3.0.1:
+    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
+    hasBin: true
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
+  is-plain-obj@1.1.0:
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
+    engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-ssh@1.4.1:
+    resolution: {integrity: sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-text-path@1.0.1:
+    resolution: {integrity: sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==}
+    engines: {node: '>=0.10.0'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
+  jake@10.9.4:
+    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  jest-changed-files@30.4.1:
+    resolution: {integrity: sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-circus@30.4.2:
+    resolution: {integrity: sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-cli@30.4.2:
+    resolution: {integrity: sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jest-config@30.4.2:
+    resolution: {integrity: sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      esbuild-register: '>=3.4.0'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild-register:
+        optional: true
+      ts-node:
+        optional: true
+
+  jest-diff@30.4.1:
+    resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-docblock@30.4.0:
+    resolution: {integrity: sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-each@30.4.1:
+    resolution: {integrity: sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-environment-jsdom@30.4.1:
+    resolution: {integrity: sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jest-environment-node@30.4.1:
+    resolution: {integrity: sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-haste-map@30.4.1:
+    resolution: {integrity: sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-leak-detector@30.4.1:
+    resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-matcher-utils@30.4.1:
+    resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-message-util@30.4.1:
+    resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-mock@30.4.1:
+    resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-pnp-resolver@1.2.3:
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+
+  jest-regex-util@30.4.0:
+    resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-resolve-dependencies@30.4.2:
+    resolution: {integrity: sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-resolve@30.4.1:
+    resolution: {integrity: sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-runner@30.4.2:
+    resolution: {integrity: sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-runtime@30.4.2:
+    resolution: {integrity: sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-snapshot@30.4.1:
+    resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-util@30.4.1:
+    resolution: {integrity: sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-validate@30.4.1:
+    resolution: {integrity: sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-watcher@30.4.1:
+    resolution: {integrity: sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-worker@30.4.1:
+    resolution: {integrity: sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest@30.4.2:
+    resolution: {integrity: sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+    hasBin: true
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-parse-better-errors@1.0.2:
+    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-parse-even-better-errors@4.0.0:
+    resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  json-parse-even-better-errors@5.0.0:
+    resolution: {integrity: sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stringify-nice@1.1.4:
+    resolution: {integrity: sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsonc-parser@3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
+  just-diff-apply@5.5.0:
+    resolution: {integrity: sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==}
+
+  just-diff@6.0.2:
+    resolution: {integrity: sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==}
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  lerna@9.0.7:
+    resolution: {integrity: sha512-PMjbSWYfwL1yZ5c1D2PZuFyzmtYhLdn0f76uG8L25g6eYy34j+2jPb4Q6USx1UJvxVtxkdVEeAAWS/WxgJ8VZA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    hasBin: true
+
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
+  libnpmaccess@10.0.3:
+    resolution: {integrity: sha512-JPHTfWJxIK+NVPdNMNGnkz4XGX56iijPbe0qFWbdt68HL+kIvSzh+euBL8npLZvl2fpaxo+1eZSdoG15f5YdIQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  libnpmpublish@11.1.2:
+    resolution: {integrity: sha512-tNcU3cLH7toloAzhOOrBDhjzgbxpyuYvkf+BPPnnJCdc5EIcdJ8JcT+SglvCQKKyZ6m9dVXtCVlJcA6csxKdEA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lines-and-columns@2.0.3:
+    resolution: {integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
+  load-json-file@4.0.0:
+    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
+    engines: {node: '>=4'}
+
+  load-json-file@6.2.0:
+    resolution: {integrity: sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==}
+    engines: {node: '>=8'}
+
+  locate-path@2.0.0:
+    resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
+    engines: {node: '>=4'}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  lodash-es@4.18.0:
+    resolution: {integrity: sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA==}
+    deprecated: Bad release. Please use lodash-es@4.17.23 instead.
+
+  lodash.ismatch@4.4.0:
+    resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  make-fetch-happen@15.0.2:
+    resolution: {integrity: sha512-sI1NY4lWlXBAfjmCtVWIIpBypbBdhHtcjnwnv+gtCnsaOffyFil3aidszGC8hgzJe+fT1qix05sWxmD/Bmf/oQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  make-fetch-happen@15.0.6:
+    resolution: {integrity: sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  map-obj@1.0.1:
+    resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
+    engines: {node: '>=0.10.0'}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
+
+  mark.js@8.11.1:
+    resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  meow@8.1.2:
+    resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
+    engines: {node: '>=10'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.4:
+    resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist-options@4.1.0:
+    resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
+    engines: {node: '>= 6'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@4.0.1:
+    resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  minipass-fetch@5.0.2:
+    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minisearch@7.1.2:
+    resolution: {integrity: sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  modify-values@1.0.1:
+    resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
+    engines: {node: '>=0.10.0'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-gyp@12.2.0:
+    resolution: {integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
+  normalize-package-data@3.0.3:
+    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
+    engines: {node: '>=10'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  npm-bundled@4.0.0:
+    resolution: {integrity: sha512-IxaQZDMsqfQ2Lz37VvyyEtKLe8FsRZuysmedy/N06TU1RyVppYKXrO4xIhR0F+7ubIBox6Q7nir6fQI3ej39iA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-bundled@5.0.0:
+    resolution: {integrity: sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-install-checks@7.1.2:
+    resolution: {integrity: sha512-z9HJBCYw9Zr8BqXcllKIs5nI+QggAImbBdHphOzVYrz2CB4iQ6FzWyKmlqDZua+51nAu7FcemlbTc9VgQN5XDQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-install-checks@8.0.0:
+    resolution: {integrity: sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-normalize-package-bin@4.0.0:
+    resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-normalize-package-bin@5.0.0:
+    resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-package-arg@12.0.2:
+    resolution: {integrity: sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-package-arg@13.0.1:
+    resolution: {integrity: sha512-6zqls5xFvJbgFjB1B2U6yITtyGBjDBORB7suI4zA4T/sZ1OmkMFlaQSNB/4K0LtXNA1t4OprAFxPisadK5O2ag==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-packlist@10.0.3:
+    resolution: {integrity: sha512-zPukTwJMOu5X5uvm0fztwS5Zxyvmk38H/LfidkOMt3gbZVCyro2cD/ETzwzVPcWZA3JOyPznfUN/nkyFiyUbxg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-pick-manifest@10.0.0:
+    resolution: {integrity: sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-pick-manifest@11.0.3:
+    resolution: {integrity: sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-registry-fetch@19.1.0:
+    resolution: {integrity: sha512-xyZLfs7TxPu/WKjHUs0jZOPinzBAI32kEUel6za0vH+JUTnFZ5zbHI1ZoGZRDm6oMjADtrli6FxtMlk/5ABPNw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  nx@22.7.7:
+    resolution: {integrity: sha512-T4hq5PMAPXeqAmm0Y6Gr5ApeI2I+T8MflWEKN1cZ12R1Rnq2uEpfOgiwAZ74bHONmNgv6LRG9P9+x8SX2tDIlw==}
+    hasBin: true
+    peerDependencies:
+      '@swc-node/register': ^1.11.1
+      '@swc/core': ^1.15.8
+    peerDependenciesMeta:
+      '@swc-node/register':
+        optional: true
+      '@swc/core':
+        optional: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@3.1.1:
+    resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+
+  ora@5.3.0:
+    resolution: {integrity: sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==}
+    engines: {node: '>=10'}
+
+  ora@9.4.1:
+    resolution: {integrity: sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==}
+    engines: {node: '>=20'}
+
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
+  p-limit@1.3.0:
+    resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
+    engines: {node: '>=4'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@2.0.0:
+    resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
+    engines: {node: '>=4'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-map-series@2.1.0:
+    resolution: {integrity: sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q==}
+    engines: {node: '>=8'}
+
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+
+  p-map@7.0.4:
+    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+    engines: {node: '>=18'}
+
+  p-pipe@3.1.0:
+    resolution: {integrity: sha512-08pj8ATpzMR0Y80x50yJHn37NF6vjrqHutASaX5LiH5npS9XPvrUmscd9MF5R4fuYRHOxQR1FfMIlF7AzwoPqw==}
+    engines: {node: '>=8'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-reduce@2.1.0:
+    resolution: {integrity: sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
+  p-try@1.0.0:
+    resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
+    engines: {node: '>=4'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  p-waterfall@2.1.1:
+    resolution: {integrity: sha512-RRTnDb2TBG/epPRI2yYXsimO0v3BXC8Yd3ogr1545IaqKK17VGhbWVeGGN+XfCm/08OK8635nH31c8bATkHuSw==}
+    engines: {node: '>=8'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  pacote@21.0.1:
+    resolution: {integrity: sha512-LHGIUQUrcDIJUej53KJz1BPvUuHrItrR2yrnN0Kl9657cJ0ZT6QJHk9wWPBnQZhYT5KLyZWrk9jaYc2aKDu4yw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  pacote@21.5.0:
+    resolution: {integrity: sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-conflict-json@4.0.0:
+    resolution: {integrity: sha512-37CN2VtcuvKgHUs8+0b1uJeEsbGn61GRHz469C94P5xiOoqpDYJYwjg4RY9Vmz39WyZAVkR5++nbJwLMIgOCnQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  parse-json@4.0.0:
+    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
+    engines: {node: '>=4'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  parse-path@7.1.0:
+    resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
+
+  parse-url@8.1.0:
+    resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
+  path-exists@3.0.0:
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
+    engines: {node: '>=4'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  path-type@3.0.0:
+    resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
+    engines: {node: '>=4'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pify@3.0.0:
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
+    engines: {node: '>=4'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: 8.5.26
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: 8.5.26
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: 8.5.26
+      tsx: ^4.8.1
+      yaml: 2.9.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: 8.5.26
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
+  postcss-selector-parser@6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
+
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
+  preact@10.27.3:
+    resolution: {integrity: sha512-ZieIP3zQHiQsNF3BA+SNVS8dcuRIg/nsxlkFbCMBLS2L1Ww4Bkxd9n6Md2A1crfTZsEbQPADV0neYmh/EElgeQ==}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pretty-format@30.4.1:
+    resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  proc-log@5.0.0:
+    resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  proggy@3.0.0:
+    resolution: {integrity: sha512-QE8RApCM3IaRRxVzxrjbgNMpQEX6Wu0p0KBeoSiSEw5/bsGwZHsshF4LCxH2jp/r6BU+bqA3LrMDEYNfJnpD8Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  promise-all-reject-late@1.0.1:
+    resolution: {integrity: sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==}
+
+  promise-call-limit@3.0.2:
+    resolution: {integrity: sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==}
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+
+  promzard@2.0.0:
+    resolution: {integrity: sha512-Ncd0vyS2eXGOjchIRg6PVCYKetJYrW1BSbbIo+bKdig61TB6nH2RQNF2uP+qMpsI73L/jURLWojcw8JNIKZ3gg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protocols@2.0.2:
+    resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  pure-rand@7.0.1:
+    resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  quansync@1.0.0:
+    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@4.0.1:
+    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
+    engines: {node: '>=8'}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
+
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  read-cmd-shim@4.0.0:
+    resolution: {integrity: sha512-yILWifhaSEEytfXI76kB9xEEiG1AiozaCJZ83A87ytjRiN+jVibXjedjCRNjoZviinhG+4UkalO3mWTd8u5O0Q==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  read-cmd-shim@5.0.0:
+    resolution: {integrity: sha512-SEbJV7tohp3DAAILbEMPXavBjAnMN0tVnh4+9G8ihV4Pq3HYF9h8QNez9zkJ1ILkv9G2BjdzwctznGZXgu/HGw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  read-pkg-up@3.0.0:
+    resolution: {integrity: sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==}
+    engines: {node: '>=4'}
+
+  read-pkg-up@7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
+
+  read-pkg@3.0.0:
+    resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
+    engines: {node: '>=4'}
+
+  read-pkg@5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
+
+  read@4.1.0:
+    resolution: {integrity: sha512-uRfX6K+f+R8OOrYScaM3ixPY4erg69f8DN6pgTvMcA9iRc8iDhwrA4m3Yu8YYKsXJgVvum+m8PkRboZwwuLzYA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  redis@5.12.1:
+    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
+    engines: {node: '>= 18.19.0'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
+
+  resolve@1.22.11:
+    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
+  rolldown-plugin-dts@0.27.12:
+    resolution: {integrity: sha512-DJg5ELVEdLAVhirvtak7GS4nbNvBzLNAtYL1M8hLghDURBFKU2MwEH6ncHibYs6khq1NaRQ97iFMiHvzw+WoSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@typescript/native-preview': '*'
+      '@volar/typescript': ~2.4.0
+      rolldown: ^1.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ~7.0.0
+      vue-tsc: ~3.2.0 || ~3.3.0
+    peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
+      '@volar/typescript':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
+  rolldown@1.0.0-rc.11:
+    resolution: {integrity: sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.2.0:
+    resolution: {integrity: sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup-plugin-visualizer@7.0.1:
+    resolution: {integrity: sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==}
+    engines: {node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      rolldown: 1.x || ^1.0.0-beta || ^1.0.0-rc
+      rollup: 4.59.0
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
+  run-async@4.0.6:
+    resolution: {integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==}
+    engines: {node: '>=0.12.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  search-insights@2.17.3:
+    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  shiki@2.5.0:
+    resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
+
+  shiki@4.3.1:
+    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
+    engines: {node: '>=20'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  sigstore@4.1.1:
+    resolution: {integrity: sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  speakingurl@14.0.1:
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
+    engines: {node: '>=0.10.0'}
+
+  split2@3.2.2:
+    resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  split@1.0.1:
+    resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  ssri@12.0.0:
+    resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  ssri@13.0.1:
+    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
+    engines: {node: '>=18'}
+
+  string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  stylis@4.3.6:
+    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  superjson@2.2.2:
+    resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
+    engines: {node: '>=16'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  synckit@0.11.12:
+    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
+  tabbable@6.2.0:
+    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
+    engines: {node: '>=18'}
+
+  terser@5.43.1:
+    resolution: {integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
+  text-extensions@1.9.0:
+    resolution: {integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==}
+    engines: {node: '>=0.10'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  through2@2.0.5:
+    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.12:
+    resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
+
+  tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  treeverse@3.0.0:
+    resolution: {integrity: sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trim-newlines@3.0.1:
+    resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
+    engines: {node: '>=8'}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
+
+  tsdown@0.22.13:
+    resolution: {integrity: sha512-XaYFhtiKRUvTpXv/YAehsHdbEb3LN/iMlzjSINbjlaATtXN2zVPKox2STKhcyFPlh++8Zg7suNN27E679IfAUA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.22.13
+      '@tsdown/exe': 0.22.13
+      '@vitejs/devtools': '*'
+      publint: ^0.3.8
+      tsx: '*'
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
+      unplugin-unused: ^0.5.0
+      unrun: '*'
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      unrun:
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tuf-js@4.1.0:
+    resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-fest@0.18.1:
+    resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
+    engines: {node: '>=10'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+
+  type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typedoc-plugin-markdown@4.12.0:
+    resolution: {integrity: sha512-eJDEMAfxCmede22c/Jw7d0FA13ggAQv+KkwQYKYCdqI02cin6Rc9QRwbG/7XvvHWinuFejySnZVUWDtvGk3Vbg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      typedoc: 0.28.x
+
+  typedoc@0.28.20:
+    resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
+  unconfig-core@7.5.0:
+    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  unrs-resolver@1.11.1:
+    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  unrun@0.2.33:
+    resolution: {integrity: sha512-urXTjZHOHS6lMnatQerLcBpcTsaKZYGuu9aSZ+HlNfCApkiINRbj7YecC9h9hdZroMT4WQ4KVyzHfBqHKuFX9Q==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
+
+  upath@2.0.1:
+    resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
+    engines: {node: '>=4'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validate-npm-package-name@6.0.2:
+    resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  verkit@0.1.2:
+    resolution: {integrity: sha512-WqkT8n3hqizuCu71W3bUzf5fjBmkbXcudsehe/NbxA8PgqoKnSOY5K0Ba2ckg1qaRaSpSz7as/n9K1R9JXjQKg==}
+    engines: {node: '>=18.12.0'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-bundle-analyzer@1.3.9:
+    resolution: {integrity: sha512-hhy975B+ToseJaSJp3mURHriZUrMgaM2qx0BkP62kN6Yp46rw7EE3dl8ExFWYdn00OIwe7GbsA5PknvstNWG4Q==}
+    hasBin: true
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: 2.9.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: 0.28.1
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: 2.9.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: 0.28.1
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: 2.9.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitepress@1.6.4:
+    resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
+    hasBin: true
+    peerDependencies:
+      markdown-it-mathjax3: ^4
+      postcss: 8.5.26
+    peerDependenciesMeta:
+      markdown-it-mathjax3:
+        optional: true
+      postcss:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: 8.0.16
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vue@3.5.40:
+    resolution: {integrity: sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
+  walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  write-file-atomic@6.0.0:
+    resolution: {integrity: sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+  yuku-ast@0.7.3:
+    resolution: {integrity: sha512-occyAXtcU4hcl5UPEclWwLqz4J1ZAV8Us4LllmTqAe1YjL5aMbh3GCpzHt6O0sOF+dwBI3BZAcFQqbyX1RiaWg==}
+
+  yuku-codegen@0.7.3:
+    resolution: {integrity: sha512-hhyJW0TIEwm4kex8XVCS4CZIXHS/3TWWNUum+95Ji5/4W+iaLfUnvwSxJwyNfTzS8cxmd1np+EZ4b8ObLguKEA==}
+
+  yuku-parser@0.7.3:
+    resolution: {integrity: sha512-5kZ7HR+W+OsNpVtZ9LHruQsgmcoJl4TETrffPq2GbliThsFiy+zHzbMLmSxQJrokzyJqfJ/TPfFkdUDOodJCgA==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@ai-sdk/gateway@4.0.26(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@3.0.14(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.12(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@algolia/abtesting@1.1.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+      - search-insights
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)
+      search-insights: 2.17.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+
+  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)
+      '@algolia/client-search': 5.35.0
+      algoliasearch: 5.35.0
+
+  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)':
+    dependencies:
+      '@algolia/client-search': 5.35.0
+      algoliasearch: 5.35.0
+
+  '@algolia/client-abtesting@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/client-analytics@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/client-common@5.35.0': {}
+
+  '@algolia/client-insights@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/client-personalization@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/client-query-suggestions@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/client-search@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/ingestion@1.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/monitoring@1.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/recommend@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  '@algolia/requester-browser-xhr@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+
+  '@algolia/requester-fetch@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+
+  '@algolia/requester-node-http@5.35.0':
+    dependencies:
+      '@algolia/client-common': 5.35.0
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.2.4
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@7.2.0)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.6
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@0.2.3': {}
+
+  '@biomejs/biome@2.5.5':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.5.5
+      '@biomejs/cli-darwin-x64': 2.5.5
+      '@biomejs/cli-linux-arm64': 2.5.5
+      '@biomejs/cli-linux-arm64-musl': 2.5.5
+      '@biomejs/cli-linux-x64': 2.5.5
+      '@biomejs/cli-linux-x64-musl': 2.5.5
+      '@biomejs/cli-win32-arm64': 2.5.5
+      '@biomejs/cli-win32-x64': 2.5.5
+
+  '@biomejs/cli-darwin-arm64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.5.5':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.5.5':
+    optional: true
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@docsearch/css@3.8.2': {}
+
+  '@docsearch/js@3.8.2(@algolia/client-search@5.35.0)(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
+    dependencies:
+      '@docsearch/react': 3.8.2(@algolia/client-search@5.35.0)(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
+      preact: 10.27.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/react'
+      - react
+      - react-dom
+      - search-insights
+
+  '@docsearch/react@3.8.2(@algolia/client-search@5.35.0)(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.35.0)(algoliasearch@5.35.0)
+      '@docsearch/css': 3.8.2
+      algoliasearch: 5.35.0
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      search-insights: 2.17.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+
+  '@emnapi/core@1.4.5':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.4
+      tslib: 2.8.1
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@emnapi/runtime@1.4.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@emnapi/wasi-threads@1.0.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@gar/promise-retry@1.0.3': {}
+
+  '@gerrit0/mini-shiki@3.23.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@hutson/parse-repository-url@3.0.2': {}
+
+  '@iconify-json/simple-icons@1.2.49':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.0':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      mlly: 1.8.2
+
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/confirm@5.1.21(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/core@10.3.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/editor@4.2.23(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/expand@4.0.23(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/external-editor@1.0.3(@types/node@24.13.3)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/number@3.0.23(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/password@4.0.23(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/prompts@7.10.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.13.3)
+      '@inquirer/confirm': 5.1.21(@types/node@24.13.3)
+      '@inquirer/editor': 4.2.23(@types/node@24.13.3)
+      '@inquirer/expand': 4.0.23(@types/node@24.13.3)
+      '@inquirer/input': 4.3.1(@types/node@24.13.3)
+      '@inquirer/number': 3.0.23(@types/node@24.13.3)
+      '@inquirer/password': 4.0.23(@types/node@24.13.3)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.13.3)
+      '@inquirer/search': 3.2.2(@types/node@24.13.3)
+      '@inquirer/select': 4.4.2(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/rawlist@4.1.11(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/search@3.2.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/select@4.4.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/type@3.0.10(@types/node@24.13.3)':
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/cliui@9.0.0': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
+  '@isaacs/string-locale-compare@1.1.0': {}
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.15.1
+      resolve-from: 5.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
+  '@jest/console@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      chalk: 4.1.2
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      slash: 3.0.0
+
+  '@jest/core@30.4.2':
+    dependencies:
+      '@jest/console': 30.4.1
+      '@jest/pattern': 30.4.0
+      '@jest/reporters': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.4.1
+      jest-config: 30.4.2(@types/node@24.13.3)
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-resolve-dependencies: 30.4.2
+      jest-runner: 30.4.2
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      jest-watcher: 30.4.1
+      pretty-format: 30.4.1
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/create-cache-key-function@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+
+  '@jest/diff-sequences@30.0.1': {}
+
+  '@jest/diff-sequences@30.4.0': {}
+
+  '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/jsdom': 21.1.7
+      '@types/node': 24.13.3
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+      jsdom: 26.1.0
+
+  '@jest/environment@30.4.1':
+    dependencies:
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      jest-mock: 30.4.1
+
+  '@jest/expect-utils@30.4.1':
+    dependencies:
+      '@jest/get-type': 30.1.0
+
+  '@jest/expect@30.4.1':
+    dependencies:
+      expect: 30.4.1
+      jest-snapshot: 30.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/fake-timers@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+      '@sinonjs/fake-timers': 15.4.0
+      '@types/node': 24.13.3
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+
+  '@jest/get-type@30.1.0': {}
+
+  '@jest/globals@30.4.1':
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/types': 30.4.1
+      jest-mock: 30.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/pattern@30.4.0':
+    dependencies:
+      '@types/node': 24.13.3
+      jest-regex-util: 30.4.0
+
+  '@jest/reporters@30.4.1':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 24.13.3
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.3
+      exit-x: 0.2.2
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
+      slash: 3.0.0
+      string-length: 4.0.2
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/schemas@30.4.1':
+    dependencies:
+      '@sinclair/typebox': 0.34.40
+
+  '@jest/snapshot-utils@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      natural-compare: 1.4.0
+
+  '@jest/source-map@30.0.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  '@jest/test-result@30.4.1':
+    dependencies:
+      '@jest/console': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
+
+  '@jest/test-sequencer@30.4.1':
+    dependencies:
+      '@jest/test-result': 30.4.1
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.4.1
+      slash: 3.0.0
+
+  '@jest/transform@30.4.1':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/types': 30.4.1
+      '@jridgewell/trace-mapping': 0.3.31
+      babel-plugin-istanbul: 7.0.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
+      pirates: 4.0.7
+      slash: 3.0.0
+      write-file-atomic: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/types@30.4.1':
+    dependencies:
+      '@jest/pattern': 30.4.0
+      '@jest/schemas': 30.4.1
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 24.13.3
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@0.2.4':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.9.0
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@npmcli/agent@4.0.0':
+    dependencies:
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 11.2.7
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@npmcli/arborist@9.1.6':
+    dependencies:
+      '@isaacs/string-locale-compare': 1.1.0
+      '@npmcli/fs': 4.0.0
+      '@npmcli/installed-package-contents': 3.0.0
+      '@npmcli/map-workspaces': 5.0.3
+      '@npmcli/metavuln-calculator': 9.0.3
+      '@npmcli/name-from-folder': 3.0.0
+      '@npmcli/node-gyp': 4.0.0
+      '@npmcli/package-json': 7.0.2
+      '@npmcli/query': 4.0.1
+      '@npmcli/redact': 3.2.2
+      '@npmcli/run-script': 10.0.3
+      bin-links: 5.0.0
+      cacache: 20.0.4
+      common-ancestor-path: 1.0.1
+      hosted-git-info: 9.0.2
+      json-stringify-nice: 1.1.4
+      lru-cache: 11.2.7
+      minimatch: 10.2.5
+      nopt: 8.1.0
+      npm-install-checks: 7.1.2
+      npm-package-arg: 13.0.1
+      npm-pick-manifest: 11.0.3
+      npm-registry-fetch: 19.1.0
+      pacote: 21.5.0
+      parse-conflict-json: 4.0.0
+      proc-log: 5.0.0
+      proggy: 3.0.0
+      promise-all-reject-late: 1.0.1
+      promise-call-limit: 3.0.2
+      semver: 7.8.5
+      ssri: 12.0.0
+      treeverse: 3.0.0
+      walk-up-path: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@npmcli/fs@4.0.0':
+    dependencies:
+      semver: 7.8.5
+
+  '@npmcli/fs@5.0.0':
+    dependencies:
+      semver: 7.8.5
+
+  '@npmcli/git@6.0.3':
+    dependencies:
+      '@npmcli/promise-spawn': 8.0.3
+      ini: 5.0.0
+      lru-cache: 10.4.3
+      npm-pick-manifest: 10.0.0
+      proc-log: 5.0.0
+      promise-retry: 2.0.1
+      semver: 7.8.5
+      which: 5.0.0
+
+  '@npmcli/git@7.0.2':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/promise-spawn': 9.0.1
+      ini: 6.0.0
+      lru-cache: 11.2.7
+      npm-pick-manifest: 11.0.3
+      proc-log: 6.1.0
+      semver: 7.8.5
+      which: 6.0.1
+
+  '@npmcli/installed-package-contents@3.0.0':
+    dependencies:
+      npm-bundled: 4.0.0
+      npm-normalize-package-bin: 4.0.0
+
+  '@npmcli/installed-package-contents@4.0.0':
+    dependencies:
+      npm-bundled: 5.0.0
+      npm-normalize-package-bin: 5.0.0
+
+  '@npmcli/map-workspaces@5.0.3':
+    dependencies:
+      '@npmcli/name-from-folder': 4.0.0
+      '@npmcli/package-json': 7.0.2
+      glob: 13.0.6
+      minimatch: 10.2.5
+
+  '@npmcli/metavuln-calculator@9.0.3':
+    dependencies:
+      cacache: 20.0.4
+      json-parse-even-better-errors: 5.0.0
+      pacote: 21.5.0
+      proc-log: 6.1.0
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@npmcli/name-from-folder@3.0.0': {}
+
+  '@npmcli/name-from-folder@4.0.0': {}
+
+  '@npmcli/node-gyp@4.0.0': {}
+
+  '@npmcli/node-gyp@5.0.0': {}
+
+  '@npmcli/package-json@7.0.2':
+    dependencies:
+      '@npmcli/git': 7.0.2
+      glob: 11.1.0
+      hosted-git-info: 9.0.2
+      json-parse-even-better-errors: 5.0.0
+      proc-log: 6.1.0
+      semver: 7.8.5
+      validate-npm-package-license: 3.0.4
+
+  '@npmcli/promise-spawn@8.0.3':
+    dependencies:
+      which: 5.0.0
+
+  '@npmcli/promise-spawn@9.0.1':
+    dependencies:
+      which: 6.0.1
+
+  '@npmcli/query@4.0.1':
+    dependencies:
+      postcss-selector-parser: 7.1.1
+
+  '@npmcli/redact@3.2.2': {}
+
+  '@npmcli/redact@4.0.0': {}
+
+  '@npmcli/run-script@10.0.3':
+    dependencies:
+      '@npmcli/node-gyp': 5.0.0
+      '@npmcli/package-json': 7.0.2
+      '@npmcli/promise-spawn': 9.0.1
+      node-gyp: 12.2.0
+      proc-log: 6.1.0
+      which: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nx/devkit@22.6.2(nx@22.7.7(@swc/core@1.15.46(@swc/helpers@0.5.23)))':
+    dependencies:
+      '@zkochan/js-yaml': 0.0.7
+      ejs: 3.1.10
+      enquirer: 2.3.6
+      minimatch: 10.2.4
+      nx: 22.7.7(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      semver: 7.8.5
+      tslib: 2.8.1
+      yargs-parser: 21.1.1
+
+  '@nx/nx-darwin-arm64@22.7.7':
+    optional: true
+
+  '@nx/nx-darwin-x64@22.7.7':
+    optional: true
+
+  '@nx/nx-freebsd-x64@22.7.7':
+    optional: true
+
+  '@nx/nx-linux-arm-gnueabihf@22.7.7':
+    optional: true
+
+  '@nx/nx-linux-arm64-gnu@22.7.7':
+    optional: true
+
+  '@nx/nx-linux-arm64-musl@22.7.7':
+    optional: true
+
+  '@nx/nx-linux-x64-gnu@22.7.7':
+    optional: true
+
+  '@nx/nx-linux-x64-musl@22.7.7':
+    optional: true
+
+  '@nx/nx-win32-arm64-msvc@22.7.7':
+    optional: true
+
+  '@nx/nx-win32-x64-msvc@22.7.7':
+    optional: true
+
+  '@octokit/auth-token@4.0.0': {}
+
+  '@octokit/core@5.2.2':
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.1
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+
+  '@octokit/endpoint@9.0.6':
+    dependencies:
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/graphql@7.1.1':
+    dependencies:
+      '@octokit/request': 8.4.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/openapi-types@24.2.0': {}
+
+  '@octokit/plugin-enterprise-rest@6.0.1': {}
+
+  '@octokit/plugin-paginate-rest@11.4.4-cjs.2(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 13.10.0
+
+  '@octokit/plugin-request-log@4.0.1(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+
+  '@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 13.10.0
+
+  '@octokit/request-error@5.1.1':
+    dependencies:
+      '@octokit/types': 13.10.0
+      deprecation: 2.3.1
+      once: 1.4.0
+
+  '@octokit/request@8.4.1':
+    dependencies:
+      '@octokit/endpoint': 9.0.6
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/rest@20.1.2':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/plugin-paginate-rest': 11.4.4-cjs.2(@octokit/core@5.2.2)
+      '@octokit/plugin-request-log': 4.0.1(@octokit/core@5.2.2)
+      '@octokit/plugin-rest-endpoint-methods': 13.3.2-cjs.1(@octokit/core@5.2.2)
+
+  '@octokit/types@13.10.0':
+    dependencies:
+      '@octokit/openapi-types': 24.2.0
+
+  '@opentelemetry/api@1.9.0':
+    optional: true
+
+  '@oxc-project/types@0.122.0':
+    optional: true
+
+  '@oxc-project/types@0.133.0': {}
+
+  '@oxc-project/types@0.139.0': {}
+
+  '@oxc-project/types@0.140.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@pkgr/core@0.2.9': {}
+
+  '@quansync/fs@1.0.0':
+    dependencies:
+      quansync: 1.0.0
+
+  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
+
+  '@redis/client@5.12.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
+
+  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
+
+  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.0':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.0':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.0':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.0':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.11(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
+    optional: true
+
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      picomatch: 4.0.5
+      rolldown: 1.2.0
+    optionalDependencies:
+      '@babel/runtime': 7.29.2
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0)
+
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      picomatch: 4.0.5
+      rolldown: 1.2.0
+    optionalDependencies:
+      '@babel/runtime': 7.29.2
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0)
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@shikijs/core@2.5.0':
+    dependencies:
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/core@4.3.1':
+    dependencies:
+      '@shikijs/primitive': 4.3.1
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 3.1.1
+
+  '@shikijs/engine-javascript@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/engine-oniguruma@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/langs@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+
+  '@shikijs/primitive@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+
+  '@shikijs/transformers@2.5.0':
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/types@2.5.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@4.3.1':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sigstore/bundle@4.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.0
+
+  '@sigstore/core@3.2.1': {}
+
+  '@sigstore/protobuf-specs@0.5.0': {}
+
+  '@sigstore/sign@4.1.1':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.0
+      make-fetch-happen: 15.0.6
+      proc-log: 6.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/tuf@4.0.2':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.0
+      tuf-js: 4.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/verify@3.1.1':
+    dependencies:
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.0
+
+  '@sinclair/typebox@0.34.40': {}
+
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@15.4.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@swc/core-darwin-arm64@1.15.46':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.46':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.46':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.46':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.46':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.46':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.46':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.46':
+    optional: true
+
+  '@swc/core@1.15.46(@swc/helpers@0.5.23)':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.27
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.46
+      '@swc/core-darwin-x64': 1.15.46
+      '@swc/core-linux-arm-gnueabihf': 1.15.46
+      '@swc/core-linux-arm64-gnu': 1.15.46
+      '@swc/core-linux-arm64-musl': 1.15.46
+      '@swc/core-linux-ppc64-gnu': 1.15.46
+      '@swc/core-linux-s390x-gnu': 1.15.46
+      '@swc/core-linux-x64-gnu': 1.15.46
+      '@swc/core-linux-x64-musl': 1.15.46
+      '@swc/core-win32-arm64-msvc': 1.15.46
+      '@swc/core-win32-ia32-msvc': 1.15.46
+      '@swc/core-win32-x64-msvc': 1.15.46
+      '@swc/helpers': 0.5.23
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
+  '@swc/jest@0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))':
+    dependencies:
+      '@jest/create-cache-key-function': 30.4.1
+      '@swc/core': 1.15.46(@swc/helpers@0.5.23)
+      '@swc/counter': 0.1.3
+      jsonc-parser: 3.2.0
+
+  '@swc/types@0.1.27':
+    dependencies:
+      '@swc/counter': 0.1.3
+
+  '@tailwindcss/typography@0.5.20(tailwindcss@4.3.2)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.3.2
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@tufjs/canonical-json@2.0.0': {}
+
+  '@tufjs/models@4.1.0':
+    dependencies:
+      '@tufjs/canonical-json': 2.0.0
+      minimatch: 10.2.5
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.9.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@30.0.0':
+    dependencies:
+      expect: 30.4.1
+      pretty-format: 30.4.1
+
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
+
+  '@types/minimist@1.2.5': {}
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/normalize-package-data@2.4.4': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/stack-utils@2.0.3': {}
+
+  '@types/tough-cookie@4.0.5': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@types/unist@3.0.3': {}
+
+  '@types/web-bluetooth@0.0.21': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
+  '@ungap/structured-clone@1.3.0': {}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    optional: true
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vitejs/plugin-react@6.0.4(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0))
+      babel-plugin-react-compiler: 1.0.0
+
+  '@vitejs/plugin-react@6.0.4(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0))
+      babel-plugin-react-compiler: 1.0.0
+
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.3(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
+    dependencies:
+      vite: 6.4.3(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(yaml@2.9.0)
+      vue: 3.5.40(typescript@6.0.3)
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vue/compiler-core@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.40
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.40':
+    dependencies:
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/compiler-sfc@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.40
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/shared': 3.5.40
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.26
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.40':
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/devtools-api@7.7.7':
+    dependencies:
+      '@vue/devtools-kit': 7.7.7
+
+  '@vue/devtools-kit@7.7.7':
+    dependencies:
+      '@vue/devtools-shared': 7.7.7
+      birpc: 2.9.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.2
+
+  '@vue/devtools-shared@7.7.7':
+    dependencies:
+      rfdc: 1.4.1
+
+  '@vue/reactivity@3.5.40':
+    dependencies:
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-core@3.5.40':
+    dependencies:
+      '@vue/reactivity': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-dom@3.5.40':
+    dependencies:
+      '@vue/reactivity': 3.5.40
+      '@vue/runtime-core': 3.5.40
+      '@vue/shared': 3.5.40
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.40':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/shared@3.5.40': {}
+
+  '@vueuse/core@12.8.2(typescript@6.0.3)':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 12.8.2
+      '@vueuse/shared': 12.8.2(typescript@6.0.3)
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/integrations@12.8.2(axios@1.18.0)(focus-trap@7.6.5)(typescript@6.0.3)':
+    dependencies:
+      '@vueuse/core': 12.8.2(typescript@6.0.3)
+      '@vueuse/shared': 12.8.2(typescript@6.0.3)
+      vue: 3.5.40(typescript@6.0.3)
+    optionalDependencies:
+      axios: 1.18.0(supports-color@7.2.0)
+      focus-trap: 7.6.5
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/shared@12.8.2(typescript@6.0.3)':
+    dependencies:
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@workflow/serde@4.1.0': {}
+
+  '@yarnpkg/lockfile@1.1.0': {}
+
+  '@yuku-codegen/binding-darwin-arm64@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-darwin-x64@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-freebsd-x64@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm-gnu@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm-musl@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm64-gnu@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm64-musl@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-x64-gnu@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-linux-x64-musl@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-win32-arm64@0.7.3':
+    optional: true
+
+  '@yuku-codegen/binding-win32-x64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-darwin-arm64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-darwin-x64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-freebsd-x64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-gnu@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-musl@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-musl@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-gnu@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-musl@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-win32-arm64@0.7.3':
+    optional: true
+
+  '@yuku-parser/binding-win32-x64@0.7.3':
+    optional: true
+
+  '@yuku-toolchain/types@0.7.3': {}
+
+  '@zkochan/js-yaml@0.0.7':
+    dependencies:
+      argparse: 2.0.1
+
+  JSONStream@1.3.5:
+    dependencies:
+      jsonparse: 1.3.1
+      through: 2.3.8
+
+  abbrev@3.0.1: {}
+
+  abbrev@4.0.0: {}
+
+  acorn@8.16.0: {}
+
+  add-stream@1.0.0: {}
+
+  agent-base@6.0.2(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  agent-base@7.1.4: {}
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+
+  ai@7.0.34(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.26(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      zod: 4.4.3
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  algoliasearch@5.35.0:
+    dependencies:
+      '@algolia/abtesting': 1.1.0
+      '@algolia/client-abtesting': 5.35.0
+      '@algolia/client-analytics': 5.35.0
+      '@algolia/client-common': 5.35.0
+      '@algolia/client-insights': 5.35.0
+      '@algolia/client-personalization': 5.35.0
+      '@algolia/client-query-suggestions': 5.35.0
+      '@algolia/client-search': 5.35.0
+      '@algolia/ingestion': 1.35.0
+      '@algolia/monitoring': 1.35.0
+      '@algolia/recommend': 5.35.0
+      '@algolia/requester-browser-xhr': 5.35.0
+      '@algolia/requester-fetch': 5.35.0
+      '@algolia/requester-node-http': 5.35.0
+
+  ansi-colors@4.1.3: {}
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
+
+  ansis@4.3.1: {}
+
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  aproba@2.0.0: {}
+
+  arg@5.0.2: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  array-ify@1.0.0: {}
+
+  arrify@1.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  async@3.2.6: {}
+
+  asynckit@0.4.0: {}
+
+  autoprefixer@10.5.4(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.6
+      caniuse-lite: 1.0.30001806
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  axios@1.18.0(supports-color@7.2.0):
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  babel-jest@30.4.1(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/transform': 30.4.1
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 7.0.1
+      babel-preset-jest: 30.4.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-istanbul@7.0.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 6.0.3
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-jest-hoist@30.4.0:
+    dependencies:
+      '@types/babel__core': 7.20.5
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.7
+
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
+
+  babel-preset-jest@30.4.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      babel-plugin-jest-hoist: 30.4.0
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+
+  balanced-match@4.0.3: {}
+
+  balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.10.43: {}
+
+  before-after-hook@2.2.3: {}
+
+  bin-links@5.0.0:
+    dependencies:
+      cmd-shim: 7.0.0
+      npm-normalize-package-bin: 4.0.0
+      proc-log: 5.0.0
+      read-cmd-shim: 5.0.0
+      write-file-atomic: 6.0.0
+
+  binary-extensions@2.3.0: {}
+
+  birpc@2.9.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.6:
+    dependencies:
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.389
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.6)
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
+  buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  byte-size@8.1.1: {}
+
+  cac@7.0.0: {}
+
+  cacache@20.0.4:
+    dependencies:
+      '@npmcli/fs': 5.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 11.2.7
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.4
+      ssri: 13.0.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  callsites@3.1.0: {}
+
+  camelcase-css@2.0.1: {}
+
+  camelcase-keys@6.2.2:
+    dependencies:
+      camelcase: 5.3.1
+      map-obj: 4.3.0
+      quick-lru: 4.0.1
+
+  camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001806: {}
+
+  ccount@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  chalk@4.1.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  chardet@2.1.1: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chownr@3.0.0: {}
+
+  ci-info@3.9.0: {}
+
+  ci-info@4.3.1: {}
+
+  ci-info@4.4.0: {}
+
+  cjs-module-lexer@2.2.0: {}
+
+  clean-stack@2.2.0: {}
+
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.6.1: {}
+
+  cli-spinners@3.4.0: {}
+
+  cli-width@4.1.0: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
+  clone@1.0.4: {}
+
+  clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.2: {}
+
+  cmd-shim@6.0.3: {}
+
+  cmd-shim@7.0.0: {}
+
+  co@4.6.0: {}
+
+  collect-v8-coverage@1.0.3: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  color-support@1.1.3: {}
+
+  columnify@1.6.0:
+    dependencies:
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
+
+  commander@15.0.0: {}
+
+  commander@2.20.3:
+    optional: true
+
+  commander@4.1.1: {}
+
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
+  comment-parser@1.4.7: {}
+
+  common-ancestor-path@1.0.1: {}
+
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
+
+  confbox@0.1.8: {}
+
+  console-control-strings@1.1.0: {}
+
+  conventional-changelog-angular@7.0.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-core@5.0.1:
+    dependencies:
+      add-stream: 1.0.0
+      conventional-changelog-writer: 6.0.1
+      conventional-commits-parser: 4.0.0
+      dateformat: 3.0.3
+      get-pkg-repo: 4.2.1
+      git-raw-commits: 3.0.0
+      git-remote-origin-url: 2.0.0
+      git-semver-tags: 5.0.1
+      normalize-package-data: 3.0.3
+      read-pkg: 3.0.0
+      read-pkg-up: 3.0.0
+
+  conventional-changelog-preset-loader@3.0.0: {}
+
+  conventional-changelog-writer@6.0.1:
+    dependencies:
+      conventional-commits-filter: 3.0.0
+      dateformat: 3.0.3
+      handlebars: 4.7.9
+      json-stringify-safe: 5.0.1
+      meow: 8.1.2
+      semver: 7.8.5
+      split: 1.0.1
+
+  conventional-commits-filter@3.0.0:
+    dependencies:
+      lodash.ismatch: 4.4.0
+      modify-values: 1.0.1
+
+  conventional-commits-parser@4.0.0:
+    dependencies:
+      JSONStream: 1.3.5
+      is-text-path: 1.0.1
+      meow: 8.1.2
+      split2: 3.2.2
+
+  conventional-recommended-bump@7.0.1:
+    dependencies:
+      concat-stream: 2.0.0
+      conventional-changelog-preset-loader: 3.0.0
+      conventional-commits-filter: 3.0.0
+      conventional-commits-parser: 4.0.0
+      git-raw-commits: 3.0.0
+      git-semver-tags: 5.0.1
+      meow: 8.1.2
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  copy-anything@3.0.5:
+    dependencies:
+      is-what: 4.1.16
+
+  core-util-is@1.0.3: {}
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
+  cosmiconfig@9.0.0(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.3.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  css.escape@1.5.1: {}
+
+  cssesc@3.0.0: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.0
+
+  dargs@7.0.0: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  dateformat@3.0.3: {}
+
+  dayjs@1.11.20: {}
+
+  debug@4.4.3(supports-color@7.2.0):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
+
+  decamelize-keys@1.1.1:
+    dependencies:
+      decamelize: 1.2.0
+      map-obj: 1.0.1
+
+  decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
+
+  dedent@1.5.3: {}
+
+  dedent@1.7.2: {}
+
+  deepmerge@4.3.1: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
+
+  define-lazy-prop@2.0.0: {}
+
+  define-lazy-prop@3.0.0: {}
+
+  defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
+  delayed-stream@1.0.0: {}
+
+  deprecation@2.3.1: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  detect-newline@3.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  dexie@4.4.4: {}
+
+  didyoumean@1.2.2: {}
+
+  dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.4.7
+
+  dotenv@16.4.7: {}
+
+  dts-resolver@3.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
+
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.4
+
+  ejs@5.0.1: {}
+
+  electron-to-chromium@1.5.389: {}
+
+  emittery@0.13.1: {}
+
+  emoji-regex-xs@1.0.0: {}
+
+  emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  empathic@2.0.1: {}
+
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  enquirer@2.3.6:
+    dependencies:
+      ansi-colors: 4.1.3
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  env-paths@2.2.1: {}
+
+  envinfo@7.13.0: {}
+
+  err-code@2.0.3: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  es-toolkit@1.49.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+    optional: true
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@2.0.0: {}
+
+  esprima@4.0.1: {}
+
+  estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  eventemitter3@4.0.7: {}
+
+  eventsource-parser@3.1.0: {}
+
+  execa@5.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  exit-x@0.2.2: {}
+
+  expect-type@1.3.0: {}
+
+  expect@30.4.1:
+    dependencies:
+      '@jest/expect-utils': 30.4.1
+      '@jest/get-type': 30.1.0
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+
+  exponential-backoff@3.1.3: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.5: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  figures@3.2.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
+  filelist@1.0.6:
+    dependencies:
+      minimatch: 5.1.9
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@2.1.0:
+    dependencies:
+      locate-path: 2.0.0
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
+  flat@5.0.2: {}
+
+  focus-trap@7.6.5:
+    dependencies:
+      tabbable: 6.2.0
+
+  follow-redirects@1.16.0: {}
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
+  fraction.js@5.3.4: {}
+
+  fs-constants@1.0.0: {}
+
+  fs-extra@11.3.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.3
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.5.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-package-type@0.1.0: {}
+
+  get-pkg-repo@4.2.1:
+    dependencies:
+      '@hutson/parse-repository-url': 3.0.2
+      hosted-git-info: 4.1.0
+      through2: 2.0.5
+      yargs: 16.2.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-stream@6.0.0: {}
+
+  get-stream@6.0.1: {}
+
+  get-tsconfig@5.0.0-beta.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  git-raw-commits@3.0.0:
+    dependencies:
+      dargs: 7.0.0
+      meow: 8.1.2
+      split2: 3.2.2
+
+  git-remote-origin-url@2.0.0:
+    dependencies:
+      gitconfiglocal: 1.0.0
+      pify: 2.3.0
+
+  git-semver-tags@5.0.1:
+    dependencies:
+      meow: 8.1.2
+      semver: 7.8.5
+
+  git-up@7.0.0:
+    dependencies:
+      is-ssh: 1.4.1
+      parse-url: 8.1.0
+
+  git-url-parse@14.0.0:
+    dependencies:
+      git-up: 7.0.0
+
+  gitconfiglocal@1.0.0:
+    dependencies:
+      ini: 1.3.8
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.15.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
+  hachure-fill@0.5.2: {}
+
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  hard-rejection@2.1.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  has-unicode@2.0.1: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hookable@5.5.3: {}
+
+  hookable@6.1.1: {}
+
+  hosted-git-info@2.8.9: {}
+
+  hosted-git-info@4.1.0:
+    dependencies:
+      lru-cache: 6.0.0
+
+  hosted-git-info@8.1.0:
+    dependencies:
+      lru-cache: 10.4.3
+
+  hosted-git-info@9.0.2:
+    dependencies:
+      lru-cache: 11.2.7
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
+
+  html-void-elements@3.0.0: {}
+
+  http-cache-semantics@4.2.0: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1(supports-color@7.2.0):
+    dependencies:
+      agent-base: 6.0.2(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  human-signals@2.1.0: {}
+
+  husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  ignore-walk@8.0.0:
+    dependencies:
+      minimatch: 10.2.5
+
+  ignore@7.0.5: {}
+
+  immer@11.1.15: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  import-local@3.1.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+
+  import-without-cache@0.4.0: {}
+
+  imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  ini@5.0.0: {}
+
+  ini@6.0.0: {}
+
+  init-package-json@8.2.2:
+    dependencies:
+      '@npmcli/package-json': 7.0.2
+      npm-package-arg: 13.0.1
+      promzard: 2.0.0
+      read: 4.1.0
+      semver: 7.8.5
+      validate-npm-package-license: 3.0.4
+      validate-npm-package-name: 6.0.2
+
+  inquirer@12.9.6(@types/node@24.13.3):
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/prompts': 7.10.1(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      mute-stream: 2.0.0
+      run-async: 4.0.6
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
+
+  ip-address@10.3.1: {}
+
+  is-arrayish@0.2.1: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-ci@3.0.1:
+    dependencies:
+      ci-info: 3.9.0
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.4
+
+  is-docker@2.2.1: {}
+
+  is-docker@3.0.0: {}
+
+  is-extendable@0.1.1: {}
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-fn@2.1.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-interactive@1.0.0: {}
+
+  is-interactive@2.0.0: {}
+
+  is-number@7.0.0: {}
+
+  is-obj@2.0.0: {}
+
+  is-plain-obj@1.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  is-ssh@1.4.1:
+    dependencies:
+      protocols: 2.0.2
+
+  is-stream@2.0.1: {}
+
+  is-text-path@1.0.1:
+    dependencies:
+      text-extensions: 1.9.0
+
+  is-unicode-supported@0.1.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
+  is-what@4.1.16: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  isarray@1.0.0: {}
+
+  isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
+
+  isexe@4.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3(supports-color@7.2.0)
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
+  jake@10.9.4:
+    dependencies:
+      async: 3.2.6
+      filelist: 1.0.6
+      picocolors: 1.1.1
+
+  jest-changed-files@30.4.1:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 30.4.1
+      p-limit: 3.1.0
+
+  jest-circus@30.4.2:
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.2
+      is-generator-fn: 2.1.0
+      jest-each: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      p-limit: 3.1.0
+      pretty-format: 30.4.1
+      pure-rand: 7.0.1
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-cli@30.4.2(@types/node@24.13.3):
+    dependencies:
+      '@jest/core': 30.4.2
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.4.2(@types/node@24.13.3)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-config@30.4.2(@types/node@24.13.3):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.4.2
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@30.4.1:
+    dependencies:
+      '@jest/diff-sequences': 30.4.0
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.4.1
+
+  jest-docblock@30.4.0:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-each@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.4.1
+      chalk: 4.1.2
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
+
+  jest-environment-jsdom@30.4.1:
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/environment-jsdom-abstract': 30.4.1(jsdom@26.1.0)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jest-environment-node@30.4.1:
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+
+  jest-haste-map@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
+      picomatch: 4.0.5
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  jest-leak-detector@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      pretty-format: 30.4.1
+
+  jest-matcher-utils@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      jest-diff: 30.4.1
+      pretty-format: 30.4.1
+
+  jest-message-util@30.4.1:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@jest/types': 30.4.1
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-util: 30.4.1
+      picomatch: 4.0.5
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      jest-util: 30.4.1
+
+  jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
+    optionalDependencies:
+      jest-resolve: 30.4.1
+
+  jest-regex-util@30.4.0: {}
+
+  jest-resolve-dependencies@30.4.2:
+    dependencies:
+      jest-regex-util: 30.4.0
+      jest-snapshot: 30.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve@30.4.1:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.4.1
+      jest-pnp-resolver: 1.2.3(jest-resolve@30.4.1)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      slash: 3.0.0
+      unrs-resolver: 1.11.1
+
+  jest-runner@30.4.2:
+    dependencies:
+      '@jest/console': 30.4.1
+      '@jest/environment': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      chalk: 4.1.2
+      emittery: 0.13.1
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-haste-map: 30.4.1
+      jest-leak-detector: 30.4.1
+      jest-message-util: 30.4.1
+      jest-resolve: 30.4.1
+      jest-runtime: 30.4.2
+      jest-util: 30.4.1
+      jest-watcher: 30.4.1
+      jest-worker: 30.4.1
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@30.4.2:
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/globals': 30.4.1
+      '@jest/source-map': 30.0.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      chalk: 4.1.2
+      cjs-module-lexer: 2.2.0
+      collect-v8-coverage: 1.0.3
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-snapshot@30.4.1:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
+      '@babel/types': 7.29.7
+      '@jest/expect-utils': 30.4.1
+      '@jest/get-type': 30.1.0
+      '@jest/snapshot-utils': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      expect: 30.4.1
+      graceful-fs: 4.2.11
+      jest-diff: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
+      semver: 7.8.5
+      synckit: 0.11.12
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-util@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      graceful-fs: 4.2.11
+      picomatch: 4.0.5
+
+  jest-validate@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.4.1
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      leven: 3.1.0
+      pretty-format: 30.4.1
+
+  jest-watcher@30.4.1:
+    dependencies:
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 24.13.3
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 30.4.1
+      string-length: 4.0.2
+
+  jest-worker@30.4.1:
+    dependencies:
+      '@types/node': 24.13.3
+      '@ungap/structured-clone': 1.3.0
+      jest-util: 30.4.1
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  jest@30.4.2(@types/node@24.13.3):
+    dependencies:
+      '@jest/core': 30.4.2
+      '@jest/types': 30.4.1
+      import-local: 3.2.0
+      jest-cli: 30.4.2(@types/node@24.13.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jiti@1.21.7: {}
+
+  jiti@2.6.1:
+    optional: true
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@3.15.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
+  json-parse-better-errors@1.0.2: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json-parse-even-better-errors@4.0.0: {}
+
+  json-parse-even-better-errors@5.0.0: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
+
+  json-stringify-nice@1.1.4: {}
+
+  json-stringify-safe@5.0.1: {}
+
+  json5@2.2.3: {}
+
+  jsonc-parser@3.2.0: {}
+
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonparse@1.3.1: {}
+
+  just-diff-apply@5.5.0: {}
+
+  just-diff@6.0.2: {}
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
+  kind-of@6.0.3: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
+
+  lerna@9.0.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3):
+    dependencies:
+      '@npmcli/arborist': 9.1.6
+      '@npmcli/package-json': 7.0.2
+      '@npmcli/run-script': 10.0.3
+      '@nx/devkit': 22.6.2(nx@22.7.7(@swc/core@1.15.46(@swc/helpers@0.5.23)))
+      '@octokit/plugin-enterprise-rest': 6.0.1
+      '@octokit/rest': 20.1.2
+      aproba: 2.0.0
+      byte-size: 8.1.1
+      chalk: 4.1.0
+      ci-info: 4.3.1
+      cmd-shim: 6.0.3
+      color-support: 1.1.3
+      columnify: 1.6.0
+      console-control-strings: 1.1.0
+      conventional-changelog-angular: 7.0.0
+      conventional-changelog-core: 5.0.1
+      conventional-recommended-bump: 7.0.1
+      cosmiconfig: 9.0.0(typescript@5.9.3)
+      dedent: 1.5.3
+      envinfo: 7.13.0
+      execa: 5.0.0
+      fs-extra: 11.3.4
+      get-stream: 6.0.0
+      git-url-parse: 14.0.0
+      glob-parent: 6.0.2
+      has-unicode: 2.0.1
+      import-local: 3.1.0
+      ini: 1.3.8
+      init-package-json: 8.2.2
+      inquirer: 12.9.6(@types/node@24.13.3)
+      is-ci: 3.0.1
+      jest-diff: 30.4.1
+      js-yaml: 4.3.1
+      libnpmaccess: 10.0.3
+      libnpmpublish: 11.1.2
+      load-json-file: 6.2.0
+      make-fetch-happen: 15.0.2
+      minimatch: 3.1.4
+      npm-package-arg: 13.0.1
+      npm-packlist: 10.0.3
+      npm-registry-fetch: 19.1.0
+      nx: 22.7.7(@swc/core@1.15.46(@swc/helpers@0.5.23))
+      p-map: 4.0.0
+      p-map-series: 2.1.0
+      p-pipe: 3.1.0
+      p-queue: 6.6.2
+      p-reduce: 2.1.0
+      p-waterfall: 2.1.1
+      pacote: 21.0.1
+      read-cmd-shim: 4.0.0
+      semver: 7.7.2
+      signal-exit: 3.0.7
+      slash: 3.0.0
+      ssri: 12.0.0
+      string-width: 4.2.3
+      tar: 7.5.21
+      through: 2.3.8
+      tinyglobby: 0.2.12
+      typescript: 5.9.3
+      upath: 2.0.1
+      validate-npm-package-license: 3.0.4
+      validate-npm-package-name: 6.0.2
+      wide-align: 1.1.5
+      write-file-atomic: 5.0.1
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - '@swc-node/register'
+      - '@swc/core'
+      - '@types/node'
+      - babel-plugin-macros
+      - debug
+      - supports-color
+
+  leven@3.1.0: {}
+
+  libnpmaccess@10.0.3:
+    dependencies:
+      npm-package-arg: 13.0.1
+      npm-registry-fetch: 19.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  libnpmpublish@11.1.2:
+    dependencies:
+      '@npmcli/package-json': 7.0.2
+      ci-info: 4.4.0
+      npm-package-arg: 13.0.1
+      npm-registry-fetch: 19.1.0
+      proc-log: 5.0.0
+      semver: 7.8.5
+      sigstore: 4.1.1
+      ssri: 12.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  lines-and-columns@2.0.3: {}
+
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
+  load-json-file@4.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      parse-json: 4.0.0
+      pify: 3.0.0
+      strip-bom: 3.0.0
+
+  load-json-file@6.2.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      parse-json: 5.2.0
+      strip-bom: 4.0.0
+      type-fest: 0.6.0
+
+  locate-path@2.0.0:
+    dependencies:
+      p-locate: 2.0.0
+      path-exists: 3.0.0
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
+  lodash-es@4.18.0: {}
+
+  lodash.ismatch@4.4.0: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+    optional: true
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@11.2.7: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
+  lunr@2.3.9: {}
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  make-fetch-happen@15.0.2:
+    dependencies:
+      '@npmcli/agent': 4.0.0
+      cacache: 20.0.4
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 4.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 5.0.0
+      promise-retry: 2.0.1
+      ssri: 12.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  make-fetch-happen@15.0.6:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 4.0.0
+      '@npmcli/redact': 4.0.0
+      cacache: 20.0.4
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 5.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 6.1.0
+      ssri: 13.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
+
+  map-obj@1.0.1: {}
+
+  map-obj@4.3.0: {}
+
+  mark.js@8.11.1: {}
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  marked@16.4.2: {}
+
+  math-intrinsics@1.1.0: {}
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+
+  mdurl@2.0.0: {}
+
+  meow@8.1.2:
+    dependencies:
+      '@types/minimist': 1.2.5
+      camelcase-keys: 6.2.2
+      decamelize-keys: 1.1.1
+      hard-rejection: 2.1.0
+      minimist-options: 4.1.0
+      normalize-package-data: 3.0.3
+      read-pkg-up: 7.0.1
+      redent: 3.0.0
+      trim-newlines: 3.0.1
+      type-fest: 0.18.1
+      yargs-parser: 20.2.9
+
+  merge-stream@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  mermaid@11.16.1:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.0
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.4.13
+      es-toolkit: 1.49.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.3.6
+      ts-dedent: 2.2.0
+      uuid: 11.1.1
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimic-fn@2.1.0: {}
+
+  mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
+
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@3.1.4:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimist-options@4.1.0:
+    dependencies:
+      arrify: 1.0.1
+      is-plain-obj: 1.1.0
+      kind-of: 6.0.3
+
+  minimist@1.2.8: {}
+
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass-fetch@4.0.1:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 1.0.3
+      minizlib: 3.1.0
+    optionalDependencies:
+      encoding: 0.1.13
+
+  minipass-fetch@5.0.2:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.2
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@7.1.3: {}
+
+  minisearch@7.1.2: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  mitt@3.0.1: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  modify-values@1.0.1: {}
+
+  ms@2.1.3: {}
+
+  mute-stream@2.0.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.17: {}
+
+  napi-postinstall@0.3.4: {}
+
+  natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
+
+  neo-async@2.6.2: {}
+
+  node-gyp@12.2.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 15.0.6
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.8.5
+      tar: 7.5.21
+      tinyglobby: 0.2.17
+      which: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  node-int64@0.4.0: {}
+
+  node-releases@2.0.51: {}
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
+
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.11
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+
+  normalize-package-data@3.0.3:
+    dependencies:
+      hosted-git-info: 4.1.0
+      is-core-module: 2.16.1
+      semver: 7.8.5
+      validate-npm-package-license: 3.0.4
+
+  normalize-path@3.0.0: {}
+
+  npm-bundled@4.0.0:
+    dependencies:
+      npm-normalize-package-bin: 4.0.0
+
+  npm-bundled@5.0.0:
+    dependencies:
+      npm-normalize-package-bin: 5.0.0
+
+  npm-install-checks@7.1.2:
+    dependencies:
+      semver: 7.8.5
+
+  npm-install-checks@8.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  npm-normalize-package-bin@4.0.0: {}
+
+  npm-normalize-package-bin@5.0.0: {}
+
+  npm-package-arg@12.0.2:
+    dependencies:
+      hosted-git-info: 8.1.0
+      proc-log: 5.0.0
+      semver: 7.8.5
+      validate-npm-package-name: 6.0.2
+
+  npm-package-arg@13.0.1:
+    dependencies:
+      hosted-git-info: 9.0.2
+      proc-log: 5.0.0
+      semver: 7.8.5
+      validate-npm-package-name: 6.0.2
+
+  npm-packlist@10.0.3:
+    dependencies:
+      ignore-walk: 8.0.0
+      proc-log: 6.1.0
+
+  npm-pick-manifest@10.0.0:
+    dependencies:
+      npm-install-checks: 7.1.2
+      npm-normalize-package-bin: 4.0.0
+      npm-package-arg: 12.0.2
+      semver: 7.8.5
+
+  npm-pick-manifest@11.0.3:
+    dependencies:
+      npm-install-checks: 8.0.0
+      npm-normalize-package-bin: 5.0.0
+      npm-package-arg: 13.0.1
+      semver: 7.8.5
+
+  npm-registry-fetch@19.1.0:
+    dependencies:
+      '@npmcli/redact': 3.2.2
+      jsonparse: 1.3.1
+      make-fetch-happen: 15.0.6
+      minipass: 7.1.3
+      minipass-fetch: 4.0.1
+      minizlib: 3.1.0
+      npm-package-arg: 13.0.1
+      proc-log: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  nwsapi@2.2.23: {}
+
+  nx@22.7.7(@swc/core@1.15.46(@swc/helpers@0.5.23)):
+    dependencies:
+      '@emnapi/core': 1.4.5
+      '@emnapi/runtime': 1.4.5
+      '@emnapi/wasi-threads': 1.0.4
+      '@jest/diff-sequences': 30.0.1
+      '@napi-rs/wasm-runtime': 0.2.4
+      '@tybys/wasm-util': 0.9.0
+      '@yarnpkg/lockfile': 1.1.0
+      '@zkochan/js-yaml': 0.0.7
+      ansi-colors: 4.1.3
+      ansi-regex: 5.0.1
+      ansi-styles: 4.3.0
+      argparse: 2.0.1
+      asynckit: 0.4.0
+      axios: 1.18.0(supports-color@7.2.0)
+      balanced-match: 4.0.3
+      base64-js: 1.5.1
+      bl: 4.1.0
+      brace-expansion: 5.0.9
+      buffer: 5.7.1
+      call-bind-apply-helpers: 1.0.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.6.1
+      cliui: 8.0.1
+      clone: 1.0.4
+      color-convert: 2.0.1
+      color-name: 1.1.4
+      combined-stream: 1.0.8
+      defaults: 1.0.4
+      define-lazy-prop: 2.0.0
+      delayed-stream: 1.0.0
+      dotenv: 16.4.7
+      dotenv-expand: 12.0.3
+      dunder-proto: 1.0.1
+      ejs: 5.0.1
+      emoji-regex: 8.0.0
+      end-of-stream: 1.4.5
+      enquirer: 2.3.6
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      escalade: 3.2.0
+      escape-string-regexp: 1.0.5
+      figures: 3.2.0
+      flat: 5.0.2
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      fs-constants: 1.0.0
+      function-bind: 1.1.2
+      get-caller-file: 2.0.5
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-flag: 4.0.0
+      has-symbols: 1.1.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+      ieee754: 1.2.1
+      ignore: 7.0.5
+      inherits: 2.0.4
+      is-docker: 2.2.1
+      is-fullwidth-code-point: 3.0.0
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      is-wsl: 2.2.0
+      json5: 2.2.3
+      jsonc-parser: 3.2.0
+      lines-and-columns: 2.0.3
+      log-symbols: 4.1.0
+      math-intrinsics: 1.1.0
+      mime-db: 1.52.0
+      mime-types: 2.1.35
+      mimic-fn: 2.1.0
+      minimatch: 10.2.5
+      minimist: 1.2.8
+      npm-run-path: 4.0.1
+      once: 1.4.0
+      onetime: 5.1.2
+      open: 8.4.2
+      ora: 5.3.0
+      path-key: 3.1.1
+      picocolors: 1.1.1
+      proxy-from-env: 2.1.0
+      readable-stream: 3.6.2
+      require-directory: 2.1.1
+      resolve.exports: 2.0.3
+      restore-cursor: 3.1.0
+      safe-buffer: 5.2.1
+      semver: 7.7.4
+      signal-exit: 3.0.7
+      smol-toml: 1.6.1
+      string-width: 4.2.3
+      string_decoder: 1.3.0
+      strip-ansi: 6.0.1
+      strip-bom: 3.0.0
+      supports-color: 7.2.0
+      tar-stream: 2.2.0
+      tmp: 0.2.7
+      tree-kill: 1.2.2
+      tsconfig-paths: 4.2.0
+      tslib: 2.8.1
+      util-deprecate: 1.0.2
+      wcwidth: 1.0.1
+      wrap-ansi: 7.0.0
+      wrappy: 1.0.2
+      y18n: 5.0.8
+      yaml: 2.9.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@nx/nx-darwin-arm64': 22.7.7
+      '@nx/nx-darwin-x64': 22.7.7
+      '@nx/nx-freebsd-x64': 22.7.7
+      '@nx/nx-linux-arm-gnueabihf': 22.7.7
+      '@nx/nx-linux-arm64-gnu': 22.7.7
+      '@nx/nx-linux-arm64-musl': 22.7.7
+      '@nx/nx-linux-x64-gnu': 22.7.7
+      '@nx/nx-linux-x64-musl': 22.7.7
+      '@nx/nx-win32-arm64-msvc': 22.7.7
+      '@nx/nx-win32-x64-msvc': 22.7.7
+      '@swc/core': 1.15.46(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - debug
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
+
+  obug@2.1.4: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@3.1.1:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
+  ora@5.3.0:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.6.1
+      is-interactive: 1.0.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+
+  ora@9.4.1:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.2.0
+
+  p-finally@1.0.0: {}
+
+  p-limit@1.3.0:
+    dependencies:
+      p-try: 1.0.0
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@2.0.0:
+    dependencies:
+      p-limit: 1.3.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-map-series@2.1.0: {}
+
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+
+  p-map@7.0.4: {}
+
+  p-pipe@3.1.0: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-reduce@2.1.0: {}
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
+  p-try@1.0.0: {}
+
+  p-try@2.2.0: {}
+
+  p-waterfall@2.1.1:
+    dependencies:
+      p-reduce: 2.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  package-manager-detector@1.6.0: {}
+
+  pacote@21.0.1:
+    dependencies:
+      '@npmcli/git': 6.0.3
+      '@npmcli/installed-package-contents': 3.0.0
+      '@npmcli/package-json': 7.0.2
+      '@npmcli/promise-spawn': 8.0.3
+      '@npmcli/run-script': 10.0.3
+      cacache: 20.0.4
+      fs-minipass: 3.0.3
+      minipass: 7.1.3
+      npm-package-arg: 13.0.1
+      npm-packlist: 10.0.3
+      npm-pick-manifest: 10.0.0
+      npm-registry-fetch: 19.1.0
+      proc-log: 5.0.0
+      promise-retry: 2.0.1
+      sigstore: 4.1.1
+      ssri: 12.0.0
+      tar: 7.5.21
+    transitivePeerDependencies:
+      - supports-color
+
+  pacote@21.5.0:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/git': 7.0.2
+      '@npmcli/installed-package-contents': 4.0.0
+      '@npmcli/package-json': 7.0.2
+      '@npmcli/promise-spawn': 9.0.1
+      '@npmcli/run-script': 10.0.3
+      cacache: 20.0.4
+      fs-minipass: 3.0.3
+      minipass: 7.1.3
+      npm-package-arg: 13.0.1
+      npm-packlist: 10.0.3
+      npm-pick-manifest: 11.0.3
+      npm-registry-fetch: 19.1.0
+      proc-log: 6.1.0
+      sigstore: 4.1.1
+      ssri: 13.0.1
+      tar: 7.5.21
+    transitivePeerDependencies:
+      - supports-color
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-conflict-json@4.0.0:
+    dependencies:
+      json-parse-even-better-errors: 4.0.0
+      just-diff: 6.0.2
+      just-diff-apply: 5.5.0
+
+  parse-json@4.0.0:
+    dependencies:
+      error-ex: 1.3.4
+      json-parse-better-errors: 1.0.2
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  parse-path@7.1.0:
+    dependencies:
+      protocols: 2.0.2
+
+  parse-url@8.1.0:
+    dependencies:
+      parse-path: 7.1.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  path-data-parser@0.1.0: {}
+
+  path-exists@3.0.0: {}
+
+  path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.7
+      minipass: 7.1.3
+
+  path-type@3.0.0:
+    dependencies:
+      pify: 3.0.0
+
+  pathe@2.0.3: {}
+
+  perfect-debounce@1.0.0: {}
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.5: {}
+
+  pify@2.3.0: {}
+
+  pify@3.0.0: {}
+
+  pirates@4.0.7: {}
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+
+  postcss-import@15.1.0(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.11
+
+  postcss-js@4.1.0(postcss@8.5.26):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.26
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.26
+      yaml: 2.9.0
+
+  postcss-nested@6.2.0(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.17
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  powershell-utils@0.1.0: {}
+
+  preact@10.27.3: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  pretty-format@30.4.1:
+    dependencies:
+      '@jest/schemas': 30.4.1
+      ansi-styles: 5.2.0
+      react-is-18: react-is@18.3.1
+      react-is-19: react-is@19.2.7
+
+  proc-log@5.0.0: {}
+
+  proc-log@6.1.0: {}
+
+  process-nextick-args@2.0.1: {}
+
+  proggy@3.0.0: {}
+
+  promise-all-reject-late@1.0.1: {}
+
+  promise-call-limit@3.0.2: {}
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+
+  promzard@2.0.0:
+    dependencies:
+      read: 4.1.0
+
+  property-information@7.1.0: {}
+
+  protocols@2.0.2: {}
+
+  proxy-from-env@2.1.0: {}
+
+  punycode.js@2.3.1: {}
+
+  punycode@2.3.1: {}
+
+  pure-rand@7.0.1: {}
+
+  quansync@1.0.0: {}
+
+  queue-microtask@1.2.3: {}
+
+  quick-lru@4.0.1: {}
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+    optional: true
+
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
+
+  react-is@19.2.7: {}
+
+  react-router-dom@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-router: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+
+  react-router@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.8
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+    optional: true
+
+  react@19.2.8: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  read-cmd-shim@4.0.0: {}
+
+  read-cmd-shim@5.0.0: {}
+
+  read-pkg-up@3.0.0:
+    dependencies:
+      find-up: 2.1.0
+      read-pkg: 3.0.0
+
+  read-pkg-up@7.0.1:
+    dependencies:
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+
+  read-pkg@3.0.0:
+    dependencies:
+      load-json-file: 4.0.0
+      normalize-package-data: 2.5.0
+      path-type: 3.0.0
+
+  read-pkg@5.2.0:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
+
+  read@4.1.0:
+    dependencies:
+      mute-stream: 2.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  redis@5.12.1(@opentelemetry/api@1.9.0):
+    dependencies:
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
+      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))
+      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-cwd@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
+
+  resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  resolve.exports@2.0.3: {}
+
+  resolve@1.22.11:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  retry@0.12.0: {}
+
+  reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
+
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.6
+      package-json-from-dist: 1.0.1
+
+  robust-predicates@3.0.3: {}
+
+  rolldown-plugin-dts@0.27.12(rolldown@1.2.0)(typescript@6.0.3):
+    dependencies:
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.4
+      rolldown: 1.2.0
+      yuku-ast: 0.7.3
+      yuku-codegen: 0.7.3
+      yuku-parser: 0.7.3
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
+  rolldown@1.0.0-rc.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.11
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.11
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.11
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.11
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.11
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.11
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.11
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.11
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.11
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.11
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.11
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  rolldown@1.0.0-rc.11(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.11
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.11
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.11
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.11
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.11
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.11
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.11
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.11
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.11
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.11(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.11
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.11
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  rolldown@1.2.0:
+    dependencies:
+      '@oxc-project/types': 0.140.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.0
+      '@rolldown/binding-darwin-arm64': 1.2.0
+      '@rolldown/binding-darwin-x64': 1.2.0
+      '@rolldown/binding-freebsd-x64': 1.2.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.0
+      '@rolldown/binding-linux-arm64-gnu': 1.2.0
+      '@rolldown/binding-linux-arm64-musl': 1.2.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.0
+      '@rolldown/binding-linux-s390x-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-musl': 1.2.0
+      '@rolldown/binding-openharmony-arm64': 1.2.0
+      '@rolldown/binding-wasm32-wasi': 1.2.0
+      '@rolldown/binding-win32-arm64-msvc': 1.2.0
+      '@rolldown/binding-win32-x64-msvc': 1.2.0
+
+  rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.59.0):
+    dependencies:
+      open: 11.0.0
+      picomatch: 4.0.5
+      source-map: 0.7.6
+      yargs: 18.0.0
+    optionalDependencies:
+      rolldown: 1.2.0
+      rollup: 4.59.0
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rrweb-cssom@0.8.0: {}
+
+  run-applescript@7.1.0: {}
+
+  run-async@4.0.6: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+    optional: true
+
+  scheduler@0.27.0: {}
+
+  search-insights@2.17.3: {}
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
+  semver@5.7.2: {}
+
+  semver@6.3.1: {}
+
+  semver@7.7.2: {}
+
+  semver@7.7.4: {}
+
+  semver@7.8.5: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  shiki@2.5.0:
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/langs': 2.5.0
+      '@shikijs/themes': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  shiki@4.3.1:
+    dependencies:
+      '@shikijs/core': 4.3.1
+      '@shikijs/engine-javascript': 4.3.1
+      '@shikijs/engine-oniguruma': 4.3.1
+      '@shikijs/langs': 4.3.1
+      '@shikijs/themes': 4.3.1
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
+
+  sigstore@4.1.1:
+    dependencies:
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.0
+      '@sigstore/sign': 4.1.1
+      '@sigstore/tuf': 4.0.2
+      '@sigstore/verify': 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  slash@3.0.0: {}
+
+  smart-buffer@4.2.0: {}
+
+  smol-toml@1.6.1: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@7.2.0)
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.3.1
+      smart-buffer: 4.2.0
+
+  source-map-js@1.2.1: {}
+
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    optional: true
+
+  source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.23
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
+  speakingurl@14.0.1: {}
+
+  split2@3.2.2:
+    dependencies:
+      readable-stream: 3.6.2
+
+  split2@4.2.0: {}
+
+  split@1.0.1:
+    dependencies:
+      through: 2.3.8
+
+  sprintf-js@1.0.3: {}
+
+  ssri@12.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  ssri@13.0.1:
+    dependencies:
+      minipass: 7.1.3
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
+
+  stdin-discarder@0.3.2: {}
+
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
+
+  strip-bom@3.0.0: {}
+
+  strip-bom@4.0.0: {}
+
+  strip-final-newline@2.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-json-comments@3.1.1: {}
+
+  stylis@4.3.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  superjson@2.2.2:
+    dependencies:
+      copy-anything: 3.0.5
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
+
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
+
+  tabbable@6.2.0: {}
+
+  tailwindcss@3.4.19(yaml@2.9.0):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.26
+      postcss-import: 15.1.0(postcss@8.5.26)
+      postcss-js: 4.1.0(postcss@8.5.26)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.26)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.26)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.11
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  tailwindcss@4.3.2: {}
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tar@7.5.21:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  terser@5.43.1:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    optional: true
+
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.5
+
+  text-extensions@1.9.0: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  through2@2.0.5:
+    dependencies:
+      readable-stream: 2.3.8
+      xtend: 4.0.2
+
+  through@2.3.8: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.12:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tmp@0.2.7: {}
+
+  tmpl@1.0.5: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tree-kill@1.2.2: {}
+
+  treeverse@3.0.0: {}
+
+  trim-lines@3.0.1: {}
+
+  trim-newlines@3.0.1: {}
+
+  ts-dedent@2.2.0: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tsdown@0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(synckit@0.11.12)):
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.0
+      rolldown-plugin-dts: 0.27.12(rolldown@1.2.0)(typescript@6.0.3)
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.1.2
+    optionalDependencies:
+      typescript: 6.0.3
+      unrun: 0.2.33(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(synckit@0.11.12)
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
+
+  tsdown@0.22.13(typescript@6.0.3)(unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12)):
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.0
+      rolldown-plugin-dts: 0.27.12(rolldown@1.2.0)(typescript@6.0.3)
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.1.2
+    optionalDependencies:
+      typescript: 6.0.3
+      unrun: 0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12)
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
+
+  tslib@2.8.1: {}
+
+  tuf-js@4.1.0:
+    dependencies:
+      '@tufjs/models': 4.1.0
+      debug: 4.4.3(supports-color@7.2.0)
+      make-fetch-happen: 15.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  type-detect@4.0.8: {}
+
+  type-fest@0.18.1: {}
+
+  type-fest@0.21.3: {}
+
+  type-fest@0.6.0: {}
+
+  type-fest@0.8.1: {}
+
+  typedarray@0.0.6: {}
+
+  typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)):
+    dependencies:
+      typedoc: 0.28.20(typescript@6.0.3)
+
+  typedoc@0.28.20(typescript@6.0.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
+      lunr: 2.3.9
+      markdown-it: 14.3.0
+      minimatch: 10.2.5
+      typescript: 6.0.3
+      yaml: 2.9.0
+
+  typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
+
+  uc.micro@2.1.0: {}
+
+  ufo@1.6.3: {}
+
+  uglify-js@3.19.3:
+    optional: true
+
+  unconfig-core@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      quansync: 1.0.0
+
+  undici-types@7.18.2: {}
+
+  unist-util-is@6.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
+
+  universal-user-agent@6.0.1: {}
+
+  universalify@2.0.1: {}
+
+  unrs-resolver@1.11.1:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
+      '@unrs/resolver-binding-android-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-x64': 1.11.1
+      '@unrs/resolver-binding-freebsd-x64': 1.11.1
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
+      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  unrun@0.2.33(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(synckit@0.11.12):
+    dependencies:
+      rolldown: 1.0.0-rc.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      synckit: 0.11.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  unrun@0.2.33(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(synckit@0.11.12):
+    dependencies:
+      rolldown: 1.0.0-rc.11(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optionalDependencies:
+      synckit: 0.11.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  upath@2.0.1: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.6):
+    dependencies:
+      browserslist: 4.28.6
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
+
+  uuid@11.1.1: {}
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+
+  validate-npm-package-name@6.0.2: {}
+
+  verkit@0.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite-bundle-analyzer@1.3.9: {}
+
+  vite@6.4.3(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.59.0
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      terser: 5.43.1
+      yaml: 2.9.0
+
+  vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.43.1
+      yaml: 2.9.0
+
+  vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.43.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      terser: 5.43.1
+      yaml: 2.9.0
+
+  vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.43.1
+      yaml: 2.9.0
+
+  vitepress@1.6.4(@algolia/client-search@5.35.0)(@types/node@24.13.3)(@types/react@19.2.17)(axios@1.18.0)(jiti@2.6.1)(lightningcss@1.32.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(terser@5.43.1)(typescript@6.0.3)(yaml@2.9.0):
+    dependencies:
+      '@docsearch/css': 3.8.2
+      '@docsearch/js': 3.8.2(@algolia/client-search@5.35.0)(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
+      '@iconify-json/simple-icons': 1.2.49
+      '@shikijs/core': 2.5.0
+      '@shikijs/transformers': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@types/markdown-it': 14.1.2
+      '@vitejs/plugin-vue': 5.2.4(vite@6.4.3(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@vue/devtools-api': 7.7.7
+      '@vue/shared': 3.5.40
+      '@vueuse/core': 12.8.2(typescript@6.0.3)
+      '@vueuse/integrations': 12.8.2(axios@1.18.0)(focus-trap@7.6.5)(typescript@6.0.3)
+      focus-trap: 7.6.5
+      mark.js: 8.11.1
+      minisearch: 7.1.2
+      shiki: 2.5.0
+      vite: 6.4.3(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(yaml@2.9.0)
+      vue: 3.5.40(typescript@6.0.3)
+    optionalDependencies:
+      postcss: 8.5.26
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/node'
+      - '@types/react'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - fuse.js
+      - idb-keyval
+      - jiti
+      - jwt-decode
+      - less
+      - lightningcss
+      - nprogress
+      - qrcode
+      - react
+      - react-dom
+      - sass
+      - sass-embedded
+      - search-insights
+      - sortablejs
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - universal-cookie
+      - yaml
+
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(jsdom@26.1.0)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.43.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.13.3
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  vue@3.5.40(typescript@6.0.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-sfc': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/server-renderer': 3.5.40
+      '@vue/shared': 3.5.40
+    optionalDependencies:
+      typescript: 6.0.3
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  walk-up-path@4.0.0: {}
+
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
+
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  which@5.0.0:
+    dependencies:
+      isexe: 3.1.5
+
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+
+  wordwrap@1.0.0: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
+
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
+
+  write-file-atomic@6.0.0:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
+
+  ws@8.21.0: {}
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  xtend@4.0.2: {}
+
+  y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
+
+  yaml@2.9.0: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
+
+  yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.3: {}
+
+  yoctocolors@2.1.2: {}
+
+  yuku-ast@0.7.3:
+    dependencies:
+      '@yuku-toolchain/types': 0.7.3
+
+  yuku-codegen@0.7.3:
+    dependencies:
+      '@yuku-toolchain/types': 0.7.3
+    optionalDependencies:
+      '@yuku-codegen/binding-darwin-arm64': 0.7.3
+      '@yuku-codegen/binding-darwin-x64': 0.7.3
+      '@yuku-codegen/binding-freebsd-x64': 0.7.3
+      '@yuku-codegen/binding-linux-arm-gnu': 0.7.3
+      '@yuku-codegen/binding-linux-arm-musl': 0.7.3
+      '@yuku-codegen/binding-linux-arm64-gnu': 0.7.3
+      '@yuku-codegen/binding-linux-arm64-musl': 0.7.3
+      '@yuku-codegen/binding-linux-x64-gnu': 0.7.3
+      '@yuku-codegen/binding-linux-x64-musl': 0.7.3
+      '@yuku-codegen/binding-win32-arm64': 0.7.3
+      '@yuku-codegen/binding-win32-x64': 0.7.3
+
+  yuku-parser@0.7.3:
+    dependencies:
+      '@yuku-toolchain/types': 0.7.3
+      yuku-ast: 0.7.3
+    optionalDependencies:
+      '@yuku-parser/binding-darwin-arm64': 0.7.3
+      '@yuku-parser/binding-darwin-x64': 0.7.3
+      '@yuku-parser/binding-freebsd-x64': 0.7.3
+      '@yuku-parser/binding-linux-arm-gnu': 0.7.3
+      '@yuku-parser/binding-linux-arm-musl': 0.7.3
+      '@yuku-parser/binding-linux-arm64-gnu': 0.7.3
+      '@yuku-parser/binding-linux-arm64-musl': 0.7.3
+      '@yuku-parser/binding-linux-x64-gnu': 0.7.3
+      '@yuku-parser/binding-linux-x64-musl': 0.7.3
+      '@yuku-parser/binding-win32-arm64': 0.7.3
+      '@yuku-parser/binding-win32-x64': 0.7.3
+
+  zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/release-evidence/v1.0.0-stable-prepublish-3/logs/release-check.log
+++ b/release-evidence/v1.0.0-stable-prepublish-3/logs/release-check.log
@@ -1,0 +1,6236 @@
+
+> context-action-monorepo@1.0.1 release:check /Users/junwoobang/workflow/context-action
+> pnpm verify:all && pnpm release:roadmap:check && pnpm docs:api && pnpm docs:sync && pnpm docs:build && pnpm test:canonical-example && git diff --exit-code -- docs/en/api docs/.vitepress/config/api-spec.ts
+
+
+> context-action-monorepo@1.0.1 verify:all /Users/junwoobang/workflow/context-action
+> pnpm build:live-code-editor && pnpm build && pnpm test:ai-sdk-integration && pnpm verify:doc-snippets && pnpm verify:core-artifact-parity && pnpm verify:react-artifact-boundary && pnpm verify:package-exports && pnpm verify:package-tarballs && pnpm package-boundary:check && pnpm package-boundary:test && pnpm verify:local-tool-consumers && pnpm verify:v1-lifecycle && pnpm verify:v1-release-manifest && pnpm verify:v1-supply-chain && pnpm tool-durable:test:evidence && pnpm lint && pnpm convention:check && pnpm docs:management && pnpm llms:check && pnpm type-check && pnpm test && pnpm --filter example check && pnpm --filter example build && pnpm docs:build && pnpm verify:private-tools
+
+
+> context-action-monorepo@1.0.1 build:live-code-editor /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/live-code-editor build
+
+
+> @context-action/live-code-editor@0.0.0 build /Users/junwoobang/workflow/context-action/packages/live-code-editor
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/live-code-editor/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24.11.0
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+
+ WARN  We recommend using the ESM format instead of CommonJS.
+The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+
+ℹ Cleaning 8 files
+ℹ [CJS] dist/index.cjs       72.86 kB │ gzip: 16.05 kB
+ℹ [CJS] dist/index.cjs.map  144.26 kB │ gzip: 30.79 kB
+ℹ [CJS] 2 files, total: 217.12 kB
+ℹ [CJS] dist/index.d.cts.map   3.01 kB │ gzip: 1.21 kB
+ℹ [CJS] dist/index.d.cts      13.00 kB │ gzip: 2.98 kB
+ℹ [CJS] 2 files, total: 16.02 kB
+✔ Build complete in 390ms
+ℹ [ESM] dist/index.js         72.01 kB │ gzip: 15.91 kB
+ℹ [ESM] dist/index.js.map    144.26 kB │ gzip: 30.78 kB
+ℹ [ESM] dist/index.d.ts.map    3.01 kB │ gzip:  1.21 kB
+ℹ [ESM] dist/index.d.ts       13.00 kB │ gzip:  2.98 kB
+ℹ [ESM] 4 files, total: 232.28 kB
+✔ Build complete in 393ms
+
+> context-action-monorepo@1.0.1 build /Users/junwoobang/workflow/context-action
+> lerna run build
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target build for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:build
+
+
+> @context-action/mutative-core:build
+
+
+> @context-action/tool-durable-operations:build
+
+
+> @context-action/typedoc-vitepress-sync:build
+
+@context-action/tool-protocol: (node:83129) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:83130) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:83131) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:83132) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:83155) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:83160) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:83159) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:83161) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 build /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsdown
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0 build /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsdown
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 build /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > tsdown
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 build /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > tsdown
+@context-action/mutative-core: (node:83238) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:83223) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:83242) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:83266) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/tool-protocol: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/mutative-core: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/tool-durable-operations: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/tool-durable-operations/tsdown.config.ts[24m 
+@context-action/tool-protocol: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/tool-protocol/tsdown.config.ts[24m 
+@context-action/mutative-core: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/mutative-core/tsdown.config.ts[24m 
+@context-action/tool-durable-operations: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/tool-protocol: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/tool-durable-operations: [34mℹ[39m target: [34mes2020[39m
+@context-action/tool-protocol: [34mℹ[39m target: [34mes2020[39m
+@context-action/tool-durable-operations: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/tool-protocol: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/tool-protocol: [34mℹ[39m Build start
+@context-action/tool-durable-operations: [34mℹ[39m Build start
+@context-action/mutative-core: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/mutative-core: [34mℹ[39m target: [34mnode14.0.0[39m
+@context-action/mutative-core: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/mutative-core: [34mℹ[39m Build start
+@context-action/typedoc-vitepress-sync: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync/tsdown.config.ts[24m 
+@context-action/tool-durable-operations: [34mℹ[39m Cleaning 7 files
+@context-action/tool-protocol: [34mℹ[39m Cleaning 7 files
+@context-action/typedoc-vitepress-sync: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m target: [34mnode24[39m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/mutative-core: [34mℹ[39m Cleaning 8 files
+@context-action/typedoc-vitepress-sync: [34mℹ[39m Build start
+@context-action/typedoc-vitepress-sync: [34mℹ[39m Cleaning 4 files
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m      [2m 63.12 kB[22m [2m│ gzip: 13.16 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.cjs.map  [2m132.13 kB[22m [2m│ gzip: 29.66 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m 2 files, total: 195.25 kB
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m42.71 kB[22m [2m│ gzip: 9.85 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m 1 files, total: 42.71 kB
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m41.89 kB[22m [2m│ gzip: 11.34 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m 1 files, total: 41.89 kB
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22m[1mindex.js[22m        [2m 63.03 kB[22m [2m│ gzip: 15.72 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22mindex.js.map    [2m124.42 kB[22m [2m│ gzip: 29.50 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22mindex.d.ts.map  [2m  3.66 kB[22m [2m│ gzip:  1.31 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 11.80 kB[22m [2m│ gzip:  2.91 kB[22m
+@context-action/typedoc-vitepress-sync: [34mℹ[39m 4 files, total: 202.92 kB
+@context-action/typedoc-vitepress-sync: [32m✔[39m Build complete in [32m1125ms[39m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m42.14 kB[22m [2m│ gzip:  9.77 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m94.85 kB[22m [2m│ gzip: 20.86 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 3.70 kB[22m [2m│ gzip:  1.28 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m14.77 kB[22m [2m│ gzip:  2.34 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [34m[ESM][39m 4 files, total: 155.46 kB
+@context-action/tool-durable-operations: [32m✔[39m Build complete in [32m1147ms[39m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 3.70 kB[22m [2m│ gzip: 1.28 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m14.77 kB[22m [2m│ gzip: 2.35 kB[22m
+@context-action/tool-durable-operations: [34mℹ[39m [33m[CJS][39m 2 files, total: 18.47 kB
+@context-action/tool-durable-operations: [32m✔[39m Build complete in [32m1149ms[39m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 4.04 kB[22m [2m│ gzip: 1.51 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m19.63 kB[22m [2m│ gzip: 4.10 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [33m[CJS][39m 2 files, total: 23.66 kB
+@context-action/tool-protocol: [32m✔[39m Build complete in [32m1157ms[39m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m40.37 kB[22m [2m│ gzip: 11.14 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m89.50 kB[22m [2m│ gzip: 22.52 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 4.04 kB[22m [2m│ gzip:  1.51 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m19.63 kB[22m [2m│ gzip:  4.10 kB[22m
+@context-action/tool-protocol: [34mℹ[39m [34m[ESM][39m 4 files, total: 153.53 kB
+@context-action/tool-protocol: [32m✔[39m Build complete in [32m1158ms[39m
+
+> @context-action/webmcp:build
+
+
+> @context-action/core:build
+
+
+> @context-action/ai-sdk:build
+
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m 62.79 kB[22m [2m│ gzip: 13.09 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m132.12 kB[22m [2m│ gzip: 29.66 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m  2.95 kB[22m [2m│ gzip:  1.01 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 11.86 kB[22m [2m│ gzip:  2.62 kB[22m
+@context-action/mutative-core: [34mℹ[39m [34m[ESM][39m 4 files, total: 209.72 kB
+@context-action/mutative-core: [32m✔[39m Build complete in [32m1193ms[39m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 2.95 kB[22m [2m│ gzip: 1.01 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m11.86 kB[22m [2m│ gzip: 2.62 kB[22m
+@context-action/mutative-core: [34mℹ[39m [33m[CJS][39m 2 files, total: 14.81 kB
+@context-action/mutative-core: [32m✔[39m Build complete in [32m1195ms[39m
+
+> @context-action/mutative:build
+
+@context-action/core: (node:83288) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:83289) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:83287) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:83290) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:83309) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:83308) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:83311) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:83318) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 build /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsdown
+@context-action/core: > @context-action/core@1.0.0 build /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsdown
+@context-action/webmcp: > @context-action/webmcp@0.1.0 build /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsdown
+@context-action/mutative: > @context-action/mutative@0.8.8 build /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > tsdown
+@context-action/ai-sdk: (node:83385) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:83392) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:83393) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/ai-sdk: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/webmcp: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/mutative: (node:83433) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/ai-sdk: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/ai-sdk/tsdown.config.ts[24m 
+@context-action/core: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/core/tsdown.config.ts[24m 
+@context-action/webmcp: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/webmcp/tsdown.config.ts[24m 
+@context-action/ai-sdk: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/ai-sdk: [34mℹ[39m target: [34mes2022[39m
+@context-action/ai-sdk: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/ai-sdk: [34mℹ[39m Build start
+@context-action/webmcp: [34mℹ[39m entry: [34msrc/index.ts, src/profiles/chrome-legacy.ts[39m
+@context-action/webmcp: [34mℹ[39m target: [34mes2022[39m
+@context-action/webmcp: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/core: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/core: [34mℹ[39m target: [34mes2020[39m
+@context-action/core: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/webmcp: [34mℹ[39m Build start
+@context-action/core: [34mℹ[39m Build start
+@context-action/ai-sdk: [34mℹ[39m Cleaning 7 files
+@context-action/webmcp: [34mℹ[39m Cleaning 15 files
+@context-action/core: [34mℹ[39m Cleaning 7 files
+@context-action/mutative: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/mutative/tsdown.config.ts[24m 
+@context-action/mutative: [34mℹ[39m entry: [34msrc/index.ts[39m
+@context-action/mutative: [34mℹ[39m target: [34mnode24.11.0[39m
+@context-action/mutative: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/mutative: [34mℹ[39m Build start
+@context-action/mutative: [43m WARN [49m We recommend using the ESM format instead of CommonJS.
+@context-action/mutative: The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+@context-action/mutative: Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+@context-action/mutative: [34mℹ[39m Cleaning 8 files
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m      [2m24.81 kB[22m [2m│ gzip:  5.82 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.cjs.map  [2m48.54 kB[22m [2m│ gzip: 11.22 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m 2 files, total: 73.35 kB
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m23.43 kB[22m [2m│ gzip:  5.69 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m48.65 kB[22m [2m│ gzip: 11.23 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 2.22 kB[22m [2m│ gzip:  0.89 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m10.65 kB[22m [2m│ gzip:  3.00 kB[22m
+@context-action/mutative: [34mℹ[39m [34m[ESM][39m 4 files, total: 84.95 kB
+@context-action/mutative: [32m✔[39m Build complete in [32m900ms[39m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 2.22 kB[22m [2m│ gzip: 0.89 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m10.65 kB[22m [2m│ gzip: 3.00 kB[22m
+@context-action/mutative: [34mℹ[39m [33m[CJS][39m 2 files, total: 12.88 kB
+@context-action/mutative: [32m✔[39m Build complete in [32m918ms[39m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m                   [2m10.01 kB[22m [2m│ gzip: 3.23 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mprofiles/chrome-legacy.cjs[22m  [2m 0.79 kB[22m [2m│ gzip: 0.45 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m 2 files, total: 10.80 kB
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map                   [2m0.77 kB[22m [2m│ gzip: 0.41 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22mprofiles/chrome-legacy.d.cts.map  [2m0.18 kB[22m [2m│ gzip: 0.16 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m                       [2m3.47 kB[22m [2m│ gzip: 0.99 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mprofiles/chrome-legacy.d.cts[22m[39m      [2m0.52 kB[22m [2m│ gzip: 0.28 kB[22m
+@context-action/webmcp: [34mℹ[39m [33m[CJS][39m 4 files, total: 4.93 kB
+@context-action/webmcp: [32m✔[39m Build complete in [32m1000ms[39m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                         [2m 9.84 kB[22m [2m│ gzip: 3.18 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mprofiles/chrome-legacy.js[22m        [2m 0.74 kB[22m [2m│ gzip: 0.42 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map                     [2m23.00 kB[22m [2m│ gzip: 6.81 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mprofiles/chrome-legacy.js.map    [2m 1.48 kB[22m [2m│ gzip: 0.72 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map                   [2m 0.76 kB[22m [2m│ gzip: 0.41 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22mprofiles/chrome-legacy.d.ts.map  [2m 0.17 kB[22m [2m│ gzip: 0.16 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m                       [2m 3.46 kB[22m [2m│ gzip: 0.99 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mprofiles/chrome-legacy.d.ts[22m[39m      [2m 0.52 kB[22m [2m│ gzip: 0.27 kB[22m
+@context-action/webmcp: [34mℹ[39m [34m[ESM][39m 8 files, total: 39.98 kB
+@context-action/webmcp: [32m✔[39m Build complete in [32m1002ms[39m
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m113.21 kB[22m [2m│ gzip: 24.71 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m 1 files, total: 113.21 kB
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m6.34 kB[22m [2m│ gzip: 2.21 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m 1 files, total: 6.34 kB
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m0.49 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m2.36 kB[22m [2m│ gzip: 0.74 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [33m[CJS][39m 2 files, total: 2.85 kB
+@context-action/ai-sdk: [32m✔[39m Build complete in [32m1035ms[39m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m 6.14 kB[22m [2m│ gzip: 2.16 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m14.63 kB[22m [2m│ gzip: 4.78 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m 0.49 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 2.36 kB[22m [2m│ gzip: 0.74 kB[22m
+@context-action/ai-sdk: [34mℹ[39m [34m[ESM][39m 4 files, total: 23.62 kB
+@context-action/ai-sdk: [32m✔[39m Build complete in [32m1036ms[39m
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map  [2m 6.06 kB[22m [2m│ gzip: 2.10 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m      [2m19.81 kB[22m [2m│ gzip: 4.50 kB[22m
+@context-action/core: [34mℹ[39m [33m[CJS][39m 2 files, total: 25.87 kB
+@context-action/core: [32m✔[39m Build complete in [32m1046ms[39m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m        [2m112.71 kB[22m [2m│ gzip: 24.64 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map    [2m268.68 kB[22m [2m│ gzip: 62.76 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map  [2m  6.06 kB[22m [2m│ gzip:  2.10 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m      [2m 19.81 kB[22m [2m│ gzip:  4.49 kB[22m
+@context-action/core: [34mℹ[39m [34m[ESM][39m 4 files, total: 407.25 kB
+@context-action/core: [32m✔[39m Build complete in [32m1050ms[39m
+
+> @context-action/react:build
+
+@context-action/react: (node:83458) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:83467) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0 build /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > NODE_ENV=production tsdown
+@context-action/react: (node:83495) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/react: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/react/tsdown.config.ts[24m 
+@context-action/react: [34mℹ[39m entry: [34msrc/index.ts, src/advanced.ts, src/utils.ts, src/react18.ts, src/tools/index.ts, src/webmcp.ts[39m
+@context-action/react: [34mℹ[39m target: [34mes2022[39m
+@context-action/react: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/react: [34mℹ[39m Build start
+@context-action/react: [34mℹ[39m Cleaning 70 files
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m             [2m71.31 kB[22m [2m│ gzip: 14.27 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mtools/index.cjs[22m       [2m43.17 kB[22m [2m│ gzip:  9.19 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1madvanced.cjs[22m          [2m 6.26 kB[22m [2m│ gzip:  1.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mwebmcp.cjs[22m            [2m 3.75 kB[22m [2m│ gzip:  1.24 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mutils.cjs[22m             [2m 1.21 kB[22m [2m│ gzip:  0.34 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mreact18.cjs[22m           [2m 0.00 kB[22m [2m│ gzip:  0.02 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mStoreRegistry.cjs     [2m51.32 kB[22m [2m│ gzip: 13.45 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.cjs     [2m15.34 kB[22m [2m│ gzip:  3.62 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mcomparison.cjs        [2m 5.25 kB[22m [2m│ gzip:  1.36 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils2.cjs            [2m 3.57 kB[22m [2m│ gzip:  1.12 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrolldown-runtime.cjs  [2m 1.09 kB[22m [2m│ gzip:  0.53 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m 11 files, total: 202.25 kB
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.d.cts.map                [2m 6.45 kB[22m [2m│ gzip: 2.23 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mtools/index.d.cts.map          [2m 1.74 kB[22m [2m│ gzip: 0.70 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.d.cts.map        [2m 1.25 kB[22m [2m│ gzip: 0.62 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mActionContext.types.d.cts.map  [2m 1.23 kB[22m [2m│ gzip: 0.51 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mtypes.d.cts.map                [2m 1.19 kB[22m [2m│ gzip: 0.50 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mStore.d.cts.map                [2m 0.96 kB[22m [2m│ gzip: 0.50 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils.d.cts.map                [2m 0.74 kB[22m [2m│ gzip: 0.39 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22madvanced.d.cts.map             [2m 0.39 kB[22m [2m│ gzip: 0.25 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22mwebmcp.d.cts.map               [2m 0.19 kB[22m [2m│ gzip: 0.17 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m                    [2m19.34 kB[22m [2m│ gzip: 4.07 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mtools/index.d.cts[22m[39m              [2m 5.91 kB[22m [2m│ gzip: 1.54 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1madvanced.d.cts[22m[39m                 [2m 2.61 kB[22m [2m│ gzip: 0.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mutils2.d.cts[22m[39m                   [2m 1.02 kB[22m [2m│ gzip: 0.40 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mwebmcp.d.cts[22m[39m                   [2m 0.63 kB[22m [2m│ gzip: 0.32 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mreact18.d.cts[22m[39m                  [2m 0.08 kB[22m [2m│ gzip: 0.08 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mActionContext.d.cts[39m            [2m 4.37 kB[22m [2m│ gzip: 1.38 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes.d.cts[39m                    [2m 4.07 kB[22m [2m│ gzip: 1.35 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mStore.d.cts[39m                    [2m 3.19 kB[22m [2m│ gzip: 1.12 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mActionContext.types.d.cts[39m      [2m 3.11 kB[22m [2m│ gzip: 0.91 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mutils.d.cts[39m                    [2m 1.79 kB[22m [2m│ gzip: 0.77 kB[22m
+@context-action/react: [34mℹ[39m [33m[CJS][39m 20 files, total: 60.26 kB
+@context-action/react: [32m✔[39m Build complete in [32m792ms[39m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                      [2m 68.72 kB[22m [2m│ gzip: 14.06 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mtools/index.js[22m                [2m 39.97 kB[22m [2m│ gzip:  9.02 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1madvanced.js[22m                   [2m  5.11 kB[22m [2m│ gzip:  1.78 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mwebmcp.js[22m                     [2m  3.65 kB[22m [2m│ gzip:  1.20 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mutils.js[22m                      [2m  0.40 kB[22m [2m│ gzip:  0.19 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mreact18.js[22m                    [2m  0.00 kB[22m [2m│ gzip:  0.02 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map                  [2m156.58 kB[22m [2m│ gzip: 33.44 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStoreRegistry.js.map          [2m103.54 kB[22m [2m│ gzip: 27.95 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtools/index.js.map            [2m 79.57 kB[22m [2m│ gzip: 17.99 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStoreRegistry.js              [2m 48.55 kB[22m [2m│ gzip: 13.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.js.map          [2m 32.51 kB[22m [2m│ gzip:  8.24 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.js              [2m 14.70 kB[22m [2m│ gzip:  3.54 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mcomparison.js.map             [2m 11.82 kB[22m [2m│ gzip:  3.59 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22madvanced.js.map               [2m  9.37 kB[22m [2m│ gzip:  3.25 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mwebmcp.js.map                 [2m  7.09 kB[22m [2m│ gzip:  2.36 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.d.ts.map                [2m  6.45 kB[22m [2m│ gzip:  2.23 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mcomparison.js                 [2m  4.68 kB[22m [2m│ gzip:  1.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils2.js.map                 [2m  4.14 kB[22m [2m│ gzip:  1.20 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils2.js                     [2m  3.55 kB[22m [2m│ gzip:  1.11 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtools/index.d.ts.map          [2m  1.74 kB[22m [2m│ gzip:  0.70 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.d.ts.map        [2m  1.25 kB[22m [2m│ gzip:  0.62 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mActionContext.types.d.ts.map  [2m  1.23 kB[22m [2m│ gzip:  0.51 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mtypes.d.ts.map                [2m  1.18 kB[22m [2m│ gzip:  0.50 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mStore.d.ts.map                [2m  0.95 kB[22m [2m│ gzip:  0.50 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils.d.ts.map                [2m  0.74 kB[22m [2m│ gzip:  0.38 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22madvanced.d.ts.map             [2m  0.39 kB[22m [2m│ gzip:  0.25 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22mwebmcp.d.ts.map               [2m  0.19 kB[22m [2m│ gzip:  0.17 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m                    [2m 19.34 kB[22m [2m│ gzip:  4.06 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mtools/index.d.ts[22m[39m              [2m  5.90 kB[22m [2m│ gzip:  1.54 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1madvanced.d.ts[22m[39m                 [2m  2.61 kB[22m [2m│ gzip:  0.90 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mutils2.d.ts[22m[39m                   [2m  1.02 kB[22m [2m│ gzip:  0.39 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mwebmcp.d.ts[22m[39m                   [2m  0.62 kB[22m [2m│ gzip:  0.32 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mreact18.d.ts[22m[39m                  [2m  0.08 kB[22m [2m│ gzip:  0.08 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mActionContext.d.ts[39m            [2m  4.37 kB[22m [2m│ gzip:  1.38 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes.d.ts[39m                    [2m  4.06 kB[22m [2m│ gzip:  1.35 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mStore.d.ts[39m                    [2m  3.19 kB[22m [2m│ gzip:  1.12 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mActionContext.types.d.ts[39m      [2m  3.11 kB[22m [2m│ gzip:  0.91 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mutils.d.ts[39m                    [2m  1.82 kB[22m [2m│ gzip:  0.78 kB[22m
+@context-action/react: [34mℹ[39m [34m[ESM][39m 38 files, total: 654.23 kB
+@context-action/react: [32m✔[39m Build complete in [32m802ms[39m
+
+> @context-action/llms-generator:build
+
+@context-action/llms-generator: (node:83506) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:83513) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 build /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > tsdown
+@context-action/llms-generator: (node:83538) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: [34mℹ[39m [34mtsdown v0.22.13[39m powered by [91mrolldown v1.2.0[39m
+@context-action/llms-generator: [34mℹ[39m config file: [4m/Users/junwoobang/workflow/context-action/packages/llms-generator/tsdown.config.ts[24m 
+@context-action/llms-generator: [34mℹ[39m entry: [34msrc/index.ts, src/cli/index.ts[39m
+@context-action/llms-generator: [34mℹ[39m target: [34mnode24[39m
+@context-action/llms-generator: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+@context-action/llms-generator: [34mℹ[39m Build start
+@context-action/llms-generator: [34mℹ[39m Cleaning 10 files
+@context-action/llms-generator: [34mℹ[39m Granting execute permission to [4mdist/cli/index.js[24m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[1mcli/index.js[22m        [2m186.78 kB[22m [2m│ gzip: 41.50 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[1mindex.js[22m            [2m  0.13 kB[22m [2m│ gzip:  0.11 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mcli/index.js.map    [2m377.59 kB[22m [2m│ gzip: 82.14 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22msrc.js.map          [2m 36.89 kB[22m [2m│ gzip:  7.87 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22msrc.js              [2m 20.92 kB[22m [2m│ gzip:  4.89 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mindex.d.ts.map      [2m  1.76 kB[22m [2m│ gzip:  0.60 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22mcli/index.d.ts.map  [2m  0.11 kB[22m [2m│ gzip:  0.12 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m          [2m  7.05 kB[22m [2m│ gzip:  2.06 kB[22m
+@context-action/llms-generator: [34mℹ[39m [2mdist/[22m[32m[1mcli/index.d.ts[22m[39m      [2m  0.14 kB[22m [2m│ gzip:  0.13 kB[22m
+@context-action/llms-generator: [34mℹ[39m 9 files, total: 631.36 kB
+@context-action/llms-generator: [32m✔[39m Build complete in [32m636ms[39m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target build for 10 projects
+
+
+
+> context-action-monorepo@1.0.1 test:ai-sdk-integration /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/tool-protocol build && pnpm --filter @context-action/ai-sdk build && node scripts/verify-ai-sdk-runtime.mjs
+
+
+> @context-action/tool-protocol@1.0.0 build /Users/junwoobang/workflow/context-action/packages/tool-protocol
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/tool-protocol/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2020
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  41.89 kB │ gzip: 11.34 kB
+ℹ [CJS] 1 files, total: 41.89 kB
+ℹ [CJS] dist/index.d.cts.map   4.04 kB │ gzip: 1.51 kB
+ℹ [CJS] dist/index.d.cts      19.63 kB │ gzip: 4.10 kB
+ℹ [CJS] 2 files, total: 23.66 kB
+ℹ [ESM] dist/index.js        40.37 kB │ gzip: 11.14 kB
+ℹ [ESM] dist/index.js.map    89.50 kB │ gzip: 22.52 kB
+ℹ [ESM] dist/index.d.ts.map   4.04 kB │ gzip:  1.51 kB
+ℹ [ESM] dist/index.d.ts      19.63 kB │ gzip:  4.10 kB
+ℹ [ESM] 4 files, total: 153.53 kB
+✔ Build complete in 715ms
+✔ Build complete in 716ms
+
+> @context-action/ai-sdk@0.1.0 build /Users/junwoobang/workflow/context-action/packages/ai-sdk
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/ai-sdk/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2022
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  6.34 kB │ gzip: 2.21 kB
+ℹ [CJS] 1 files, total: 6.34 kB
+ℹ [CJS] dist/index.d.cts.map  0.49 kB │ gzip: 0.32 kB
+ℹ [CJS] dist/index.d.cts      2.36 kB │ gzip: 0.74 kB
+ℹ [CJS] 2 files, total: 2.85 kB
+✔ Build complete in 565ms
+ℹ [ESM] dist/index.js         6.14 kB │ gzip: 2.16 kB
+ℹ [ESM] dist/index.js.map    14.63 kB │ gzip: 4.78 kB
+ℹ [ESM] dist/index.d.ts.map   0.49 kB │ gzip: 0.32 kB
+ℹ [ESM] dist/index.d.ts       2.36 kB │ gzip: 0.74 kB
+ℹ [ESM] 4 files, total: 23.62 kB
+✔ Build complete in 566ms
+AI SDK runtime integration passed
+
+> context-action-monorepo@1.0.1 verify:doc-snippets /Users/junwoobang/workflow/context-action
+> node scripts/verify-doc-snippets.mjs
+
+Documentation snippets compiled: 2
+
+> context-action-monorepo@1.0.1 verify:core-artifact-parity /Users/junwoobang/workflow/context-action
+> node scripts/verify-core-artifact-parity.mjs
+
+Verified core ESM/CJS runtime parity for diagnostics, limits, conditions, and timeout validation.
+
+> context-action-monorepo@1.0.1 verify:react-artifact-boundary /Users/junwoobang/workflow/context-action
+> node scripts/verify-react-artifact-boundary.mjs
+
+Verified React production artifact boundaries: default entry is tool-free and tools entry is explicit.
+
+> context-action-monorepo@1.0.1 verify:package-exports /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-exports.mjs
+
+
+@context-action/ai-sdk
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/core
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/llms-generator
+  ✓ . import -> ./dist/index.js [ESM loaded]
+  ✓ . types -> ./dist/index.d.ts
+  ✓ ./cli import -> ./dist/cli/index.js [ESM loaded]
+  ✓ ./cli types -> ./dist/cli/index.d.ts
+
+@context-action/mutative
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/mutative-core
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/react
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+  ✓ ./advanced import/types -> ./dist/advanced.d.ts
+  ✓ ./advanced import/default -> ./dist/advanced.js [ESM loaded]
+  ✓ ./advanced require/types -> ./dist/advanced.d.cts
+  ✓ ./advanced require/default -> ./dist/advanced.cjs [CJS loaded]
+  ✓ ./utils import/types -> ./dist/utils.d.ts
+  ✓ ./utils import/default -> ./dist/utils.js [ESM loaded]
+  ✓ ./utils require/types -> ./dist/utils.d.cts
+  ✓ ./utils require/default -> ./dist/utils.cjs [CJS loaded]
+  ✓ ./react18 import/types -> ./dist/react18.d.ts
+  ✓ ./react18 import/default -> ./dist/react18.js [ESM loaded]
+  ✓ ./react18 require/types -> ./dist/react18.d.cts
+  ✓ ./react18 require/default -> ./dist/react18.cjs [CJS loaded]
+  ✓ ./tools import/types -> ./dist/tools/index.d.ts
+  ✓ ./tools import/default -> ./dist/tools/index.js [ESM loaded]
+  ✓ ./tools require/types -> ./dist/tools/index.d.cts
+  ✓ ./tools require/default -> ./dist/tools/index.cjs [CJS loaded]
+  ✓ ./webmcp import/types -> ./dist/webmcp.d.ts
+  ✓ ./webmcp import/default -> ./dist/webmcp.js [ESM loaded]
+  ✓ ./webmcp require/types -> ./dist/webmcp.d.cts
+  ✓ ./webmcp require/default -> ./dist/webmcp.cjs [CJS loaded]
+
+@context-action/tool-durable-operations
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/tool-protocol
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+
+@context-action/typedoc-vitepress-sync
+  ✓ . import -> ./dist/index.js [ESM loaded]
+  ✓ . types -> ./dist/index.d.ts
+  ✓ ./cli import -> ./bin/cli.js [runtime load skipped: executable CLI]
+
+@context-action/webmcp
+  ✓ . import/types -> ./dist/index.d.ts
+  ✓ . import/default -> ./dist/index.js [ESM loaded]
+  ✓ . require/types -> ./dist/index.d.cts
+  ✓ . require/default -> ./dist/index.cjs [CJS loaded]
+  ✓ ./profiles/chrome-legacy import/types -> ./dist/profiles/chrome-legacy.d.ts
+  ✓ ./profiles/chrome-legacy import/default -> ./dist/profiles/chrome-legacy.js [ESM loaded]
+  ✓ ./profiles/chrome-legacy require/types -> ./dist/profiles/chrome-legacy.d.cts
+  ✓ ./profiles/chrome-legacy require/default -> ./dist/profiles/chrome-legacy.cjs [CJS loaded]
+
+Verified 10 packages, 63 export targets, and 31 runtime loads.
+
+> context-action-monorepo@1.0.1 verify:package-tarballs /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-tarballs.mjs
+
+
+@context-action/ai-sdk
+  ✓ context-action-ai-sdk-0.1.0.tgz (10 files, 7 manifest targets)
+
+@context-action/core
+  ✓ context-action-core-1.0.0.tgz (10 files, 7 manifest targets)
+
+@context-action/llms-generator
+  ✓ context-action-llms-generator-0.8.7.tgz (17 files, 7 manifest targets)
+
+@context-action/mutative
+  ✓ context-action-mutative-0.8.8.tgz (11 files, 7 manifest targets)
+
+@context-action/mutative-core
+  ✓ context-action-mutative-core-0.8.8.tgz (13 files, 7 manifest targets)
+
+@context-action/react
+  ✓ context-action-react-1.0.0.tgz (72 files, 27 manifest targets)
+
+@context-action/tool-durable-operations
+  ✓ context-action-tool-durable-operations-0.1.1.tgz (20 files, 8 manifest targets)
+
+@context-action/tool-protocol
+  ✓ context-action-tool-protocol-1.0.0.tgz (11 files, 7 manifest targets)
+
+@context-action/typedoc-vitepress-sync
+  ✓ context-action-typedoc-vitepress-sync-0.8.8.tgz (8 files, 6 manifest targets)
+
+@context-action/webmcp
+  ✓ context-action-webmcp-0.1.0.tgz (17 files, 11 manifest targets)
+
+Verified 10 npm package tarballs against their package publication contracts.
+
+> context-action-monorepo@1.0.1 package-boundary:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-package-boundaries.mjs
+
+Workspace package-boundary verification
+- workspace packages: 13
+- integration hosts: 2
+- source files scanned: 949
+- workspace imports checked: 300
+- violations: 0
+
+> context-action-monorepo@1.0.1 package-boundary:test /Users/junwoobang/workflow/context-action
+> node --test scripts/verify-package-boundaries.test.mjs
+
+✔ accepts declared workspace imports through exported entry points (157.65175ms)
+✔ rejects missing declarations and private workspace subpath imports (154.079709ms)
+✔ allows development-only imports in tests but rejects them from runtime source (306.383583ms)
+✔ rejects relative imports that escape an owning package (157.335167ms)
+ℹ tests 4
+ℹ suites 0
+ℹ pass 4
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 818.996792
+
+> context-action-monorepo@1.0.1 verify:local-tool-consumers /Users/junwoobang/workflow/context-action
+> node scripts/verify-published-tool-consumers.cjs --local
+
+
+added 22 packages in 754ms
+published tool package consumer imports passed: @context-action/core, @context-action/mutative-core, @context-action/mutative, @context-action/tool-protocol, @context-action/tool-durable-operations, @context-action/react, @context-action/react/tools, @context-action/react/webmcp, @context-action/ai-sdk, @context-action/webmcp, @context-action/webmcp/profiles/chrome-legacy
+published tool package ESM imports passed: @context-action/core, @context-action/mutative-core, @context-action/mutative, @context-action/tool-protocol, @context-action/tool-durable-operations, @context-action/react, @context-action/react/tools, @context-action/react/webmcp, @context-action/ai-sdk, @context-action/webmcp, @context-action/webmcp/profiles/chrome-legacy
+
+added 4 packages, and changed 1 package in 267ms
+React SSR consumer passed with React 18.3.1
+
+removed 2 packages, and changed 3 packages in 263ms
+React SSR consumer passed with React 19.2.8
+Local tarball tool package consumer matrix passed (CJS, ESM, NodeNext declarations, React 18/19 SSR): file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-wlSW52/local-packages/context-action-core-1.0.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-wlSW52/local-packages/context-action-mutative-core-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-wlSW52/local-packages/context-action-mutative-0.8.8.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-wlSW52/local-packages/context-action-tool-protocol-1.0.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-wlSW52/local-packages/context-action-tool-durable-operations-0.1.1.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-wlSW52/local-packages/context-action-react-1.0.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-wlSW52/local-packages/context-action-ai-sdk-0.1.0.tgz, file:/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/context-action-tool-consumer-wlSW52/local-packages/context-action-webmcp-0.1.0.tgz, ai@7.0.34, @types/react@19.2.17, typescript@6.0.3
+
+> context-action-monorepo@1.0.1 verify:v1-lifecycle /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-lifecycle-contract.mjs
+
+Wrote passed lifecycle report to reports/release/v1.0.0/test-results/lifecycle-report.json
+
+> context-action-monorepo@1.0.1 verify:v1-release-manifest /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-manifest.mjs
+
+{"status":"ok","manifest":"docs/releases/v1.0.0/release-manifest.json","stage":"candidate-unapproved"}
+
+> context-action-monorepo@1.0.1 verify:v1-supply-chain /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-supply-chain.mjs
+
+Wrote passed supply-chain report to reports/release/v1.0.0/security-report.json
+
+> context-action-monorepo@1.0.1 tool-durable:test:evidence /Users/junwoobang/workflow/context-action
+> node --test scripts/verify-durable-operation-evidence-schema.test.mjs
+
+✔ complete evidence passes the strict deployment gate (72.441917ms)
+✔ schema-valid incomplete evidence is rejected by the strict gate (134.294708ms)
+ℹ tests 2
+ℹ suites 0
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 248.51675
+
+> context-action-monorepo@1.0.1 lint /Users/junwoobang/workflow/context-action
+> biome lint packages/core/src packages/tool-protocol/src packages/ai-sdk/src packages/webmcp/src packages/tool-durable-operations/src packages/react/src packages/mutative-core/src packages/mutative/src packages/llms-generator/src packages/typedoc-vitepress-sync/src scripts/security-audit.mjs scripts/verify-private-tools.mjs scripts/verify-package-boundaries.mjs scripts/verify-package-boundaries.test.mjs scripts/verify-durable-operation-evidence-schema.mjs scripts/verify-durable-operation-evidence-schema.test.mjs scripts/verify-ai-sdk-runtime.mjs scripts/verify-doc-snippets.mjs scripts/verify-react-compatibility.mjs scripts/verify-react-artifact-boundary.mjs scripts/verify-core-artifact-parity.mjs scripts/write-release-evidence.mjs scripts/verify-release-evidence.mjs scripts/release-evidence.test.mjs scripts/generate-release-inventory.mjs scripts/verify-v1-release-roadmap-alignment.mjs scripts/verify-react-webmcp-isolation.mjs scripts/verify-v1-core-migration-fixture.mjs scripts/verify-v1-lifecycle-contract.mjs scripts/verify-v1-release-manifest.mjs scripts/verify-v1-supply-chain.mjs scripts/capture-published-release.mjs scripts/verify-prerelease-dist-tags.cjs
+
+Checked 161 files in 81ms. No fixes applied.
+
+> context-action-monorepo@1.0.1 convention:check /Users/junwoobang/workflow/context-action
+> node scripts/check-context-layered-conventions.mjs
+
+Context-Layered convention check
+- transitional direct registrations: 0 file(s)
+- stale transitional allowlist entries: 0 file(s)
+- invalid direct registrations: 0 file(s)
+- provider-order violations: 0 occurrence(s)
+- canonical layered roots: 31
+- layer-path/name violations: 0 occurrence(s)
+- classified non-canonical handler roots: 2 (advanced 1, compatibility 1)
+- migration classification violations: 0 occurrence(s)
+
+> context-action-monorepo@1.0.1 docs:management /Users/junwoobang/workflow/context-action
+> node scripts/verify-documentation-management.mjs
+
+Documentation management verification
+- paired directories checked: 3
+- issue forms checked: 3
+- convention discovery links checked: en, ko
+- change-management metadata and handoff checklist checked: en, ko
+- decision-record home and package-boundary gate checked: en, ko
+
+> context-action-monorepo@1.0.1 llms:check /Users/junwoobang/workflow/context-action
+> node packages/llms-generator/dist/cli/index.js detect-mismatches --check-only --fail-on-mismatch
+
+
+> context-action-monorepo@1.0.1 type-check /Users/junwoobang/workflow/context-action
+> lerna run type-check
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target type-check for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:type-check
+
+
+> @context-action/mutative-core:type-check
+
+
+> @context-action/tool-durable-operations:type-check
+
+
+> @context-action/typedoc-vitepress-sync:type-check
+
+@context-action/mutative-core: (node:86007) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:86009) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:86006) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:86008) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:86035) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:86034) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:86036) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:86037) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 type-check /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0 type-check /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > tsc --noEmit
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > tsc --noEmit
+@context-action/tool-durable-operations: (node:86157) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:86161) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 type-check:src /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsc --noEmit
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0 type-check:src /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsc --noEmit
+
+> @context-action/mutative:type-check
+
+@context-action/mutative: (node:86240) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:86234) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:86242) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 test:type-check /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0 test:type-check /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/mutative: (node:86252) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: > @context-action/mutative@0.8.8 type-check /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > tsc --noEmit
+
+> @context-action/core:type-check
+
+
+> @context-action/webmcp:type-check
+
+
+> @context-action/ai-sdk:type-check
+
+@context-action/webmcp: (node:86354) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:86353) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:86355) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:86375) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:86374) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:86376) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: > @context-action/webmcp@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/core: > @context-action/core@1.0.0 type-check /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/webmcp: (node:86470) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:86469) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:86472) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: > @context-action/webmcp@0.1.0 type-check:src /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsc --noEmit
+@context-action/core: > @context-action/core@1.0.0 type-check:src /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsc --noEmit
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 type-check:src /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsc --noEmit
+@context-action/core: (node:86579) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:86585) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: > @context-action/core@1.0.0 test:type-check /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/webmcp: > @context-action/webmcp@0.1.0 test:type-check /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > tsc -p __tests__/tsconfig.json --pretty false
+@context-action/ai-sdk: (node:86592) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 test:type-check /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > tsc -p __tests__/tsconfig.json --pretty false
+
+> @context-action/react:type-check
+
+@context-action/react: (node:86692) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:86699) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0 type-check /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > pnpm run type-check:src && pnpm run test:type-check
+@context-action/react: (node:86731) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0 type-check:src /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > tsc --noEmit
+@context-action/react: (node:86771) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0 test:type-check /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > tsc -p __tests__/tsconfig.json --pretty false
+
+> @context-action/llms-generator:type-check
+
+@context-action/llms-generator: (node:86807) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:86814) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 type-check /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > tsc --noEmit
+
+
+
+ Lerna (powered by Nx)   Successfully ran target type-check for 10 projects
+
+
+
+> context-action-monorepo@1.0.1 test /Users/junwoobang/workflow/context-action
+> lerna run test
+
+lerna notice cli v9.0.7
+lerna info versioning independent
+
+ Lerna (powered by Nx)   Running target test for 10 projects:
+
+- @context-action/ai-sdk
+- @context-action/core
+- @context-action/llms-generator
+- @context-action/mutative
+- @context-action/mutative-core
+- @context-action/react
+- @context-action/tool-durable-operations
+- @context-action/tool-protocol
+- @context-action/typedoc-vitepress-sync
+- @context-action/webmcp
+
+
+
+> @context-action/tool-protocol:test
+
+
+> @context-action/mutative-core:test
+
+
+> @context-action/tool-durable-operations:test
+
+
+> @context-action/typedoc-vitepress-sync:test
+
+@context-action/tool-protocol: (node:86886) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:86889) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:86887) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:86888) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:86908) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:86914) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:86915) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:86917) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: > @context-action/mutative-core@0.8.8 test /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/mutative-core: > vitest run --config vitest.config.ts
+@context-action/tool-durable-operations: > @context-action/tool-durable-operations@0.1.1 test /Users/junwoobang/workflow/context-action/packages/tool-durable-operations
+@context-action/tool-durable-operations: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/tool-protocol: > @context-action/tool-protocol@1.0.0 test /Users/junwoobang/workflow/context-action/packages/tool-protocol
+@context-action/tool-protocol: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/typedoc-vitepress-sync: > @context-action/typedoc-vitepress-sync@0.8.8 test /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+@context-action/typedoc-vitepress-sync: > jest
+@context-action/mutative-core: (node:86997) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-protocol: (node:87010) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-protocol: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:87017) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/tool-durable-operations: (node:86998) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/tool-durable-operations: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core:  RUN  v4.1.10 /Users/junwoobang/workflow/context-action/packages/mutative-core
+@context-action/typedoc-vitepress-sync: (node:87203) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:87208) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:87209) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:87202) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:87210) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:87205) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:87207) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:87206) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:87213) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:87212) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:87204) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync: (node:87211) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/typedoc-vitepress-sync: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative-core: (node:87214) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative-core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/tool-protocol: [1mTest Suites: [22m[1m[32m5 passed[39m[22m, 5 total
+@context-action/tool-protocol: [1mTests:       [22m[1m[32m57 passed[39m[22m, 57 total
+@context-action/tool-protocol: [1mSnapshots:   [22m0 total
+@context-action/tool-protocol: [1mTime:[22m        0.873 s, estimated 1 s
+@context-action/tool-protocol: [2mRan all test suites[22m[2m.[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.19s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest loaded: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/mutative-core:  Test Files  4 passed (4)
+@context-action/mutative-core:       Tests  29 passed (29)
+@context-action/mutative-core:    Start at  18:32:33
+@context-action/mutative-core:    Duration  823ms (transform 1.59s, setup 57ms, import 2.02s, tests 36ms, environment 0ms)
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 3
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 50.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 3
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest loaded: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed 1 stale generated API file(s) from .test-sync/target/test
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 2 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 2
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 40.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 2
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 3 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 3
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 3
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-hanging/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in .test-sync/target/test/problematic.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/TypeDocVitePressSync.test.ts[39m[0m[2m:196:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Package directory not found: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat SidebarGenerator.warn [as parseApiStructure] ([22m[2msrc/processors/SidebarGenerator.ts[2m:37:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.parseApiStructure [as sync] ([22m[2msrc/index.ts[2m:184:50)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:96:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 4 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+
+> @context-action/mutative:test
+
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 4
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 4
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.04s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 0
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: ./reports/typedoc-vitepress-sync-metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.09s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: ./reports/typedoc-vitepress-sync-metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in .test-sync/target/test/bad.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/source/packages/test-package/test.md: Error: EACCES: permission denied, mkdir '/var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test'[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:116:9)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🧹 Cleaning cache and generated files...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Package directory not found: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat SidebarGenerator.warn [as parseApiStructure] ([22m[2msrc/processors/SidebarGenerator.ts[2m:37:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.parseApiStructure [as sync] ([22m[2msrc/index.ts[2m:184:50)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:116:9)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache cleared
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed target directory: .test-sync/target
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Removed sidebar config: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] ✅ Cleanup completed
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Auto-configured parallel processing: batchSize=18, maxWorkers=8
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Auto-optimization configured
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/source/packages/test-package/test.md: ENOSPC: no space left on device[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Recovery: No space left on device
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] 💡 Tip: Free up disk space and try again[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.error [as action] ([22m[2msrc/core/ErrorHandler.ts[2m:33:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.action [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:83:23)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+
+> @context-action/core:test
+
+
+> @context-action/webmcp:test
+
+
+> @context-action/ai-sdk:test
+
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/source/packages/test-package/huge.md: Markdown file exceeds the 8388608 byte processing limit: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/source/packages/test-package/huge.md[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:177:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 2 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 2
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 2
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 6 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 6
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 6
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 0)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m          at async Promise.allSettled (index 1)[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: .test-sync/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 4 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: .test-sync/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 4
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 4
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:310:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 1
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-0.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-1.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-10.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-11.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-12.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-13.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-14.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-15.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-16.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-17.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-18.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-19.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-2.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-20.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-21.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-22.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-23.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-24.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-25.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-26.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-27.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-28.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-29.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-3.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-30.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-31.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-32.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-33.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-34.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-35.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-36.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-37.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-38.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-39.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-4.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-40.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-41.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-42.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-43.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-44.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-45.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-46.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-47.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/core: (node:87221) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:87222) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-48.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/mutative: (node:87220) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-49.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-5.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-50.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-51.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-52.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/ai-sdk: (node:87223) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-53.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-54.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/tool-durable-operations: [1mTest Suites: [22m[1m[32m9 passed[39m[22m, 9 total
+@context-action/tool-durable-operations: [1mTests:       [22m[1m[33m2 skipped[39m[22m, [1m[32m43 passed[39m[22m, 45 total
+@context-action/tool-durable-operations: [1mSnapshots:   [22m0 total
+@context-action/tool-durable-operations: [1mTime:[22m        1.182 s, estimated 2 s
+@context-action/tool-durable-operations: [2mRan all test suites[22m[2m.[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-55.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-56.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-57.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-58.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-59.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-6.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-60.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-61.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-62.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-63.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-64.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-65.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-66.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-67.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-68.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-69.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-7.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-70.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-71.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-72.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-73.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-74.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-75.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-76.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-77.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-78.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-79.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-8.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-80.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-81.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-82.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-83.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-84.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-85.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-86.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-87.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-88.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-89.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-9.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-90.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-91.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-92.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-93.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-94.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-95.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-96.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-97.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-98.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Quality issues found in /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test-99.md: 1 issues[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat QualityValidator.warn [as validateFile] ([22m[2msrc/core/QualityValidator.ts[2m:57:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile ([22m[2msrc/core/FileProcessor.ts[2m:114:7)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles ([22m[2msrc/core/FileProcessor.ts[2m:149:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.sync ([22m[2msrc/index.ts[2m:156:30)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:361:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 100 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 100
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.16s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 100
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     ⚠️ Quality Issues:
+@context-action/typedoc-vitepress-sync:       - Files with issues: 100
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 50 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 50
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.02s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 50
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Transient write failure for /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test.md; retrying (1/3)[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.warn [as writeFileWithRetry] ([22m[2msrc/core/FileProcessor.ts[2m:281:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.writeFileWithRetry [as processFile] ([22m[2msrc/core/FileProcessor.ts[2m:104:12)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:404:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] Transient write failure for /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/target/test/test.md; retrying (2/3)[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.warn [as writeFileWithRetry] ([22m[2msrc/core/FileProcessor.ts[2m:281:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.writeFileWithRetry [as processFile] ([22m[2msrc/core/FileProcessor.ts[2m:104:12)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:404:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 1 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 1
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.01s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/source/packages/test-package/test.md: EACCES: permission denied[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:439:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔧 Recovery: Permission denied
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[33mconsole.warn[39m[22m
+@context-action/typedoc-vitepress-sync: [33m    [WARN] 💡 Tip: Check file permissions or run with appropriate privileges[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      59 |   warn(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      60 |     if (this.shouldLog('warn')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 61 |       console.warn(this.formatMessage('warn', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      62 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      63 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      64 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.warn ([22m[2msrc/utils/ConsoleLogger.ts[2m:61:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.warn [as action] ([22m[2msrc/core/ErrorHandler.ts[2m:26:22)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.action [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:83:23)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:439:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🚀 TypeDoc VitePress Sync starting...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache directory created: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/cache
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📦 Processing package: test-package
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2m[31mconsole.error[39m[22m
+@context-action/typedoc-vitepress-sync: [31m    [ERROR] ❌ Processing file: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/source/packages/test-package/valid.md: Simulated failure[39m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      65 |   error(message: string, ...args: unknown[]): void {[22m
+@context-action/typedoc-vitepress-sync: [2m      66 |     if (this.shouldLog('error')) {[22m
+@context-action/typedoc-vitepress-sync: [2m    > 67 |       console.error(this.formatMessage('error', message, ...args))[22m
+@context-action/typedoc-vitepress-sync: [2m         |               ^[22m
+@context-action/typedoc-vitepress-sync: [2m      68 |     }[22m
+@context-action/typedoc-vitepress-sync: [2m      69 |   }[22m
+@context-action/typedoc-vitepress-sync: [2m      70 |[22m
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.error ([22m[2msrc/utils/ConsoleLogger.ts[2m:67:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ErrorHandler.error [as handleError] ([22m[2msrc/core/ErrorHandler.ts[2m:77:18)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.handleError ([22m[2msrc/core/FileProcessor.ts[2m:125:25)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFile [as processFiles] ([22m[2msrc/core/FileProcessor.ts[2m:149:35)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat FileProcessor.processFiles [as processDirectory] ([22m[2msrc/core/FileProcessor.ts[2m:208:17)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat TypeDocVitePressSync.processDirectory [as sync] ([22m[2msrc/index.ts[2m:156:51)[22m[2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat Object.<anonymous> ([22m[2m[0m[36m__tests__/ErrorRecovery.test.ts[39m[0m[2m:471:24)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 🔍 Generating sidebar configuration...
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Sidebar configuration generated: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/api-spec.ts
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] Cache manifest saved: 0 entries
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 📊 Metrics saved: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/typedoc-vitepress-sync:   [2mconsole.info[22m
+@context-action/typedoc-vitepress-sync:     [INFO] 
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     ✅ TypeDoc VitePress Sync Complete!
+@context-action/typedoc-vitepress-sync:     ============================================================
+@context-action/typedoc-vitepress-sync:     📄 Files processed: 0
+@context-action/typedoc-vitepress-sync:     ⏭️  Files skipped: 0
+@context-action/typedoc-vitepress-sync:     ⏱️  Processing time: 0.00s
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📊 Cache Statistics:
+@context-action/typedoc-vitepress-sync:       - Hit rate: 0.00%
+@context-action/typedoc-vitepress-sync:       - Hits: 0
+@context-action/typedoc-vitepress-sync:       - Misses: 1
+@context-action/typedoc-vitepress-sync:       - Expired: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     🚨 Errors & Warnings:
+@context-action/typedoc-vitepress-sync:       - Errors: 1
+@context-action/typedoc-vitepress-sync:       - Warnings: 0
+@context-action/typedoc-vitepress-sync:     
+@context-action/typedoc-vitepress-sync:     📋 Reports:
+@context-action/typedoc-vitepress-sync:       - Metrics: /var/folders/ss/p9hh1w09423bbbt07xcftfr40000gn/T/typedoc-vitepress-sync-error-recovery-87204/metrics.json
+@context-action/typedoc-vitepress-sync: [2m[22m
+@context-action/typedoc-vitepress-sync: [2m      [2mat ConsoleLogger.info ([22m[2msrc/utils/ConsoleLogger.ts[2m:55:15)[22m[2m[22m
+@context-action/webmcp: (node:87243) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:87245) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:87246) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:87251) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: > @context-action/webmcp@0.1.0 test /Users/junwoobang/workflow/context-action/packages/webmcp
+@context-action/webmcp: > jest --runInBand
+@context-action/mutative: > @context-action/mutative@0.8.8 test /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: > vitest run
+@context-action/core: > @context-action/core@1.0.0 test /Users/junwoobang/workflow/context-action/packages/core
+@context-action/core: > NODE_OPTIONS=--max-old-space-size=8192 jest --runInBand --logHeapUsage
+@context-action/ai-sdk: > @context-action/ai-sdk@0.1.0 test /Users/junwoobang/workflow/context-action/packages/ai-sdk
+@context-action/ai-sdk: > jest --runInBand
+@context-action/mutative: (node:87303) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/webmcp: (node:87296) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/webmcp: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/core: (node:87327) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/core: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: (node:87363) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/ai-sdk: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative:  RUN  v4.1.10 /Users/junwoobang/workflow/context-action/packages/mutative
+@context-action/mutative: (node:87475) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:87477) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:87476) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/mutative: (node:87474) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/mutative: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/ai-sdk: [1mTest Suites: [22m[1m[32m1 passed[39m[22m, 1 total
+@context-action/ai-sdk: [1mTests:       [22m[1m[32m15 passed[39m[22m, 15 total
+@context-action/ai-sdk: [1mSnapshots:   [22m0 total
+@context-action/ai-sdk: [1mTime:[22m        0.195 s, estimated 1 s
+@context-action/ai-sdk: [2mRan all test suites[22m[2m.[22m
+@context-action/mutative:  Test Files  4 passed (4)
+@context-action/mutative:       Tests  40 passed (40)
+@context-action/mutative:    Start at  18:32:34
+@context-action/mutative:    Duration  250ms (transform 338ms, setup 0ms, import 428ms, tests 27ms, environment 0ms)
+@context-action/webmcp: [1mTest Suites: [22m[1m[32m2 passed[39m[22m, 2 total
+@context-action/webmcp: [1mTests:       [22m[1m[32m18 passed[39m[22m, 18 total
+@context-action/webmcp: [1mSnapshots:   [22m0 total
+@context-action/webmcp: [1mTime:[22m        0.23 s, estimated 1 s
+@context-action/webmcp: [2mRan all test suites[22m[2m.[22m
+@context-action/typedoc-vitepress-sync: [1mTest Suites: [22m[1m[33m1 skipped[39m[22m, [1m[32m8 passed[39m[22m, 8 of 9 total
+@context-action/typedoc-vitepress-sync: [1mTests:       [22m[1m[33m15 skipped[39m[22m, [1m[32m113 passed[39m[22m, 128 total
+@context-action/typedoc-vitepress-sync: [1mSnapshots:   [22m0 total
+@context-action/typedoc-vitepress-sync: [1mTime:[22m        1.868 s, estimated 2 s
+@context-action/typedoc-vitepress-sync: [2mRan all test suites[22m[2m.[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:40.645Z] [DebugRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'parallel',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:40.649Z] [DebugRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.087Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.088Z] [ConcurrencyTest] Handler registered: updateUser {
+@context-action/core:       handlerId: 'updateUser_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.090Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.091Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.091Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.092Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.093Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.093Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.094Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.095Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.095Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.096Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.097Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.097Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.098Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.099Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.099Z] [ConcurrencyTest] Handler registered: updateUI { handlerId: 'ui-updater', priority: 60, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.100Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.101Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.101Z] [ConcurrencyTest] Handler registered: searchUsers { handlerId: 'user-search', priority: 80, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.102Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.103Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.103Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.104Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.105Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.105Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.119Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.120Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.120Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-0', priority: undefined, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.121Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-1', priority: undefined, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.121Z] [ConcurrencyTest] Handler registered: test { handlerId: 'once-2', priority: undefined, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.121Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-0', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.122Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-1', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.122Z] [ConcurrencyTest] One-time handler removed: test { handlerId: 'once-2', remainingHandlers: 0 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.122Z] [ConcurrencyTest] Pipeline lookup for 'test' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.123Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.123Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.124Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.124Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.125Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.126Z] [ConcurrencyTest] Handler registered: test {
+@context-action/core:       handlerId: 'test_ConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.126Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.127Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Sequential: 0.00ms, Parallel: 1.00ms
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-docs-simple.test.ts[39m[0m[2m:456:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.128Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.128Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.129Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_1',
+@context-action/core:       priority: 50,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.129Z] [ConcurrencyTest] Handler registered: operation {
+@context-action/core:       handlerId: 'operation_ConcurrencyTest_2',
+@context-action/core:       priority: 100,
+@context-action/core:       totalHandlers: 2
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.132Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.133Z] [ConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.134Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler1', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.134Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler2', priority: 200, totalHandlers: 2 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.135Z] [ConcurrencyTest] Handler registered: test { handlerId: 'handler3', priority: 50, totalHandlers: 3 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.135Z] [ConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.277Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.278Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.279Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.280Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.281Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.281Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.282Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.282Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.283Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.284Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.284Z] [WarningTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.285Z] [WarningTestRegister] Pipeline lookup for 'userLogout' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.285Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.287Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.288Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.288Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.289Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.289Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.290Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.290Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.291Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.292Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.293Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.293Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.294Z] [WarningTestRegister] Pipeline lookup for 'userLogout' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.294Z] [WarningTestRegister] Pipeline lookup for 'processData' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.295Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.295Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.296Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.296Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.297Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.297Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.298Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.299Z] [WarningTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.299Z] [WarningTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.300Z] [WarningTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.368Z] [ActionRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.369Z] [ActionRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.417Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.418Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.419Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.420Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.421Z] [TypeOnlyTestRegister] Pipeline lookup for 'anotherTypeOnly' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.421Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.422Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.422Z] [TypeOnlyTestRegister] Pipeline lookup for 'userLogin' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.423Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.423Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.424Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.424Z] [TypeOnlyTestRegister] Handler registered: userLogout { handlerId: 'logout-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.424Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin', 'userLogout' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.428Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.429Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.429Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.430Z] [TypeOnlyTestRegister] Pipeline lookup for 'processData' {
+@context-action/core:       pipelineExists: false,
+@context-action/core:       handlersCount: 0,
+@context-action/core:       allRegisteredActions: [ 'userLogin' ]
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.430Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.431Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.431Z] [TypeOnlyTestRegister] Handler registered: userLogin { handlerId: 'login-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.432Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.433Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.434Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.435Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.435Z] [TypeOnlyTestRegister] Pipeline lookup for 'typeOnlyAction' { pipelineExists: false, handlersCount: 0, allRegisteredActions: [] }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.436Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.436Z] [TypeOnlyTestRegister] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: false,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.437Z] [TypeOnlyTestRegister] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.545Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.546Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Starting Promise.all operations...
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:48:15)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 1 completed { id: 1, timestamp: 1786267961547 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 2 completed { id: 2, timestamp: 1786267961548 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 starting
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:37:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     Promise.all operation 3 completed { id: 3, timestamp: 1786267961549 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat Object.log [as handler] ([22m[2m[0m[36m__tests__/concurrency/concurrency-async-fixed.test.ts[39m[0m[2m:42:17)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.550Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.550Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.551Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.551Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.552Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.553Z] [AsyncConcurrencyTest] Handler registered: syncTest { handlerId: 'sync-handler', priority: 100, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.553Z] [AsyncConcurrencyTest] Handler registered: asyncTest { handlerId: 'async-handler', priority: 50, totalHandlers: 1 }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.553Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.554Z] [AsyncConcurrencyTest] ActionRegister initialized {
+@context-action/core:       defaultExecutionMode: 'sequential',
+@context-action/core:       autoCleanup: true,
+@context-action/core:       concurrencyQueue: true,
+@context-action/core:       debugMode: true
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.554Z] [AsyncConcurrencyTest] Handler registered: asyncTest {
+@context-action/core:       handlerId: 'asyncTest_AsyncConcurrencyTest_1',
+@context-action/core:       priority: undefined,
+@context-action/core:       totalHandlers: 1
+@context-action/core:     }
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core:   [2mconsole.log[22m
+@context-action/core:     🎯 [2026-08-09T09:32:41.555Z] [AsyncConcurrencyTest] ActionRegister destroyed
+@context-action/core: [2m[22m
+@context-action/core: [2m      [2mat ActionRegister.log ([22m[2msrc/ActionRegister.ts[2m:504:21)[22m[2m[22m
+@context-action/core: [1mTest Suites: [22m[1m[32m34 passed[39m[22m, 34 total
+@context-action/core: [1mTests:       [22m[1m[32m766 passed[39m[22m, 766 total
+@context-action/core: [1mSnapshots:   [22m0 total
+@context-action/core: [1mTime:[22m        6.939 s, estimated 7 s
+@context-action/core: [2mRan all test suites[22m[2m.[22m
+
+> @context-action/react:test
+
+@context-action/react: (node:87531) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87538) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/react: > @context-action/react@1.0.0 test /Users/junwoobang/workflow/context-action/packages/react
+@context-action/react: > jest
+@context-action/react: (node:87563) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87635) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87636) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87633) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87632) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87638) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87631) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87639) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87634) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87641) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87640) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react: (node:87637) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/react: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Business Logic Separation Proof:
+@context-action/react:           - Validation: Pure function, no dependencies
+@context-action/react:           - Upload: Async operation with callbacks
+@context-action/react:           - Progress tracking: 11 updates
+@context-action/react:           - Result: file_1786267963851
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:203:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Performance Test Results:
+@context-action/react:           - setValue approach: 3 re-renders
+@context-action/react:           - notifyPath approach: 2 re-renders
+@context-action/react:           - Reduction: 33%
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:97:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Selective Re-rendering Proof:
+@context-action/react:           - user.name path: 2 renders (updated)
+@context-action/react:           - user.email path: 1 render (not updated)
+@context-action/react:           - ui.loading path: 1 render (not updated)
+@context-action/react:           - Efficiency: Only affected paths re-render
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:153:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ RAF Batching Proof:
+@context-action/react:           - notifyPath calls: 3
+@context-action/react:           - Re-renders after initial: 0 (batched)
+@context-action/react:           - Batching: Working
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:195:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ notifyPaths Batching Proof:
+@context-action/react:           - Paths notified: 3
+@context-action/react:           - RAF cycles: 1
+@context-action/react:           - Each subscriber: 2 total renders (1 initial + 1 batched)
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:248:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Event Loop Control Proof:
+@context-action/react:           - Total re-renders: 2
+@context-action/react:           - Loading state: notified without re-render
+@context-action/react:           - Final data: single re-render
+@context-action/react:           - Efficiency: Minimal render cycles
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:295:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Infinite Loop Prevention Proof:
+@context-action/react:           - Subscription calls: 1 (not infinite)
+@context-action/react:           - Processing calls: 1
+@context-action/react:           - Method: Direct mutation + notifyPath
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:338:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           🔄 Batched vs Immediate Mode Comparison:
+@context-action/react:     
+@context-action/react:           Batched Mode (RAF):
+@context-action/react:           - Render count: 1
+@context-action/react:           - Behavior: Multiple notifyPath calls batched into single RAF frame
+@context-action/react:           - Use case: High-frequency updates, animations, smooth UI
+@context-action/react:     
+@context-action/react:           Immediate Mode:
+@context-action/react:           - Render count: 1
+@context-action/react:           - Behavior: Each notifyPath triggers immediate notification
+@context-action/react:           - Use case: Critical updates, testing, predictable timing
+@context-action/react:     
+@context-action/react:           Difference: 0 additional renders in immediate mode
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:398:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           📊 Performance Benchmark (100 iterations):
+@context-action/react:     
+@context-action/react:           setValue Approach:
+@context-action/react:           - Total renders: 101
+@context-action/react:           - Time: 3200.00ms
+@context-action/react:     
+@context-action/react:           notifyPath Approach:
+@context-action/react:           - Total renders: 101
+@context-action/react:           - Time: 3200.00ms
+@context-action/react:     
+@context-action/react:           Improvements:
+@context-action/react:           - Render reduction: 0.0%
+@context-action/react:           - Time improvement: 0.0%
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-performance.test.tsx[39m[0m[2m:480:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Async State Machine Proof:
+@context-action/react:           - State transitions: validating → uploading → processing → complete
+@context-action/react:           - Progress updates: 11 notifications
+@context-action/react:           - State renders: 5
+@context-action/react:           - Progress renders: 12
+@context-action/react:           - Status renders: 6
+@context-action/react:           - Pattern: Direct mutation + notifyPath for selective updates
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:305:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Progress-Only Update Proof:
+@context-action/react:           - Progress updates: 10
+@context-action/react:           - Progress renders: 10 (selective)
+@context-action/react:           - State renders: 0 (not affected)
+@context-action/react:           - Efficiency: 100% (no wasted renders)
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:361:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Modular Business Logic Integration Proof:
+@context-action/react:     
+@context-action/react:           Business Logic Layer:
+@context-action/react:           - FileUploadService: Pure business logic (validation, upload, processing)
+@context-action/react:           - No React/store dependencies in business code
+@context-action/react:     
+@context-action/react:           State Management Layer:
+@context-action/react:           - TimeTravelStore with mutable mode
+@context-action/react:           - Direct mutation + notifyPath pattern
+@context-action/react:           - Path-based selective updates
+@context-action/react:     
+@context-action/react:           Rendering Efficiency:
+@context-action/react:           - Files list renders: 3 (only when files change)
+@context-action/react:           - Active upload renders: 8 (only when active upload changes)
+@context-action/react:           - Progress updates: 5 (no files list re-renders)
+@context-action/react:     
+@context-action/react:           Architecture Benefits:
+@context-action/react:           - ✅ Business logic testable in isolation
+@context-action/react:           - ✅ State management decoupled from business logic
+@context-action/react:           - ✅ Selective re-rendering prevents wasted renders
+@context-action/react:           - ✅ Batch updates with notifyPaths for efficiency
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:483:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Error State Management Proof:
+@context-action/react:           - Business logic validation: File size check
+@context-action/react:           - State transition: idle → error
+@context-action/react:           - Error message: "File size exceeds 10MB limit"
+@context-action/react:           - Selective rendering: Only state + error paths updated
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:563:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:           ✅ Complex Multi-file Upload Queue Proof:
+@context-action/react:     
+@context-action/react:           Queue Management:
+@context-action/react:           - Files processed: 3
+@context-action/react:           - Failed uploads: 0
+@context-action/react:           - Queue size: 3
+@context-action/react:     
+@context-action/react:           State Updates:
+@context-action/react:           - Per-file state transitions: idle → uploading → complete
+@context-action/react:           - Per-file progress updates: 5 updates per file
+@context-action/react:           - Global processing state: true → false
+@context-action/react:           - Current index tracking: -1 → 0 → 1 → 2 → -1
+@context-action/react:     
+@context-action/react:           Performance Benefits:
+@context-action/react:           - Selective path updates (queue[i].progress only)
+@context-action/react:           - Batch updates with notifyPaths
+@context-action/react:           - No unnecessary re-renders of other queue items
+@context-action/react:     
+@context-action/react:           Business Logic:
+@context-action/react:           - Queue orchestration separated from UI
+@context-action/react:           - State machine per file
+@context-action/react:           - Progress tracking independent of state changes
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-async-process.test.tsx[39m[0m[2m:673:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     All refs ready: { element1: HTMLDivElement {}, element2: HTMLButtonElement {} }
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/refs/createRefContext.test.tsx[39m[0m[2m:223:21)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:     🏪 Store 동시성 문제 분석 결과:
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:198:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     총 테스트: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:199:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Critical 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:200:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     High 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:201:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Medium 문제: 0
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/concurrency/store-concurrency.test.ts[39m[0m[2m:202:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🔄 [useMouseEventsLogic] Container unmounted, handlers deactivated
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:254:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🎯 [useMouseEventsLogic] Container mounted via reactive state
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:249:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     🚀 [useMouseEventsLogic] Handlers are now ready
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m../../example/src/pages/performance/mouse-events/enhanced-context-store/hooks/useMouseEventsLogic.ts[2m:252:15)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Dispatch references: [ '0: function', '1: function', '2: function' ]
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/actions/dispatch-stability.test.tsx[39m[0m[2m:209:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Unique dispatch references: 1
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/actions/dispatch-stability.test.tsx[39m[0m[2m:214:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     Store references across Provider re-creations:
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:291:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     0: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     1: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     2: counter=object, user=object
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat log ([22m[2m[0m[36m__tests__/stores/patterns/store-stability.test.tsx[39m[0m[2m:293:15)[22m[2m[22m
+@context-action/react: [2m          at Array.forEach (<anonymous>)[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     ✅ Immediate mode: Listeners triggered synchronously
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:56:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     ✅ Batched mode: Listeners deferred to RAF and batched
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:93:13)[22m[2m[22m
+@context-action/react:   [2mconsole.log[22m
+@context-action/react:     
+@context-action/react:     📊 Mode Comparison Results:
+@context-action/react:     - Immediate mode: 5 notifications (5 notifyPath calls = 5 notifications)
+@context-action/react:     - Batched mode before RAF: 0 notifications
+@context-action/react:     - Batched mode after RAF: 1 notifications (5 notifyPath calls = 1 batched notification)
+@context-action/react:     - Difference: 4x more notifications in immediate mode
+@context-action/react: [2m[22m
+@context-action/react: [2m      [2mat Object.log ([22m[2m[0m[36m__tests__/stores/notifyPath-mode-verification.test.tsx[39m[0m[2m:141:13)[22m[2m[22m
+@context-action/react: [1mTest Suites: [22m[1m[32m52 passed[39m[22m, 52 total
+@context-action/react: [1mTests:       [22m[1m[32m688 passed[39m[22m, 688 total
+@context-action/react: [1mSnapshots:   [22m0 total
+@context-action/react: [1mTime:[22m        2.605 s, estimated 3 s
+@context-action/react: [2mRan all test suites[22m[2m.[22m
+
+> @context-action/llms-generator:test
+
+@context-action/llms-generator: (node:87642) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: (node:87649) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `pnpm --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: > @context-action/llms-generator@0.8.7 test /Users/junwoobang/workflow/context-action/packages/llms-generator
+@context-action/llms-generator: > jest
+@context-action/llms-generator: (node:87674) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+@context-action/llms-generator: (Use `node --trace-warnings ...` to show where the warning was created)
+@context-action/llms-generator: [1mTest Suites: [22m[1m[32m15 passed[39m[22m, 15 total
+@context-action/llms-generator: [1mTests:       [22m[1m[32m224 passed[39m[22m, 224 total
+@context-action/llms-generator: [1mSnapshots:   [22m0 total
+@context-action/llms-generator: [1mTime:[22m        1.043 s
+@context-action/llms-generator: [2mRan all test suites[22m[2m.[22m
+
+
+
+ Lerna (powered by Nx)   Successfully ran target test for 10 projects
+
+
+
+> example@1.0.0 check /Users/junwoobang/workflow/context-action/example
+> biome check src && pnpm run verify:catalog && pnpm run verify:approval && pnpm run verify:trace && pnpm run verify:usecase && pnpm run verify:conditional && pnpm run verify:mouse-action && pnpm run verify:mouse-pattern && pnpm run verify:mouse-enhanced
+
+Checked 536 files in 177ms. No fixes applied.
+
+> example@1.0.0 verify:catalog /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-mcp-function-calling-catalog.mjs
+
+MCP/function-calling catalog contract check
+- UI catalog tool references checked: 7
+- standalone catalog tool references checked: 12
+- Live Code Editor catalog tool references checked: 8
+- realtime web-coding catalog tool references checked: 7
+- AI runner response-message history checked: 2 showcases
+- realtime local-agent source/mode contract checked
+- example tools/list/tools/call trace methods checked
+- example agent.request trace lifecycle checked
+- live editor agent/discovery trace lifecycle checked
+- live editor action/presentation boundary checked
+- live editor observability/settings/export boundaries checked
+- live editor document mutation/preview boundary checked
+- live editor workspace/document observability boundary checked
+- live editor reset approval boundary checked
+- realtime web-coding handler/action/presentation boundary checked
+- realtime web-coding observability/trace export boundary checked
+- realtime web-coding workspace action boundary checked
+- realtime web-coding shared document action boundary checked
+- realtime web-coding reset approval boundary checked
+
+> example@1.0.0 preverify:approval /Users/junwoobang/workflow/context-action/example
+> pnpm --filter @context-action/core build
+
+
+> @context-action/core@1.0.0 build /Users/junwoobang/workflow/context-action/packages/core
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/core/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: es2020
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 7 files
+ℹ [CJS] dist/index.cjs  113.21 kB │ gzip: 24.71 kB
+ℹ [CJS] 1 files, total: 113.21 kB
+ℹ [CJS] dist/index.d.cts.map   6.06 kB │ gzip: 2.10 kB
+ℹ [CJS] dist/index.d.cts      19.81 kB │ gzip: 4.50 kB
+ℹ [CJS] 2 files, total: 25.87 kB
+✔ Build complete in 688ms
+ℹ [ESM] dist/index.js        112.71 kB │ gzip: 24.64 kB
+ℹ [ESM] dist/index.js.map    268.68 kB │ gzip: 62.76 kB
+ℹ [ESM] dist/index.d.ts.map    6.06 kB │ gzip:  2.10 kB
+ℹ [ESM] dist/index.d.ts       19.81 kB │ gzip:  4.49 kB
+ℹ [ESM] 4 files, total: 407.25 kB
+✔ Build complete in 696ms
+
+> example@1.0.0 verify:approval /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-example-live-editor-approval.mjs
+
+Verified Live Code Editor filesystem approval lifecycle.
+
+> example@1.0.0 verify:trace /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-example-tool-call-trace.mjs
+
+Verified example tool trace provenance and no-raw-payload projection.
+
+> example@1.0.0 verify:usecase /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-live-usecase-conventions.mjs
+
+Live Code Editor usecase convention check
+- contexts: action + store providers
+- business: pure validation, packet, and activity functions
+- handlers: registry orchestration only
+- facade: reactive view model + stable commands
+- recipe: facade-driven presentation only
+
+> example@1.0.0 verify:conditional /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-conditional-permission-conventions.mjs
+
+Conditional permission usecase convention check
+- contexts: Action → Store provider boundary
+- business: pure role/action permission evaluation
+- actions: semantic check and secure-operation commands
+- handlers: Registry orchestration with fail-secure guard
+- page: facade-driven presentation and store subscriptions
+
+> example@1.0.0 verify:mouse-action /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-context-store-action-mouse-conventions.mjs
+
+Context-store action-based mouse convention check
+- contexts: Action + Store contracts and Provider boundary
+- business: pure path, velocity, and activity calculations
+- actions: typed handler factories using business rules
+- handlers: six action registrations in one Registry
+- compatibility: legacy store path re-export retained
+
+> example@1.0.0 verify:mouse-pattern /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-context-store-pattern-conventions.mjs
+
+Context-store pattern convention check
+- contexts: canonical boundary with legacy bridge isolated
+- provider: Action → Store → Registry composition
+- handlers: six mouse action registrations
+- consumers: no direct legacy context imports
+
+> example@1.0.0 verify:mouse-enhanced /Users/junwoobang/workflow/context-action/example
+> node ../scripts/verify-enhanced-context-store-conventions.mjs
+
+Enhanced context-store convention check
+- contexts: typed Store, Action, and Ref contracts
+- business: pure movement, click, activity, and metric rules
+- actions: semantic mouse command facade
+- provider: Action → Store → Ref → Registry composition
+- handlers: five action registrations outside the View
+- compatibility: legacy model path re-export retained
+
+> example@1.0.0 prebuild /Users/junwoobang/workflow/context-action/example
+> pnpm --filter @context-action/openrouter-browser-storage check && pnpm --filter @context-action/openrouter-browser-storage build
+
+
+> @context-action/openrouter-browser-storage@0.0.0 check /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage
+> pnpm exec biome check src
+
+Checked 1 file in 3ms. No fixes applied.
+
+> @context-action/openrouter-browser-storage@0.0.0 build /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/openrouter-browser-storage/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24.11.0
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+
+ WARN  We recommend using the ESM format instead of CommonJS.
+The ESM format is compatible with modern platforms and runtimes, and most new libraries are now distributed only in ESM format.
+Learn more at https://nodejs.org/en/learn/modules/publishing-a-package#how-did-we-get-here
+
+ℹ Cleaning 8 files
+ℹ [CJS] dist/index.cjs      2.80 kB │ gzip: 0.93 kB
+ℹ [CJS] dist/index.cjs.map  4.00 kB │ gzip: 1.43 kB
+ℹ [CJS] 2 files, total: 6.80 kB
+ℹ [ESM] dist/index.js        2.55 kB │ gzip: 0.87 kB
+ℹ [ESM] dist/index.js.map    4.00 kB │ gzip: 1.43 kB
+ℹ [ESM] dist/index.d.ts.map  0.13 kB │ gzip: 0.13 kB
+ℹ [ESM] dist/index.d.ts      0.57 kB │ gzip: 0.26 kB
+ℹ [ESM] 4 files, total: 7.25 kB
+✔ Build complete in 287ms
+ℹ [CJS] dist/index.d.cts.map  0.13 kB │ gzip: 0.13 kB
+ℹ [CJS] dist/index.d.cts      0.57 kB │ gzip: 0.27 kB
+ℹ [CJS] 2 files, total: 0.70 kB
+✔ Build complete in 287ms
+
+> example@1.0.0 build /Users/junwoobang/workflow/context-action/example
+> tsc && vite build
+
+vite v8.1.5 building client environment for production...
+[2Ktransforming...✓ 617 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/index.html                                                   2.23 kB │ gzip:   0.97 kB
+dist/assets/ChatPage-ubcKJM2V.css                                 1.21 kB │ gzip:   0.49 kB
+dist/assets/LiveCodeEditorPage-BGn3uVXL.css                       3.00 kB │ gzip:   1.07 kB
+dist/assets/PriorityPerformancePage-BJCO70AV.css                  4.87 kB │ gzip:   1.21 kB
+dist/assets/ToolContextAIDemo-ByChMvQp.css                        7.79 kB │ gzip:   1.91 kB
+dist/assets/LiveWebCodingPage-C_ERQ4ZK.css                       10.75 kB │ gzip:   2.83 kB
+dist/assets/tool-result-format-D5ejSXo7.css                      17.45 kB │ gzip:   4.07 kB
+dist/assets/index-BhQagSdA.css                                  103.05 kB │ gzip:  15.27 kB
+dist/assets/github-DKNKrW6Q.js                                    0.33 kB │ gzip:   0.23 kB
+dist/assets/rolldown-runtime-b3L32Ng1.js                          0.69 kB │ gzip:   0.42 kB
+dist/assets/useSourceLinkRegistration-CWVhPFw4.js                 0.87 kB │ gzip:   0.51 kB
+dist/assets/Container-Ccwmkx4I.js                                 0.97 kB │ gzip:   0.60 kB
+dist/assets/Status-1r9AZ6wY.js                                    1.26 kB │ gzip:   0.70 kB
+dist/assets/useRegisterSourceFile-WayGyomj.js                     1.53 kB │ gzip:   0.74 kB
+dist/assets/Card-BPUJpjf_.js                                      2.68 kB │ gzip:   0.97 kB
+dist/assets/SourceLink-HdIYjwXn.js                                2.69 kB │ gzip:   1.22 kB
+dist/assets/MemoizationPerformancePage-DBHqXQ12.js                2.93 kB │ gzip:   1.12 kB
+dist/assets/logger-C85UoTAn.js                                    3.45 kB │ gzip:   1.22 kB
+dist/assets/TimeTravelStore-DUxQtGfA.js                           4.61 kB │ gzip:   1.42 kB
+dist/assets/ActionGuardIndexPage-DclMNWOi.js                      5.38 kB │ gzip:   2.21 kB
+dist/assets/FoundationsOverview-C5z1NGuM.js                       5.46 kB │ gzip:   1.51 kB
+dist/assets/ActionLifecycleWorkbenchPage-CkAqq7QL.js              6.29 kB │ gzip:   2.65 kB
+dist/assets/ActionContext-ioSZTSlF.js                             6.67 kB │ gzip:   2.55 kB
+dist/assets/PerformanceOverview-Cyc5AM2e.js                       7.20 kB │ gzip:   1.78 kB
+dist/assets/WarningDemoPage-C8Jiv7II.js                           7.71 kB │ gzip:   2.75 kB
+dist/assets/time-travel-store-pattern-r--jf3PW.js                 7.83 kB │ gzip:   2.92 kB
+dist/assets/EnhancedContextStoreProvider-CC8zaAhl.js              7.93 kB │ gzip:   3.05 kB
+dist/assets/createRefContext-BK0td0DI.js                          8.26 kB │ gzip:   2.94 kB
+dist/assets/FormValidation-BdAR14LC.js                            8.30 kB │ gzip:   2.60 kB
+dist/assets/MouseEventsIndexPage-DoBxPp8m.js                      9.18 kB │ gzip:   2.32 kB
+dist/assets/WorkflowSteps-B7OdYVi7.js                             9.34 kB │ gzip:   3.01 kB
+dist/assets/ImplementationScenarioLibraryPage-Bedm-EDh.js         9.79 kB │ gzip:   3.10 kB
+dist/assets/UtilitiesOverview-Ce2DP4eI.js                        10.85 kB │ gzip:   2.63 kB
+dist/assets/TimeTravelTestPage-DGcvP6av.js                       11.02 kB │ gzip:   4.18 kB
+dist/assets/BasicsPage-BBArJN4n.js                               11.43 kB │ gzip:   4.18 kB
+dist/assets/DemoPage-DtEroLmR.js                                 11.45 kB │ gzip:   3.85 kB
+dist/assets/IntegrationsOverview-B0fTzzHV.js                     11.55 kB │ gzip:   3.30 kB
+dist/assets/ToastConfigPage-BERvzVel.js                          11.80 kB │ gzip:   3.99 kB
+dist/assets/ConditionalPatternsIndex-DzOPHhLP.js                 12.18 kB │ gzip:   3.38 kB
+dist/assets/FormBuilderPage-6QVcOZ1c.js                          12.65 kB │ gzip:   3.35 kB
+dist/assets/ToolContextAIDemo-Biag6pSw.js                        13.21 kB │ gzip:   5.09 kB
+dist/assets/FeatureToggle-BZoiazvN.js                            13.28 kB │ gzip:   4.10 kB
+dist/assets/ui-CvdPn6tv.js                                       13.33 kB │ gzip:   4.35 kB
+dist/assets/EnhancedAbortableSearchExample-CBzX7RLm.js           13.47 kB │ gzip:   4.62 kB
+dist/assets/ActionGuardOverview-us-0PrP4.js                      13.68 kB │ gzip:   3.10 kB
+dist/assets/ConcurrentActionsPage-C1AFQOdg.js                    13.81 kB │ gzip:   4.91 kB
+dist/assets/ExamplesUtilitiesOverview-ClN-Oer2.js                13.94 kB │ gzip:   3.33 kB
+dist/assets/ActionGuardContextStoreMouseEventsPage-CQNwmtBw.js   14.88 kB │ gzip:   5.18 kB
+dist/assets/HomePage-DzoTMJd1.js                                 14.94 kB │ gzip:   4.50 kB
+dist/assets/LegacyMouseEventsPage-CRKMFp_z.js                    15.07 kB │ gzip:   5.35 kB
+dist/assets/PatternsOverview-D4kq4gyt.js                         15.55 kB │ gzip:   3.40 kB
+dist/assets/AdvancedFilteringPage-Dv-zR17G.js                    16.40 kB │ gzip:   4.71 kB
+dist/assets/BasicsPage-CYdbuL4F.js                               17.00 kB │ gzip:   5.17 kB
+dist/assets/HooksPage-qfxHrtZv.js                                17.35 kB │ gzip:   6.02 kB
+dist/assets/tool-call-trace-BdnAafEP.js                          18.53 kB │ gzip:   6.57 kB
+dist/assets/UseRefMountStateTestPage-5xAQ3Ed-.js                 18.73 kB │ gzip:   5.94 kB
+dist/assets/AdvancedPage-c67NV9TB.js                             20.26 kB │ gzip:   6.25 kB
+dist/assets/ContextPage-BqGJU8nn.js                              21.38 kB │ gzip:   6.55 kB
+dist/assets/RefsIndexPage-DAhs-IcG.js                            21.50 kB │ gzip:   5.30 kB
+dist/assets/ProviderPage-C6H-ZiKP.js                             21.63 kB │ gzip:   5.64 kB
+dist/assets/WaitForRefsPerformancePage-DsiLKZQt.js               22.45 kB │ gzip:   5.35 kB
+dist/assets/DemosIndexPage-C7Ju5663.js                           24.14 kB │ gzip:   7.16 kB
+dist/assets/PermissionBasedExecution-PtudIGRv.js                 24.14 kB │ gzip:   7.48 kB
+dist/assets/CanvasRefDemoPage-Dl5tKKqC.js                        24.24 kB │ gzip:   6.33 kB
+dist/assets/SourceLinkDirectory-DUaL6tcx.js                      25.02 kB │ gzip:   7.64 kB
+dist/assets/CoreConceptsOverview-BvXdwCT6.js                     25.17 kB │ gzip:   5.80 kB
+dist/assets/LogMonitor-D_SjJVh3.js                               25.52 kB │ gzip:   8.26 kB
+dist/assets/ImmutabilityTestPage-BsyfyQ33.js                     26.83 kB │ gzip:   8.44 kB
+dist/assets/TimeTravelContextTestPage-DxuETKtW.js                27.02 kB │ gzip:   7.36 kB
+dist/assets/AccessRequestExamplePage-CKmkLdZj.js                 28.22 kB │ gzip:   7.93 kB
+dist/assets/RenewalRiskReviewExamplePage-D_lJsRHg.js             28.88 kB │ gzip:   8.13 kB
+dist/assets/ContextStoreActionPage-DJ6Agu_8.js                   29.90 kB │ gzip:   8.25 kB
+dist/assets/McpFunctionCallingCatalog-KuSQ1M9_.js                30.04 kB │ gzip:   7.92 kB
+dist/assets/IncidentEscalationExamplePage-CoMsHgN3.js            30.14 kB │ gzip:   8.22 kB
+dist/assets/FlowControlPlaygroundPageV2-Cwz6qLTx.js              30.76 kB │ gzip:   8.89 kB
+dist/assets/BusinessLogicPage-CehACubk.js                        31.39 kB │ gzip:   9.24 kB
+dist/assets/LoggerPage-CRglWGrQ.js                               31.69 kB │ gzip:   9.71 kB
+dist/assets/NonReactiveContextStorePage-B6N8Ss2P.js              32.81 kB │ gzip:   9.28 kB
+dist/assets/ChatPage-fIJqm76h.js                                 34.69 kB │ gzip:  10.86 kB
+dist/assets/LiveWebCodingPage-t--pAXbY.js                        36.17 kB │ gzip:  12.66 kB
+dist/assets/CanonicalOrderExamplePage-BqZ9uIOd.js                36.36 kB │ gzip:   9.69 kB
+dist/assets/EnhancedContextStorePage-6PLFBuO1.js                 37.54 kB │ gzip:  10.79 kB
+dist/assets/DemoPage-CWGEWOSG.js                                 38.12 kB │ gzip:  10.53 kB
+dist/assets/ThrottleComparisonPageRefactored-D54R_A9u.js         38.45 kB │ gzip:  10.04 kB
+dist/assets/ScrollPageRefactored-DajJO-7y.js                     38.80 kB │ gzip:   9.35 kB
+dist/assets/ApiBlockingPageRefactored-B6MynotF.js                42.05 kB │ gzip:  10.64 kB
+dist/assets/SearchPageRefactored-BqdewG0L.js                     43.50 kB │ gzip:  10.62 kB
+dist/assets/UseActionWithResultPage-CykoOTMW.js                  44.36 kB │ gzip:  11.99 kB
+dist/assets/CanvasPage-DQ1sq0HU.js                               50.80 kB │ gzip:  15.04 kB
+dist/assets/ActionRegister-DYcTScvM.js                           50.99 kB │ gzip:  13.49 kB
+dist/assets/ActionGuardPageRefactored-DLqR9xZk.js                51.74 kB │ gzip:  14.38 kB
+dist/assets/PriorityPerformancePage-BOGP1BmW.js                  51.75 kB │ gzip:  16.03 kB
+dist/assets/store-definition-DDz1VMMq.js                         58.54 kB │ gzip:  17.46 kB
+dist/assets/LayeredArchitecturePage-CZfwM0ie.js                  58.59 kB │ gzip:  15.62 kB
+dist/assets/ImperativeRefPage-CqUA0kVr.js                        87.04 kB │ gzip:  23.02 kB
+dist/assets/index-DJoCrtX8.js                                    87.17 kB │ gzip:  23.43 kB
+dist/assets/LiveCodeEditorPage-PvL-mEBg.js                       89.69 kB │ gzip:  30.29 kB
+dist/assets/tool-result-format-D7TCD8Nj.js                      144.61 kB │ gzip:  47.90 kB
+dist/assets/react-vendor-DmnbxDi2.js                            239.43 kB │ gzip:  77.60 kB
+dist/assets/openrouter-models-C5bSTcxO.js                       570.87 kB │ gzip: 140.43 kB
+
+[33m[PLUGIN_TIMINGS] [0mYour build spent significant time in plugin `@rolldown/plugin-babel`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.
+
+✓ built in 9.19s
+
+> context-action-monorepo@1.0.1 docs:build /Users/junwoobang/workflow/context-action
+> vitepress build docs
+
+
+  vitepress v1.6.4
+
+- building client + server bundles...
+[32m✓[0m building client + server bundles...
+- rendering pages...
+[32m✓[0m rendering pages...
+build complete in 31.99s.
+
+> context-action-monorepo@1.0.1 verify:private-tools /Users/junwoobang/workflow/context-action
+> node scripts/verify-private-tools.mjs
+
+
+> @context-action/style-testing@0.1.0 type-check /Users/junwoobang/workflow/context-action/packages/style-testing
+> tsc --noEmit
+
+
+> @context-action/style-testing@0.1.0 test /Users/junwoobang/workflow/context-action/packages/style-testing
+> pnpm run build && node --test test/*.test.mjs
+
+
+> @context-action/style-testing@0.1.0 build /Users/junwoobang/workflow/context-action/packages/style-testing
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/style-testing/tsdown.config.ts 
+ℹ entry: src/index.ts, src/cli/index.ts, src/analyzers/babel-plugin.ts
+ℹ target: node24
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 14 files
+ℹ Granting execute permission to dist/cli/index.js
+ℹ dist/cli/index.js                      4.08 kB │ gzip: 1.53 kB
+ℹ dist/analyzers/babel-plugin.js         1.21 kB │ gzip: 0.54 kB
+ℹ dist/index.js                          0.31 kB │ gzip: 0.19 kB
+ℹ dist/reporter-_x_EL2or.js.map         37.03 kB │ gzip: 9.68 kB
+ℹ dist/reporter-_x_EL2or.js             17.45 kB │ gzip: 4.84 kB
+ℹ dist/cli/index.js.map                  7.58 kB │ gzip: 2.52 kB
+ℹ dist/analyzers/babel-plugin.js.map     3.22 kB │ gzip: 1.21 kB
+ℹ dist/index.d.ts.map                    0.94 kB │ gzip: 0.49 kB
+ℹ dist/analyzers/babel-plugin.d.ts.map   0.17 kB │ gzip: 0.16 kB
+ℹ dist/index.d.ts                        3.42 kB │ gzip: 1.18 kB
+ℹ dist/analyzers/babel-plugin.d.ts       0.41 kB │ gzip: 0.26 kB
+ℹ dist/cli/index.d.ts                    0.01 kB │ gzip: 0.03 kB
+ℹ 12 files, total: 75.83 kB
+✔ Build complete in 581ms
+
+> @context-action/style-testing@0.1.0 postbuild /Users/junwoobang/workflow/context-action/packages/style-testing
+> pnpm verify:exports
+
+
+> @context-action/style-testing@0.1.0 verify:exports /Users/junwoobang/workflow/context-action/packages/style-testing
+> node scripts/verify-exports.mjs
+
+Verified 6 style-testing export artifacts.
+✔ the Babel plugin creates stable IDs and preserves explicitly supplied IDs (31.395625ms)
+✔ the extractor and diff engine agree on Tailwind-derived styles (3.779291ms)
+ℹ tests 2
+ℹ suites 0
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 300.295584
+Verified workspace-only tool package.
+
+> context-action-monorepo@1.0.1 release:roadmap:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-roadmap-alignment.mjs
+
+v1 release roadmaps aligned (6 invariants).
+
+> context-action-monorepo@1.0.1 docs:api /Users/junwoobang/workflow/context-action
+> typedoc --options ./typedoc.json
+
+[info] Loaded plugin typedoc-plugin-markdown
+[warning] The signature packages/core/src.ActionRegister.dispatch has an @param with name "payload", which was not used
+[warning] The signature packages/core/src.ActionRegister.dispatch has an @param with name "options", which was not used
+[warning] The signature packages/core/src.ActionRegister.dispatchWithResult has an @param with name "payload", which was not used
+[warning] The signature packages/core/src.ActionRegister.dispatchWithResult has an @param with name "options", which was not used
+[info] markdown generated at ./docs/api/generated
+[warning] Found 0 errors and 4 warnings
+
+> context-action-monorepo@1.0.1 docs:sync /Users/junwoobang/workflow/context-action
+> pnpm --filter @context-action/typedoc-vitepress-sync build && node packages/typedoc-vitepress-sync/bin/cli.js sync --config ./typedoc-vitepress-sync.config.js
+
+
+> @context-action/typedoc-vitepress-sync@0.8.8 build /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync
+> tsdown
+
+ℹ tsdown v0.22.13 powered by rolldown v1.2.0
+ℹ config file: /Users/junwoobang/workflow/context-action/packages/typedoc-vitepress-sync/tsdown.config.ts 
+ℹ entry: src/index.ts
+ℹ target: node24
+ℹ tsconfig: tsconfig.json
+ℹ Build start
+ℹ Cleaning 4 files
+ℹ dist/index.js         63.03 kB │ gzip: 15.72 kB
+ℹ dist/index.js.map    124.42 kB │ gzip: 29.50 kB
+ℹ dist/index.d.ts.map    3.66 kB │ gzip:  1.31 kB
+ℹ dist/index.d.ts       11.80 kB │ gzip:  2.91 kB
+ℹ 4 files, total: 202.92 kB
+✔ Build complete in 522ms
+- Initializing sync...
+[INFO] 🚀 TypeDoc VitePress Sync starting...
+[INFO] Cache manifest loaded: 304 entries
+[INFO] 📦 Processing package: core
+[INFO] 📦 Processing package: tool-protocol
+[INFO] 📦 Processing package: ai-sdk
+[INFO] 📦 Processing package: webmcp
+[INFO] 📦 Processing package: tool-durable-operations
+[INFO] 📦 Processing package: react
+[INFO] 🔍 Generating sidebar configuration...
+[INFO] Sidebar configuration generated: ./docs/.vitepress/config/api-spec.ts
+[INFO] Cache manifest saved: 304 entries
+[INFO] 📊 Metrics saved: ./reports/api-sync-metrics.json
+[INFO] 
+============================================================
+✅ TypeDoc VitePress Sync Complete!
+============================================================
+📄 Files processed: 0
+⏭️  Files skipped: 304
+⏱️  Processing time: 0.04s
+
+📊 Cache Statistics:
+  - Hit rate: 100.00%
+  - Hits: 304
+  - Misses: 0
+  - Expired: 0
+
+📋 Reports:
+  - Metrics: ./reports/api-sync-metrics.json
+✔ Documentation sync completed!
+
+📊 Sync Results:
+  Files Processed: 0
+  Files Skipped: 304 (cache hits)
+  Processing Time: 0.04s
+
+💾 Cache Performance:
+  Hit Rate: 100.00%
+  Cache Hits: 304
+  Cache Misses: 0
+
+⚡ Performance: Excellent
+  Average time per file: 0.14ms
+
+> context-action-monorepo@1.0.1 docs:build /Users/junwoobang/workflow/context-action
+> vitepress build docs
+
+
+  vitepress v1.6.4
+
+- building client + server bundles...
+[32m✓[0m building client + server bundles...
+- rendering pages...
+[32m✓[0m rendering pages...
+build complete in 33.19s.
+
+> context-action-monorepo@1.0.1 test:canonical-example /Users/junwoobang/workflow/context-action
+> pnpm --dir packages/react test:canonical-example
+
+
+> @context-action/react@1.0.0 test:canonical-example /Users/junwoobang/workflow/context-action/packages/react
+> jest --runInBand __tests__/patterns/implementation-playbook.integration.test.tsx
+
+Test Suites: 1 passed, 1 total
+Tests:       4 passed, 4 total
+Snapshots:   0 total
+Time:        0.763 s, estimated 1 s
+Ran all test suites matching __tests__/patterns/implementation-playbook.integration.test.tsx.

--- a/release-evidence/v1.0.0-stable-prepublish-3/logs/release-inventory.log
+++ b/release-evidence/v1.0.0-stable-prepublish-3/logs/release-inventory.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 release:inventory /Users/junwoobang/workflow/context-action
+> node scripts/generate-release-inventory.mjs
+
+Wrote inventory for 10 publishable packages to reports/release/v1.0.0/package-inventory.json

--- a/release-evidence/v1.0.0-stable-prepublish-3/logs/release-manifest.log
+++ b/release-evidence/v1.0.0-stable-prepublish-3/logs/release-manifest.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 verify:v1-release-manifest /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-manifest.mjs
+
+{"status":"ok","manifest":"docs/releases/v1.0.0/release-manifest.json","stage":"candidate-unapproved"}

--- a/release-evidence/v1.0.0-stable-prepublish-3/logs/roadmap.log
+++ b/release-evidence/v1.0.0-stable-prepublish-3/logs/roadmap.log
@@ -1,0 +1,5 @@
+
+> context-action-monorepo@1.0.1 release:roadmap:check /Users/junwoobang/workflow/context-action
+> node scripts/verify-v1-release-roadmap-alignment.mjs
+
+v1 release roadmaps aligned (6 invariants).

--- a/release-evidence/v1.0.0-stable-prepublish-3/manifest.json
+++ b/release-evidence/v1.0.0-stable-prepublish-3/manifest.json
@@ -1,0 +1,86 @@
+{
+  "schemaVersion": "context-action-release-evidence.v1",
+  "release": "context-action-v1.0.0",
+  "stage": "v1.0.0-stable-prepublish-3",
+  "commit": "6120279629dd95b712fb783b23da0b963642308e",
+  "roadmapRevision": "v1-r2",
+  "status": "recorded",
+  "generatedAt": "2026-08-09T09:34:34.597Z",
+  "workingTree": "clean",
+  "environment": {
+    "node": "v24.19.0",
+    "pnpm": "10.30.3",
+    "typescript": "6.0.3"
+  },
+  "commands": [
+    {
+      "id": "release-check",
+      "command": "pnpm release:check",
+      "startedAt": "2026-08-09T09:31:56.648Z",
+      "completedAt": "2026-08-09T09:34:23.717Z",
+      "durationMs": 147064,
+      "exitCode": 0,
+      "status": "passed",
+      "log": {
+        "path": "logs/release-check.log",
+        "sha256": "0280eab8dfb974724c793995c75bd8af3e5f7fc0d37bf5d948cea2f0aa802ec2"
+      }
+    },
+    {
+      "id": "release-inventory",
+      "command": "pnpm release:inventory",
+      "startedAt": "2026-08-09T09:34:23.720Z",
+      "completedAt": "2026-08-09T09:34:34.144Z",
+      "durationMs": 10424,
+      "exitCode": 0,
+      "status": "passed",
+      "log": {
+        "path": "logs/release-inventory.log",
+        "sha256": "83e43a96e88509e6c1c9d13d13d3e29f56790a410c9cb758ad6c4c40dcb1917a"
+      }
+    },
+    {
+      "id": "release-manifest",
+      "command": "pnpm verify:v1-release-manifest",
+      "startedAt": "2026-08-09T09:34:34.144Z",
+      "completedAt": "2026-08-09T09:34:34.394Z",
+      "durationMs": 250,
+      "exitCode": 0,
+      "status": "passed",
+      "log": {
+        "path": "logs/release-manifest.log",
+        "sha256": "c5d2c42c377d9e7ba5a0e25bcbf914f3465afe92ac98d572b54b6dccb2d7462b"
+      }
+    },
+    {
+      "id": "roadmap",
+      "command": "pnpm release:roadmap:check",
+      "startedAt": "2026-08-09T09:34:34.394Z",
+      "completedAt": "2026-08-09T09:34:34.594Z",
+      "durationMs": 200,
+      "exitCode": 0,
+      "status": "passed",
+      "log": {
+        "path": "logs/roadmap.log",
+        "sha256": "a6397257031ab3026f8acee7dc889c475ed02913f65f01dc4702c589cf422b6a"
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "sourcePath": "docs/releases/v1.0.0/release-manifest.json",
+      "path": "artifacts/01-release-manifest.json",
+      "sha256": "b00df503219439988367ff24da83577cb6cf39b2bab193f5fdbd5de3b0269a75",
+      "bytes": 930
+    },
+    {
+      "sourcePath": "pnpm-lock.yaml",
+      "path": "artifacts/02-pnpm-lock.yaml",
+      "sha256": "4389233d0ad91cf319cbcca79d8f02757d742b1d04a75dd6d95e6cef4f5be35e",
+      "bytes": 458812
+    }
+  ],
+  "notes": [
+    "Stable candidate prepared for next-tag publication; registry provenance, independent audit, and latest promotion remain pending."
+  ]
+}


### PR DESCRIPTION
## Historical release evidence

Commits the previously untracked clean evidence bundle under **CA-1X-RELEASE-001**. It is bound to ancestor commit `6120279629dd95b712fb783b23da0b963642308e`; its strict verifier must run from that exact checkout, so it is preserved as historical evidence rather than current promotion authorization.

No version, registry tag, workflow, or source behavior changes.