### PR TITLE
chore(release): record Tool Protocol 1.0.1 correction

### DIFF
--- a/docs/releases/v1.0.0/audit-report.md
+++ b/docs/releases/v1.0.0/audit-report.md
@@ -15,9 +15,10 @@ protected promotion workflow remained the only mutation path.
   `release-evidence/v1.0.0-stable-promotion-31347327623/`.
 - Public export, migration, lifecycle, React/WebMCP isolation, documentation,
   consumer, security, and provenance checks passed.
-- Open P0/P1 findings: none. The only non-runtime artifact issue is the
-  Tool Protocol 1.0.0 bundled CHANGELOG, with a protected 1.0.1 correction in
-  progress.
+- Open P0/P1 findings: none. The Tool Protocol 1.0.0 bundled-CHANGELOG issue
+  was resolved by protected packaging-only patch `1.0.1`; its exact-version
+  consumer and npm attestation provenance evidence are recorded at
+  `release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/`.
 - Verdict: `READY` for the promoted v1 stable surfaces.
 
 ## Optional record

--- a/docs/releases/v1.0.0/issue-ledger.md
+++ b/docs/releases/v1.0.0/issue-ledger.md
@@ -1,6 +1,6 @@
 # v1.0.0 Delivery Issue Ledger
 
-**Status:** `v1 stable promotion complete; artifact correction in progress`
+**Status:** `v1 stable promotion and artifact correction complete`
 **Roadmap revision:** `v1-r2`
 
 | ID | Scope | Implementation state | Remaining release condition |
@@ -16,7 +16,7 @@
 | CA-1X-MIGRATION-001 | 0.9 consumer migration | Packed Core fixture and release migration guide verified | Maintain for future breaking changes |
 | CA-1X-LOCALIZE-001 | EN canonical/KO governance | Alignment verifier passed | Govern future release-document changes |
 | CA-1X-RELEASE-001 | Publish/recovery | Protected promotion, provenance, rollback, and evidence completed | Use the protected path for future promotions |
-| CA-1X-ARTIFACT-001 | Tool Protocol bundled CHANGELOG | `1.0.1` packaging correction implemented | Publish the protected `@context-action/tool-protocol@1.0.1` patch and capture evidence |
+| CA-1X-ARTIFACT-001 | Tool Protocol bundled CHANGELOG | Protected `1.0.1` correction published; consumer and attestation provenance verified | Closed; rerun the source-and-tarball changelog verifier for a future Tool Protocol release |
 
 No row authorizes a direct tag mutation. The protected workflow is the only
 stable-promotion path; issue URLs and owner notes remain optional history.

--- a/docs/releases/v1.0.0/known-limitations.md
+++ b/docs/releases/v1.0.0/known-limitations.md
@@ -16,12 +16,14 @@
   have passed. The single-maintainer policy does not impose an unavailable
   independent-auditor gate; future promotions remain protected by automated
   checks.
-- `@context-action/tool-protocol@1.0.0` bundles a `CHANGELOG.md` whose newest
-  entry is `0.8.9`. The immutable artifact cannot be repaired in place. The
-  protected `@context-action/tool-protocol@1.0.1` packaging correction is
-  implemented and awaits publication; it changes no runtime API or declaration
-  contract and will replace `latest` only after exact-version consumer and
-  registry checks pass.
+- The immutable `@context-action/tool-protocol@1.0.0` artifact bundles a
+  `CHANGELOG.md` whose newest entry is `0.8.9`; it cannot be repaired in
+  place. Protected packaging-only patch `@context-action/tool-protocol@1.0.1`
+  resolved the distribution-facing issue, owns `latest`, preserves
+  `next=1.0.0` and `rc=1.0.0-rc.0`, and changes no runtime API or declaration
+  contract. Its exact-version consumer and npm attestation provenance evidence
+  are recorded at
+  `release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/`.
 - The accidental WebMCP RC `latest` tag has been replaced by the protected
   `@context-action/webmcp@0.1.1` hygiene patch. Run `31341251251` recorded
   `latest=0.1.1`, `next=0.1.0`, `rc=0.1.0-rc.0`, and a passing external

--- a/docs/releases/v1.0.0/readiness.md
+++ b/docs/releases/v1.0.0/readiness.md
@@ -87,6 +87,13 @@ passed the exact-version CJS/ESM/NodeNext/React 18/19 consumer matrix, and
 captured fresh registry plus provenance evidence at
 `release-evidence/v1.0.0-stable-promotion-31347327623/`.
 
+The immutable Tool Protocol `1.0.0` archive had a stale bundled changelog.
+Protected workflow run `31349046893` published the packaging-only
+`@context-action/tool-protocol@1.0.1` correction, which now owns `latest`.
+It preserved `next=1.0.0` and `rc=1.0.0-rc.0`, passed the exact-version
+consumer check, and has independently verified npm attestation provenance at
+`release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/`.
+
 WebMCP remains excluded from the stable set: its versioned hygiene patch
 `0.1.1` owns its `latest` tag while the immutable `0.1.0` candidate remains
 on `next`.

--- a/docs/releases/v1.0.0/release-manifest.json
+++ b/docs/releases/v1.0.0/release-manifest.json
@@ -127,7 +127,5 @@
     "Use the protected promotion workflow, which re-verifies npm provenance, the stable-surface consumer matrix, registry hygiene, and the current governance fingerprint before changing latest.",
     "Record post-promotion registry evidence before declaring the stable promotion complete."
   ],
-  "acceptedLimitations": [
-    "tool-protocol@1.0.0 includes a bundled CHANGELOG.md whose newest entry is 0.8.9; canonical v1.0.0 release notes are the repository and GitHub release documents. This does not affect runtime or declaration artifacts."
-  ]
+  "acceptedLimitations": []
 }

--- a/docs/releases/v1.0.0/status.md
+++ b/docs/releases/v1.0.0/status.md
@@ -42,9 +42,12 @@ and command results/artifact hashes belong in
   inventory, workflow-contract validation, and a governed-file fingerprint
   that includes the stable-consumer verifier. Its SHA-256 and fingerprint are
   bound in the manifest.
-- `@context-action/tool-protocol@1.0.0` has the accepted bundled-CHANGELOG
-  limitation recorded in the manifest and known-limitations document. A patch
-  cohort is required if bundled release notes are a certification requirement.
+- The immutable `@context-action/tool-protocol@1.0.0` tarball had a stale
+  bundled `CHANGELOG.md`. The protected packaging-only correction
+  `@context-action/tool-protocol@1.0.1` now owns `latest`, preserved
+  `next=1.0.0` and `rc=1.0.0-rc.0`, passed the exact-version consumer check,
+  and has independently verified npm attestation provenance. Evidence is in
+  `release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/`.
 - A successful `latest` tag mutation with failed registry-evidence capture is
   represented as `promotion-evidence-pending`, never as `promoted`. That state
   is retriable but still blocks release declaration until fresh evidence is
@@ -89,10 +92,12 @@ remain fail-closed before any publication attempt.
 ## Stable promotion result
 
 Protected workflow run `31347327623` completed successfully on 2026-08-10.
-It reverified npm provenance for the published cohort, promoted only
+It reverified npm provenance for the published cohort, promoted
 `@context-action/tool-protocol@1.0.0`, `@context-action/core@1.0.0`, and
 `@context-action/react@1.0.0`, waited for the exact `latest` metadata, and
-passed the CJS/ESM/NodeNext/React 18/19 consumer matrix. Captured artifacts are
+passed the CJS/ESM/NodeNext/React 18/19 consumer matrix. The later protected
+Tool Protocol `1.0.1` packaging correction owns `latest`; it changes neither
+the runtime API nor declaration contract. Captured promotion artifacts are
 stored at `release-evidence/v1.0.0-stable-promotion-31347327623/`.
 
 `@context-action/webmcp` remains experimental: `latest` is the separately

--- a/release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/tool-protocol-changelog-patch-provenance.json
+++ b/release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/tool-protocol-changelog-patch-provenance.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "context-action-tool-protocol-changelog-patch-provenance.v1",
+  "status": "verified",
+  "recordedAt": "2026-08-10T02:14:26Z",
+  "verifier": "npm audit signatures --include-attestations",
+  "package": {
+    "name": "@context-action/tool-protocol",
+    "version": "1.0.1",
+    "sourceCommit": "8295e17a71fdec2ae109aa04561d4c992d907dfa",
+    "workflow": {
+      "repository": "https://github.com/mineclover/context-action",
+      "ref": "refs/heads/main",
+      "path": ".github/workflows/publish-tool-protocol-changelog-patch.yml",
+      "run": "https://github.com/mineclover/context-action/actions/runs/31349046893/attempts/1"
+    },
+    "attestationUrl": "https://registry.npmjs.org/-/npm/v1/attestations/@context-action%2ftool-protocol@1.0.1"
+  }
+}

--- a/release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/tool-protocol-changelog-patch-registry-evidence.json
+++ b/release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/tool-protocol-changelog-patch-registry-evidence.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "context-action-published-release-evidence.v1",
+  "capturedAt": "2026-08-10T02:11:23.929Z",
+  "distTag": "latest",
+  "packages": {
+    "@context-action/tool-protocol": {
+      "version": "1.0.1",
+      "integrity": "sha512-OGdUe0l83UeH21zvq9XkzlDd3/BpC2Y75QkKX/q4owRQeII68ngfC6S362ANtgLSzywLBLfl4iaxTo1mK1jDnQ==",
+      "tarball": "https://registry.npmjs.org/@context-action/tool-protocol/-/tool-protocol-1.0.1.tgz",
+      "sha256": "eb2b5561c9e545c12eb94d31d094a107bec5995ca15650016e21e5680211c079",
+      "publishedAt": "2026-08-10T02:11:07.109Z",
+      "distTags": {
+        "rc": "1.0.0-rc.0",
+        "latest": "1.0.1",
+        "next": "1.0.0"
+      },
+      "provenance": {
+        "status": "pending-verification",
+        "sourceCommit": null
+      },
+      "externalConsumer": {
+        "status": "passed"
+      }
+    }
+  },
+  "notes": [
+    "Tarball SHA-256 and registry metadata were read after publication.",
+    "Provenance status remains pending until the npm attestation source commit is independently verified."
+  ]
+}

--- a/release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/tool-protocol-changelog-patch-summary.json
+++ b/release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/tool-protocol-changelog-patch-summary.json
@@ -1,0 +1,7 @@
+[
+  {
+    "packageName": "@context-action/tool-protocol",
+    "version": "1.0.1",
+    "status": "published"
+  }
+]


### PR DESCRIPTION
## Summary
- preserve protected Tool Protocol 1.0.1 publication, registry, consumer, and npm attestation evidence
- close CA-1X-ARTIFACT-001 across the v1 release ledger and review documents
- retain the immutable v1.0.0 promotion snapshot while recording the later packaging-only correction separately

## Verification
- `pnpm verify:v1-release-manifest`
- `pnpm docs:management`
- `pnpm verify:doc-snippets`
- `pnpm verify:tool-protocol-changelog`
- `pnpm docs:build`

Protected publication: [run 31349046893](https://github.com/mineclover/context-action/actions/runs/31349046893)