### PR TITLE
fix(release): fingerprint stable consumer verifier

### DIFF
--- a/scripts/verify-v1-promotion-governance.mjs
+++ b/scripts/verify-v1-promotion-governance.mjs
@@ -14,6 +14,7 @@ const governedFiles = [
   'scripts/verify-v1-promotion-authorization.mjs',
   'scripts/verify-v1-promotion-governance.mjs',
   'scripts/verify-v1-published-provenance.mjs',
+  'scripts/verify-published-tool-consumers.cjs',
   'scripts/verify-v1-release-manifest.mjs',
   'scripts/verify-v1-release-workflows.mjs',
 ];


### PR DESCRIPTION
## Summary
- includes `verify-published-tool-consumers.cjs` in the v1 promotion-governance fingerprint
- ensures future promotion authorization cannot reuse governance evidence after the stable-consumer verifier changes

## Traceability
- `CA-1X-RELEASE-001` — stable-release promotion integrity

## Validation
- `node scripts/verify-v1-promotion-governance.mjs`
- `pnpm verify:v1-release-workflows`
- `pnpm lint`
- `git diff --check`

A new clean governance evidence bundle and manifest binding will follow this merged control update before the protected promotion is retried.