### PR TITLE
chore(release): record v1 stable promotion

### DIFF
--- a/docs/releases/v1.0.0/readiness.md
+++ b/docs/releases/v1.0.0/readiness.md
@@ -1,6 +1,6 @@
 # v1.0.0 Release Readiness Report
 
-**Verdict:** `APPROVED-FOR-STABLE — protected promotion pending`
+**Verdict:** `PROMOTED — stable surfaces at latest`
 **Roadmap revision:** `v1-r2`
 
 This report links the current implementation work to the release gates. The
@@ -79,13 +79,17 @@ This publication predates the protected publish authorization gate. The final
 versions are immutable; do not republish them to “repair” documentation or
 metadata. A release defect requires a corrected patch version.
 
-## Remaining release blockers
+## Stable promotion result
 
-1. Run the guarded `latest` promotion under the owner-authorized self-review
-   exception. The workflow performs provenance, stable-consumer, rollback,
-   and evidence checks without a second reviewer.
-2. Commit the captured promotion evidence and advance the manifest to
-   `promoted` only after its registry checks succeed.
+The protected promotion workflow run `31347327623` completed successfully on
+2026-08-10. It promoted Core, React, and Tool Protocol `1.0.0` to `latest`,
+passed the exact-version CJS/ESM/NodeNext/React 18/19 consumer matrix, and
+captured fresh registry plus provenance evidence at
+`release-evidence/v1.0.0-stable-promotion-31347327623/`.
+
+WebMCP remains excluded from the stable set: its versioned hygiene patch
+`0.1.1` owns its `latest` tag while the immutable `0.1.0` candidate remains
+on `next`.
 
 No document alone authorizes a release to `latest`; the protected workflow is
 the only path that can mutate stable tags.

--- a/docs/releases/v1.0.0/release-manifest.json
+++ b/docs/releases/v1.0.0/release-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./release-manifest.schema.json",
   "schemaVersion": "context-action-v1-release-manifest.v6",
-  "status": "approved-for-stable",
+  "status": "promoted",
   "release": "context-action-v1.0.0",
   "commit": "63f790a521e3428a7a2825677747338f8f05ccf3",
   "distTag": "next",
@@ -12,7 +12,7 @@
       "sha256": "d83869e72cfbb46da0a581bf23bb77195f8fb0254dbe64ff6da98625b5837c08",
       "tarball": "https://registry.npmjs.org/@context-action/core/-/core-1.0.0.tgz",
       "publishedAt": "2026-08-09T10:13:18.315Z",
-      "distTags": { "latest": "0.9.2", "rc": "1.0.0-rc.0", "next": "1.0.0" },
+      "distTags": { "latest": "1.0.0", "rc": "1.0.0-rc.0", "next": "1.0.0" },
       "provenance": {
         "status": "verified",
         "sourceCommit": "63f790a521e3428a7a2825677747338f8f05ccf3",
@@ -29,7 +29,7 @@
       "sha256": "f5dae62522137ee912afff9e589e6381110a1ba807b0cd07853f5cab5d4306c3",
       "tarball": "https://registry.npmjs.org/@context-action/react/-/react-1.0.0.tgz",
       "publishedAt": "2026-08-09T10:13:35.051Z",
-      "distTags": { "latest": "0.9.2", "rc": "1.0.0-rc.0", "next": "1.0.0" },
+      "distTags": { "latest": "1.0.0", "rc": "1.0.0-rc.0", "next": "1.0.0" },
       "provenance": {
         "status": "verified",
         "sourceCommit": "63f790a521e3428a7a2825677747338f8f05ccf3",
@@ -46,7 +46,7 @@
       "sha256": "8e8b1e67ca3854351f3f0a2bba16fa71f08d15530db971c22cdb3321193d06bf",
       "tarball": "https://registry.npmjs.org/@context-action/tool-protocol/-/tool-protocol-1.0.0.tgz",
       "publishedAt": "2026-08-09T10:13:10.741Z",
-      "distTags": { "latest": "0.8.8", "next": "1.0.0", "rc": "1.0.0-rc.0" },
+      "distTags": { "latest": "1.0.0", "next": "1.0.0", "rc": "1.0.0-rc.0" },
       "provenance": {
         "status": "verified",
         "sourceCommit": "63f790a521e3428a7a2825677747338f8f05ccf3",
@@ -81,7 +81,11 @@
     "evidenceSha256": "2c266ff7d1520b25ab70691eaaf1501af83296b7208dcc45a699f66afa998978",
     "fingerprintSha256": "2109ef32ab6c3ae94689d320e08e206cb4d47b68e884b1338b423086e499d34e"
   },
-  "promotionEvidence": null,
+  "promotionEvidence": {
+    "status": "captured",
+    "workflowRun": "https://github.com/mineclover/context-action/actions/runs/31347327623",
+    "checkedAt": "2026-08-10T01:32:49.793Z"
+  },
   "registryHygiene": {
     "status": "cleared",
     "evidence": "Protected workflow run 31341251251 verified @context-action/webmcp@0.1.1 at latest, preserved next=0.1.0 and rc=0.1.0-rc.0, and passed the latest external-consumer check. Evidence: release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json. WebMCP is experimental and excluded from the v1 stable-promotion target set.",

--- a/docs/releases/v1.0.0/status.md
+++ b/docs/releases/v1.0.0/status.md
@@ -1,7 +1,7 @@
 # Context-Action v1.0.0 Release Status
 
-**Status:** `APPROVED-FOR-STABLE — protected promotion pending`<br>
-**Baseline commit:** `1a77f373ade554fb959fe17aac7b7c1157aa74f5` (current single-maintainer governance evidence)<br>
+**Status:** `PROMOTED — stable surfaces at latest`<br>
+**Baseline commit:** `17d6ddb2ddd8c6e23078a38db0fd0eb2647c3666` (protected promotion dispatch commit)<br>
 **Roadmap revision:** `v1-r2`<br>
 **Last synchronized:** 2026-08-10
 
@@ -82,11 +82,22 @@ remain fail-closed before any publication attempt.
 
 ## Immediate next work
 
-1. Run the protected `npm-stable` promotion under the documented
-   owner-authorized self-review exception; it will reverify source provenance
-   and the stable-surface consumer matrix.
-2. Record the captured post-promotion registry evidence before declaring the
-   promotion complete.
+1. Preserve the promotion artifact from protected workflow run `31347327623`
+   with its registry and provenance results.
+2. Review the v1 specification set against the now-stable package surfaces.
+
+## Stable promotion result
+
+Protected workflow run `31347327623` completed successfully on 2026-08-10.
+It reverified npm provenance for the published cohort, promoted only
+`@context-action/tool-protocol@1.0.0`, `@context-action/core@1.0.0`, and
+`@context-action/react@1.0.0`, waited for the exact `latest` metadata, and
+passed the CJS/ESM/NodeNext/React 18/19 consumer matrix. Captured artifacts are
+stored at `release-evidence/v1.0.0-stable-promotion-31347327623/`.
+
+`@context-action/webmcp` remains experimental: `latest` is the separately
+published hygiene patch `0.1.1`; its original `0.1.0` candidate remains on
+`next` and was not part of the stable-surface promotion.
 
 ## Development evidence
 

--- a/release-evidence/v1.0.0-stable-promotion-31347327623/npm-v1-promotion-registry-evidence.json
+++ b/release-evidence/v1.0.0-stable-promotion-31347327623/npm-v1-promotion-registry-evidence.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "context-action-published-release-evidence.v1",
+  "capturedAt": "2026-08-10T01:32:49.793Z",
+  "distTag": "latest",
+  "packages": {
+    "@context-action/core": {
+      "version": "1.0.0",
+      "integrity": "sha512-WVMCxAwZkoMTQZYgL9Ha7OqKWEQxu7Z9R6DnxcdLcFQXWEEDIVyzL4hKojTmMRwh1BFup7zirbfITSkX5vIEXQ==",
+      "tarball": "https://registry.npmjs.org/@context-action/core/-/core-1.0.0.tgz",
+      "sha256": "d83869e72cfbb46da0a581bf23bb77195f8fb0254dbe64ff6da98625b5837c08",
+      "publishedAt": "2026-08-09T10:13:18.315Z",
+      "distTags": { "latest": "1.0.0", "rc": "1.0.0-rc.0", "next": "1.0.0" },
+      "provenance": { "status": "pending-verification", "sourceCommit": null },
+      "externalConsumer": { "status": "passed" }
+    },
+    "@context-action/react": {
+      "version": "1.0.0",
+      "integrity": "sha512-35KHuhJ1liCkPUF7h2s9Nef/rtWkfYK1L3f30fioniK7aUFsBK4YoW+Yk73NKBqVpIW3XlWkeVJMoQPeuYozmQ==",
+      "tarball": "https://registry.npmjs.org/@context-action/react/-/react-1.0.0.tgz",
+      "sha256": "f5dae62522137ee912afff9e589e6381110a1ba807b0cd07853f5cab5d4306c3",
+      "publishedAt": "2026-08-09T10:13:35.051Z",
+      "distTags": { "latest": "1.0.0", "rc": "1.0.0-rc.0", "next": "1.0.0" },
+      "provenance": { "status": "pending-verification", "sourceCommit": null },
+      "externalConsumer": { "status": "passed" }
+    },
+    "@context-action/tool-protocol": {
+      "version": "1.0.0",
+      "integrity": "sha512-sOW7dwTajB+j0N0prU7T3fmnJaDkLzZNegRHr2y9pBoZuEeEaOv+olOBN7zRSzPYLBDCD8DyT/eN/SVq8F8Alg==",
+      "tarball": "https://registry.npmjs.org/@context-action/tool-protocol/-/tool-protocol-1.0.0.tgz",
+      "sha256": "8e8b1e67ca3854351f3f0a2bba16fa71f08d15530db971c22cdb3321193d06bf",
+      "publishedAt": "2026-08-09T10:13:10.741Z",
+      "distTags": { "latest": "1.0.0", "rc": "1.0.0-rc.0", "next": "1.0.0" },
+      "provenance": { "status": "pending-verification", "sourceCommit": null },
+      "externalConsumer": { "status": "passed" }
+    }
+  },
+  "notes": [
+    "Tarball SHA-256 and registry metadata were read after publication.",
+    "The adjacent provenance artifact independently verifies the source commit for the complete published cohort."
+  ]
+}

--- a/release-evidence/v1.0.0-stable-promotion-31347327623/npm-v1-provenance-verification.json
+++ b/release-evidence/v1.0.0-stable-promotion-31347327623/npm-v1-provenance-verification.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "context-action-v1-provenance-verification.v1",
+  "status": "verified",
+  "verifier": "npm audit signatures --include-attestations",
+  "verifiedAt": "2026-08-10T01:32:25.626Z",
+  "sourceCommit": "63f790a521e3428a7a2825677747338f8f05ccf3",
+  "packages": [
+    { "name": "@context-action/core", "version": "1.0.0", "sourceCommit": "63f790a521e3428a7a2825677747338f8f05ccf3", "workflow": { "repository": "https://github.com/mineclover/context-action", "path": ".github/workflows/publish-v1-stable-candidate.yml", "ref": "refs/heads/main" }, "run": "https://github.com/mineclover/context-action/actions/runs/31307576721/attempts/1", "attestationUrl": "https://registry.npmjs.org/-/npm/v1/attestations/@context-action%2fcore@1.0.0" },
+    { "name": "@context-action/react", "version": "1.0.0", "sourceCommit": "63f790a521e3428a7a2825677747338f8f05ccf3", "workflow": { "repository": "https://github.com/mineclover/context-action", "path": ".github/workflows/publish-v1-stable-candidate.yml", "ref": "refs/heads/main" }, "run": "https://github.com/mineclover/context-action/actions/runs/31307576721/attempts/1", "attestationUrl": "https://registry.npmjs.org/-/npm/v1/attestations/@context-action%2freact@1.0.0" },
+    { "name": "@context-action/tool-protocol", "version": "1.0.0", "sourceCommit": "63f790a521e3428a7a2825677747338f8f05ccf3", "workflow": { "repository": "https://github.com/mineclover/context-action", "path": ".github/workflows/publish-v1-stable-candidate.yml", "ref": "refs/heads/main" }, "run": "https://github.com/mineclover/context-action/actions/runs/31307576721/attempts/1", "attestationUrl": "https://registry.npmjs.org/-/npm/v1/attestations/@context-action%2ftool-protocol@1.0.0" },
+    { "name": "@context-action/webmcp", "version": "0.1.0", "sourceCommit": "63f790a521e3428a7a2825677747338f8f05ccf3", "workflow": { "repository": "https://github.com/mineclover/context-action", "path": ".github/workflows/publish-v1-stable-candidate.yml", "ref": "refs/heads/main" }, "run": "https://github.com/mineclover/context-action/actions/runs/31307576721/attempts/1", "attestationUrl": "https://registry.npmjs.org/-/npm/v1/attestations/@context-action%2fwebmcp@0.1.0" }
+  ]
+}


### PR DESCRIPTION
## Summary
- records successful protected promotion run `31347327623`
- advances the v1 release manifest to `promoted`
- captures registry and independently verified provenance artifacts
- documents Core, React, and Tool Protocol `1.0.0` at `latest`; WebMCP remains experimental at its versioned `0.1.1` hygiene-patch latest

## Traceability
- `CA-1X-RELEASE-001` — stable-release promotion integrity

## Validation
- `pnpm verify:v1-release-manifest`
- `pnpm docs:management`
- `pnpm docs:build`
- `git diff --check`

Promotion workflow: https://github.com/mineclover/context-action/actions/runs/31347327623