### PR TITLE
fix(release): wait for promoted npm metadata

### DIFF
--- a/scripts/verify-published-tool-consumers.cjs
+++ b/scripts/verify-published-tool-consumers.cjs
@@ -104,12 +104,22 @@ function validVersion(value) {
     && /^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/u.test(value);
 }
 
-function publishedVersion(name, tag) {
+function expectedPublishedVersion({ name, directory }) {
   const entry = Array.isArray(summary)
     ? summary.find((item) => item?.packageName === name)
     : undefined;
   if (validVersion(entry?.version)) return entry.version;
 
+  const packageManifest = JSON.parse(
+    readFileSync(path.join(repositoryRoot, directory, 'package.json'), 'utf8'),
+  );
+  if (!validVersion(packageManifest.version)) {
+    throw new Error(`Package manifest has an invalid version for ${name}: ${packageManifest.version}`);
+  }
+  return packageManifest.version;
+}
+
+function publishedVersion(name, tag, expectedVersion) {
   const output = execFileSync(
     'npm',
     ['view', tag ? `${name}@${tag}` : name, 'version', '--registry=https://registry.npmjs.org'],
@@ -118,14 +128,21 @@ function publishedVersion(name, tag) {
   if (!validVersion(output)) {
     throw new Error(`npm returned an invalid published version for ${name}: ${output}`);
   }
+  if (expectedVersion && output !== expectedVersion) {
+    throw new Error(
+      `npm dist-tag ${tag} for ${name} still resolves to ${output}; expected ${expectedVersion}`,
+    );
+  }
   return output;
 }
 
-function waitForPublishedVersion(name, tag) {
+function waitForPublishedVersion(packageDefinition, tag) {
+  const { name } = packageDefinition;
+  const expectedVersion = expectedPublishedVersion(packageDefinition);
   const attempts = 30;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      const version = publishedVersion(name, tag);
+      const version = publishedVersion(name, tag, expectedVersion);
       if (attempt > 1) {
         process.stdout.write(`npm metadata became visible after ${attempt} attempts.\n`);
       }
@@ -328,8 +345,9 @@ function main() {
   try {
     const packageSpecs = local
       ? createLocalPackageSpecs(consumerRoot).filter(({ name }) => selectedPackages.some(pkg => pkg.name === name))
-      : selectedPackages.map(({ name }) => {
-          const version = waitForPublishedVersion(name, tag);
+      : selectedPackages.map((packageDefinition) => {
+          const { name } = packageDefinition;
+          const version = waitForPublishedVersion(packageDefinition, tag);
           return { name, spec: `${name}@${version}` };
         });
     packageSpecs.push(...consumerRuntimeDependencies);


### PR DESCRIPTION
## Summary
- makes the published-consumer verifier require each requested package to resolve to its exact current release version
- retries while npm serves a stale dist-tag response, rather than installing a prior version immediately after promotion
- preserves the promotion workflow's rollback until the exact stable cohort passes its consumer matrix

## Traceability
- `CA-1X-RELEASE-001` — stable-release promotion integrity

## Incident evidence
Promotion run `31345573085` passed authentication, provenance, and authorization, retagged all three stable packages, then installed stale `@context-action/react@0.9.2` while `latest` propagation was pending. The consumer check failed and the workflow automatically restored all prior tags.

## Validation
- `pnpm verify:published-tool-consumers -- --tag next --packages '@context-action/core,@context-action/react,@context-action/tool-protocol'`
- `pnpm lint`
- `git diff --check`

Owner-authorized self-review exception applies.