### PR TITLE
docs(release): align v1 specs with stable promotion

### DIFF
--- a/docs/releases/v1.0.0/contract-candidates.md
+++ b/docs/releases/v1.0.0/contract-candidates.md
@@ -1,21 +1,23 @@
 # v1.0.0 Contract Candidates
 
-**Status:** `candidate — not approved for the 1.x promise`  
+**Status:** `promoted stable contracts; experimental entries retained`
 **Roadmap revision:** `v1-r2`
 
-This registry makes the M1 implementation facts reviewable. It is not an ADR
-and does not change the release verdict. An entry becomes a public contract
-when its documented scope and named automated evidence are recorded.
+This registry makes the M1 implementation facts reviewable. For the documented
+stable surfaces, the protected v1 promotion makes these entries part of the
+1.x public contract. WebMCP entries remain experimental and are not included in
+that promise.
 
 | Surface | Candidate behavior | Implementation evidence | Required gate evidence |
 | --- | --- | --- | --- |
-| Core handler roles | A handler ID cannot replace a different role; guards run before result handlers; observers run only after the terminal result. | `packages/core/src/ActionRegister.ts` | G1, G2, G3 |
-| `once` handlers | The once claim is made before invocation, including concurrent dispatch. | `packages/core/src/ActionRegister.ts` | G2, G3 |
-| Retry/lifecycle | A retry must abort and drain a race attempt before another attempt starts. | `packages/core/src/ActionRegister.ts` | G3 |
-| ToolContext | `@context-action/react/tools` is the stable-candidate ToolContext boundary and must not export WebMCP APIs. | `packages/react/src/tools/index.ts` | G1, G4, G6 |
-| React WebMCP hook | `@context-action/react/webmcp` is experimental, browser-only, and separately imported. | `packages/react/src/webmcp.ts` | G4, G5, G6 |
-| WebMCP notifications | `afterExecute` is the only detached post-commit observer. | `packages/webmcp/src/index.ts` | G5 |
+| Core handler roles | A handler ID cannot replace a different role; guards run before result handlers; observers run only after the terminal result. | `packages/core/src/ActionRegister.ts` | promoted Core provenance plus lifecycle and migration checks |
+| `once` handlers | The once claim is made before invocation, including concurrent dispatch. | `packages/core/src/ActionRegister.ts` | promoted Core provenance plus lifecycle checks |
+| Retry/lifecycle | A retry must abort and drain a race attempt before another attempt starts. | `packages/core/src/ActionRegister.ts` | `verify:v1-lifecycle` and clean governance evidence |
+| ToolContext | `@context-action/react/tools` is the stable ToolContext boundary and must not export WebMCP APIs. | `packages/react/src/tools/index.ts` | promoted React consumer matrix and `verify:react-webmcp-isolation` |
+| React WebMCP hook | `@context-action/react/webmcp` is experimental, browser-only, and separately imported. | `packages/react/src/webmcp.ts` | export/isolation checks; excluded from stable promotion targets |
+| WebMCP notifications | `afterExecute` is the only detached post-commit observer. | `packages/webmcp/src/index.ts` | experimental adapter regression coverage; not a v1 stable contract |
 
-The package/subpath inventory produced by `pnpm release:inventory` is the
-input for approving these candidates. Record its JSON output through
-`pnpm release:evidence:write`; do not infer approval from this table.
+The package/subpath inventory produced by `pnpm release:inventory` remains the
+input for future contract changes. Record its JSON output through
+`pnpm release:evidence:write`; a table edit alone never changes an npm tag or
+expands the stable surface.

--- a/docs/releases/v1.0.0/known-limitations.md
+++ b/docs/releases/v1.0.0/known-limitations.md
@@ -1,6 +1,6 @@
-# v1.0.0 Candidate Known Limitations
+# v1.0.0 Known Limitations
 
-**Status:** `owner-operated candidate — not yet promoted`
+**Status:** `owner-operated promoted release`
 **Roadmap revision:** `v1-r2`
 
 - `@context-action/react/webmcp` and `@context-action/webmcp` are experimental
@@ -12,9 +12,10 @@
   completed execution.
 - The development evidence bundles were generated from a dirty working tree.
   They demonstrate reproducibility but cannot certify an RC or final artifact.
-- The published `next` consumer matrix and npm registry provenance verification
+- The promoted `latest` consumer matrix and npm registry provenance verification
   have passed. The single-maintainer policy does not impose an unavailable
-  independent-auditor gate; promotion remains protected by automated checks.
+  independent-auditor gate; future promotions remain protected by automated
+  checks.
 - `@context-action/tool-protocol@1.0.0` bundles a `CHANGELOG.md` whose newest
   entry is `0.8.9`. The immutable artifact cannot be repaired in place; the
   canonical v1.0.0 notes are this release document set and the GitHub release.
@@ -29,4 +30,4 @@
   stable-promotion target set.
 
 Report any newly discovered P0/P1 issue in the issue ledger and reopen the
-affected gate before approving an RC.
+affected gate before preparing a future stable patch or minor.

--- a/docs/releases/v1.0.0/legacy-ledger.md
+++ b/docs/releases/v1.0.0/legacy-ledger.md
@@ -1,22 +1,22 @@
 # v1.0.0 Legacy Outcome Ledger
 
-**Status:** `candidate decisions — owner operated`
+**Status:** `resolved for the promoted v1 stable scope`
 **Roadmap revision:** `v1-r2`
 
-Every compatibility surface below has a named owner and a required outcome.
-Until the outcomes are approved, this ledger intentionally keeps the release
-status at `NOT READY`.
+Every compatibility surface below has a named owner and a recorded outcome.
+The Core and stable React outcomes are part of the promoted v1 contract;
+WebMCP outcomes remain explicitly experimental.
 
 | ID | Surface | Current replacement | Required 1.x decision | Evidence still required |
 | --- | --- | --- | --- | --- |
-| CA-1X-LEGACY-001 | `ActionRegister.registerEffect()` | `registerGuard()` or `registerObserver()` | **candidate retain-1x:** documented dynamic-role convenience API; `effectKind` remains mandatory | `verify:v1-core-migration`; Core type/runtime coverage |
-| CA-1X-LEGACY-002 | `HandlerConfig.blocking` | explicit `scheduling` and `errorPolicy` | **candidate retain-1x:** exact normalization in `resolveHandlerConfig()` through 1.x | `verify:v1-core-migration`; Core parity coverage |
-| CA-1X-LEGACY-003 | generic `register()` role | `registerGuard`, `registerResult`, or `registerObserver` when a specific phase is intended | **candidate retain-1x:** generic result registration as the default handler API | `verify:v1-core-migration`; public type snapshot |
-| CA-1X-LEGACY-004 | WebMCP `beforeExecute` | `afterExecute` | **candidate remove:** deprecated post-commit alias is removed | WebMCP/React negative type test and adapter regression |
-| CA-1X-LEGACY-005 | WebMCP `errorMode: 'result'` | `errorMode: 'structured'` | **candidate remove:** ambiguous alias is removed | `webmcp-error-mode.type-safety.test.ts`, package/export consumer evidence |
-| CA-1X-WEBMCP-001 | WebMCP React hook on `@context-action/react/tools` | `@context-action/react/webmcp` | **candidate experimental:** isolated experimental subpath | `verify:react-webmcp-isolation`, package/export consumer evidence |
-| CA-1X-LEGACY-006 | internal void executor | canonical result dispatch path | **candidate remove:** unused `_performDispatch()` is removed; `dispatch()` delegates to `_performDispatchWithResult()` | Core focused regression evidence |
+| CA-1X-LEGACY-001 | `ActionRegister.registerEffect()` | `registerGuard()` or `registerObserver()` | **retain-1x:** documented dynamic-role convenience API; `effectKind` remains mandatory | `verify:v1-core-migration`; Core type/runtime coverage |
+| CA-1X-LEGACY-002 | `HandlerConfig.blocking` | explicit `scheduling` and `errorPolicy` | **retain-1x:** exact normalization in `resolveHandlerConfig()` through 1.x | `verify:v1-core-migration`; Core parity coverage |
+| CA-1X-LEGACY-003 | generic `register()` role | `registerGuard`, `registerResult`, or `registerObserver` when a specific phase is intended | **retain-1x:** generic result registration as the default handler API | `verify:v1-core-migration`; public type snapshot |
+| CA-1X-LEGACY-004 | WebMCP `beforeExecute` | `afterExecute` | **experimental remove:** deprecated post-commit alias is removed outside the stable v1 promise | WebMCP/React negative type test and adapter regression |
+| CA-1X-LEGACY-005 | WebMCP `errorMode: 'result'` | `errorMode: 'structured'` | **experimental remove:** ambiguous alias is removed outside the stable v1 promise | `webmcp-error-mode.type-safety.test.ts`, package/export consumer evidence |
+| CA-1X-WEBMCP-001 | WebMCP React hook on `@context-action/react/tools` | `@context-action/react/webmcp` | **experimental:** isolated experimental subpath | `verify:react-webmcp-isolation`, package/export consumer evidence |
+| CA-1X-LEGACY-006 | internal void executor | canonical result dispatch path | **remove:** unused `_performDispatch()` is removed; `dispatch()` delegates to `_performDispatchWithResult()` | Core focused regression evidence |
 
-No row may be silently removed. When a decision is made, replace
-`decision-needed` with `remove`, `retain-1x`, or `experimental`, state the
-owner and target version, and link the immutable evidence manifest entry.
+No row may be silently removed. A future change must state the owner and target
+version, update this outcome, and link immutable evidence before expanding or
+contracting a stable surface.

--- a/docs/releases/v1.0.0/migration.md
+++ b/docs/releases/v1.0.0/migration.md
@@ -1,11 +1,11 @@
-# v1.0 to v1.0.0 Candidate Migration Guide
+# v1.0.0 Migration Guide
 
-**Status:** `documented candidate — owner operated`
+**Status:** `promoted stable-surface guide — owner operated`
 **Roadmap revision:** `v1-r2`
 
-This guide covers the compatibility decisions implemented in the v1 candidate.
-It is not a release announcement; use the published release notes and recorded
-version map for an actual upgrade.
+This guide covers the compatibility decisions in the promoted v1.0.0 stable
+surfaces. Use the release manifest and published release notes for the exact
+version map; WebMCP guidance remains experimental.
 
 ## Core handlers
 
@@ -54,4 +54,5 @@ unsupported/SSR inert scope and must not rely on it as a stable 1.x contract.
 
 The packed Core consumer fixture is run by `pnpm verify:v1-core-migration`.
 The experimental WebMCP type removals are covered by the WebMCP test suite.
-Run the appropriate packed-consumer matrix again from the final RC commit.
+The protected promotion also ran the exact-version CJS/ESM/NodeNext/React 18/19
+consumer matrix; rerun the appropriate matrix before each future release.

--- a/docs/releases/v1.0.0/scope.md
+++ b/docs/releases/v1.0.0/scope.md
@@ -1,17 +1,17 @@
 # v1.0.0 Scope and Versioning Candidates
 
-**Status:** `documented — owner operated`
+**Status:** `promoted — owner operated`
 **Roadmap revision:** `v1-r2`
 
-This document is the decision record for G0. It does not authorize publishing
-or change any package version. Generate the current package and subpath input
-with `pnpm release:inventory`; record the resulting JSON in a clean RC
-evidence bundle before the owner elects to publish.
+This document is the decision record for G0. It does not itself mutate a
+package version or npm tag. Generate the current package and subpath input with
+`pnpm release:inventory`; retain that inventory in clean release evidence when
+preparing a future stable patch or minor.
 
-The v1.0.0 cohort recorded in the release manifest was published before the
-protected authorization gate was introduced. That historical fact does not
-approve its contract or authorize `latest`; it remains subject to the
-provenance and automated promotion checks in the release status.
+The v1.0.0 cohort was published before the protected authorization gate was
+introduced, then promoted through the protected workflow after provenance,
+consumer, rollback, hygiene, and governance checks passed. The release
+manifest and promotion artifact record the resulting stable tags.
 
 ## Candidate scope
 
@@ -41,7 +41,7 @@ declared support range and exact tested version before release authorization.
 - Keep the package/subpath classification current.
 - Keep the target version map and release order current, including unpublished
   internal dependency versions.
-- Record a clean, immutable G0 evidence manifest with the inventory and the
-  final package metadata.
-- Do not publish `latest` outside the protected workflow. The workflow rechecks
+- Record a clean, immutable G0 evidence manifest with the inventory and final
+  package metadata before each future stable promotion.
+- Do not publish or retag `latest` outside the protected workflow. It rechecks
   provenance, stable-surface consumers, rollback eligibility, and evidence.

--- a/docs/releases/v1.0.0/semver-and-deprecation-policy.md
+++ b/docs/releases/v1.0.0/semver-and-deprecation-policy.md
@@ -1,6 +1,6 @@
 # v1.0.0 SemVer and Deprecation Policy
 
-**Status:** `documented — owner operated`
+**Status:** `promoted policy — owner operated`
 **Roadmap revision:** `v1-r2`
 
 ## Stable surfaces


### PR DESCRIPTION
## Summary
- updates v1 scope, contract, compatibility, migration, and limitation documents from candidate/pre-promotion language to the completed stable promotion
- records Core, React, Tool Protocol as promoted stable surfaces
- preserves WebMCP and `@context-action/react/webmcp` as explicitly experimental, outside the 1.x promise
- resolves legacy outcomes to their promoted stable or experimental classification

## Traceability
- `CA-1X-RELEASE-001` — stable-release promotion integrity

## Review evidence
- `pnpm release:inventory`
- `pnpm verify:package-exports`
- `pnpm verify:doc-snippets`
- `pnpm verify:v1-core-migration`
- `pnpm verify:v1-lifecycle`
- `pnpm verify:react-webmcp-isolation`

## Validation
- `pnpm release:roadmap:check`
- `pnpm docs:management`
- `pnpm docs:build`
- `git diff --check`