### PR TITLE
chore(release): record webmcp 0.1.2 publication evidence

### DIFF
--- a/docs/en/context-layered/v1-release-roadmap.md
+++ b/docs/en/context-layered/v1-release-roadmap.md
@@ -51,7 +51,7 @@ cohort was published to `next` from
 `63f790a521e3428a7a2825677747338f8f05ccf3`, and protected promotion run
 `31347327623` promoted Core, React, and Tool Protocol `1.0.0` to `latest`.
 The current default channel also includes the post-release
-`@context-action/tool-protocol@1.0.1` and `@context-action/webmcp@0.1.1`
+`@context-action/tool-protocol@1.0.1` and `@context-action/webmcp@0.1.2`
 patches. [release-manifest.json](../../releases/v1.0.0/release-manifest.json)
 owns the exact historical artifact, promotion, and current registry records.
 

--- a/docs/ko/context-layered/v1-release-roadmap.md
+++ b/docs/ko/context-layered/v1-release-roadmap.md
@@ -46,7 +46,7 @@ legacy 표면은 0.9.x 안정화 라인에서 아래 셋 중 하나만 선택할
 `63f790a521e3428a7a2825677747338f8f05ccf3`에서 `next`로 발행됐고, protected
 promotion run `31347327623`이 Core·React·Tool Protocol `1.0.0`을 `latest`로
 승격했다. 현재 default channel은 `@context-action/tool-protocol@1.0.1`과
-`@context-action/webmcp@0.1.1`의 사후 patch까지 반영한다. 정확한 historical
+`@context-action/webmcp@0.1.2`의 사후 patch까지 반영한다. 정확한 historical
 artifact, promotion, current registry 상태는
 [`release-manifest.json`](../../releases/v1.0.0/release-manifest.json)이 소유한다.
 

--- a/docs/releases/v1.0.0/known-limitations.md
+++ b/docs/releases/v1.0.0/known-limitations.md
@@ -32,11 +32,10 @@
   `31328975435`). WebMCP remains experimental and is excluded from the v1
   stable-promotion target set.
 - The immutable `@context-action/webmcp@0.1.1` tarball starts its bundled
-  `CHANGELOG.md` at `0.1.0`. The source changelog now records the hygiene
-  patch. `@context-action/webmcp@0.1.2` is prepared to distribute that
-  correction; it must pass the maintenance workflow and evidence capture
-  before it replaces the recorded `0.1.1` `latest` state. The already
-  published archive cannot be changed in place.
+  `CHANGELOG.md` at `0.1.0`. Protected maintenance run `31364068737`
+  published `@context-action/webmcp@0.1.2` to `latest`, with the corrected
+  bundled changelog and a passing reverse-dependency consumer matrix. The
+  affected `0.1.1` archive remains immutable historical evidence.
 
 Report any newly discovered P0/P1 issue in the issue ledger and reopen the
 affected gate before preparing a future stable patch or minor.

--- a/docs/releases/v1.0.0/publish-runbook.md
+++ b/docs/releases/v1.0.0/publish-runbook.md
@@ -16,10 +16,10 @@ After a successful run, record its evidence hash under `postReleasePatches`
 and refresh `currentRegistryState` in `release-manifest.json`. Do not edit the
 historical `artifactCohort` to describe a later package patch.
 
-`@context-action/webmcp@0.1.2` is the prepared packaging correction for the
-immutable `0.1.1` bundled Changelog. It is not part of `currentRegistryState`
-until the protected workflow publishes it and the captured registry evidence is
-committed.
+`@context-action/webmcp@0.1.2` is the published packaging correction for the
+immutable `0.1.1` bundled Changelog. Protected maintenance run `31364068737`
+captured registry evidence and passed the reverse-dependency consumer matrix;
+the correction is recorded in `currentRegistryState`.
 
 ## Historical v1.0.0 registry cohort
 
@@ -41,9 +41,9 @@ captured evidence at
 `release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json`.
 
 The existing `0.1.0` WebMCP record remains immutable evidence for the published
-`next` cohort. The separately published `0.1.1` hygiene patch owns WebMCP
-`latest`; because WebMCP is experimental, it is intentionally excluded from
-the v1 stable-promotion target set.
+`next` cohort. The separately published `0.1.2` changelog correction owns
+WebMCP `latest`; because WebMCP is experimental, it is intentionally excluded
+from the v1 stable-promotion target set.
 
 ## Historical v1 execution record (do not rerun)
 

--- a/docs/releases/v1.0.0/readiness.md
+++ b/docs/releases/v1.0.0/readiness.md
@@ -94,9 +94,9 @@ It preserved `next=1.0.0` and `rc=1.0.0-rc.0`, passed the exact-version
 consumer check, and has independently verified npm attestation provenance at
 `release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/`.
 
-WebMCP remains excluded from the stable set: its versioned hygiene patch
-`0.1.1` owns its `latest` tag while the immutable `0.1.0` candidate remains
-on `next`.
+WebMCP remains excluded from the stable set: protected maintenance run
+`31364068737` published its versioned changelog correction `0.1.2` to
+`latest`, while the immutable `0.1.0` candidate remains on `next`.
 
 No document alone authorizes a release to `latest`; the protected workflow is
 the only path that can mutate stable tags.

--- a/docs/releases/v1.0.0/release-manifest.json
+++ b/docs/releases/v1.0.0/release-manifest.json
@@ -37,17 +37,18 @@
   },
   "postReleasePatches": {
     "toolProtocolChangelog": { "package": "@context-action/tool-protocol", "version": "1.0.1", "reason": "bundled CHANGELOG.md correction", "sourceCommit": "8295e17a71fdec2ae109aa04561d4c992d907dfa", "latest": true, "registryEvidence": { "path": "release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/tool-protocol-changelog-patch-registry-evidence.json", "sha256": "8a632c6545b3b36180f8f96e1533ab3abbdadb7e60bd69f1d835291294c60bff" }, "provenanceEvidence": { "path": "release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/tool-protocol-changelog-patch-provenance.json", "sha256": "114e6a94283ba09326f73bb6f57e173b7f4da0090aeca4947346f6a8bc1dd321" } },
-    "webmcpHygiene": { "package": "@context-action/webmcp", "version": "0.1.1", "reason": "replace the accidental RC latest tag through a versioned experimental patch", "sourceCommit": null, "latest": true, "registryEvidence": { "path": "release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json", "sha256": "e930765ab7c565f91b6557dba5c6a49639431123961413290b749b6ef8ff4ace" }, "acceptedLimitation": "The immutable @context-action/webmcp@0.1.1 tarball starts its bundled CHANGELOG.md at 0.1.0. The source changelog is corrected for future patches; the published archive cannot be changed in place." }
+    "webmcpHygiene": { "package": "@context-action/webmcp", "version": "0.1.1", "reason": "replace the accidental RC latest tag through a versioned experimental patch", "sourceCommit": null, "latest": false, "registryEvidence": { "path": "release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json", "sha256": "e930765ab7c565f91b6557dba5c6a49639431123961413290b749b6ef8ff4ace" }, "acceptedLimitation": "The immutable @context-action/webmcp@0.1.1 tarball starts its bundled CHANGELOG.md at 0.1.0; it remains historical while the corrected 0.1.2 patch owns latest." },
+    "webmcpChangelogCorrection": { "package": "@context-action/webmcp", "version": "0.1.2", "reason": "distribute the corrected bundled CHANGELOG.md", "sourceCommit": "9c1b6b10fb8b41029ac2e53d1628b701592bc2b4", "latest": true, "registryEvidence": { "path": "release-evidence/webmcp-maintenance-patch-0.1.2-31364068737/maintenance-patch-registry-evidence.json", "sha256": "c75f3ae06f85c90cde009de58ef25845f77e768ad8d504c8b7091c05135fdea2" } }
   },
   "currentRegistryState": {
-    "checkedAt": "2026-08-10T02:14:26Z",
+    "checkedAt": "2026-08-10T07:01:09.337Z",
     "packages": {
       "@context-action/core": { "distTags": { "latest": "1.0.0", "next": "1.0.0", "rc": "1.0.0-rc.0" }, "evidence": { "path": "release-evidence/v1.0.0-stable-promotion-31347327623/npm-v1-promotion-registry-evidence.json", "sha256": "e46067119447acc260b8e6ef6e8047d1cf3e7c661fd964629b6ca7ea7b53e2f3" } },
       "@context-action/react": { "distTags": { "latest": "1.0.0", "next": "1.0.0", "rc": "1.0.0-rc.0" }, "evidence": { "path": "release-evidence/v1.0.0-stable-promotion-31347327623/npm-v1-promotion-registry-evidence.json", "sha256": "e46067119447acc260b8e6ef6e8047d1cf3e7c661fd964629b6ca7ea7b53e2f3" } },
       "@context-action/tool-protocol": { "distTags": { "latest": "1.0.1", "next": "1.0.0", "rc": "1.0.0-rc.0" }, "evidence": { "path": "release-evidence/tool-protocol-changelog-patch-1.0.1-31349046893/tool-protocol-changelog-patch-registry-evidence.json", "sha256": "8a632c6545b3b36180f8f96e1533ab3abbdadb7e60bd69f1d835291294c60bff" } },
-      "@context-action/webmcp": { "distTags": { "latest": "0.1.1", "next": "0.1.0", "rc": "0.1.0-rc.0" }, "evidence": { "path": "release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json", "sha256": "e930765ab7c565f91b6557dba5c6a49639431123961413290b749b6ef8ff4ace" } }
+      "@context-action/webmcp": { "distTags": { "latest": "0.1.2", "next": "0.1.0", "rc": "0.1.0-rc.0" }, "evidence": { "path": "release-evidence/webmcp-maintenance-patch-0.1.2-31364068737/maintenance-patch-registry-evidence.json", "sha256": "c75f3ae06f85c90cde009de58ef25845f77e768ad8d504c8b7091c05135fdea2" } }
     }
   },
   "requiredBeforeCertification": [],
-  "acceptedLimitations": ["The immutable @context-action/webmcp@0.1.1 tarball has a stale bundled CHANGELOG.md. Source is prepared as @context-action/webmcp@0.1.2 to correct the distributed changelog; currentRegistryState remains 0.1.1 until protected publication and evidence capture complete."]
+  "acceptedLimitations": []
 }

--- a/docs/releases/v1.0.0/status.md
+++ b/docs/releases/v1.0.0/status.md
@@ -18,7 +18,7 @@ and command results/artifact hashes belong in
 | `@context-action/core` | `1.0.0` |
 | `@context-action/react` | `1.0.0` |
 | `@context-action/tool-protocol` | `1.0.1` |
-| `@context-action/webmcp` | `0.1.1` |
+| `@context-action/webmcp` | `0.1.2` |
 
 The v1.0.0 artifact cohort and the current default channel are intentionally
 different records. The manifest preserves the former under `artifactCohort`
@@ -42,10 +42,10 @@ and the latter under `currentRegistryState`.
 - Registry evidence records the published `next` cohort from
   `63f790a521e3428a7a2825677747338f8f05ccf3`. The npm CLI cryptographically
   verified all four registry signatures and SLSA provenance bundles. The protected hygiene
-  workflow has replaced the accidental WebMCP RC `latest` tag with
-  `@context-action/webmcp@0.1.1`. The immutable `0.1.0` candidate is now
-  experimental surface is excluded from the v1 stable-promotion target set;
-  its separately published patch does not block stable-surface promotion.
+  workflow replaced the accidental WebMCP RC `latest` tag, and maintenance run
+  `31364068737` published the corrected bundled changelog as
+  `@context-action/webmcp@0.1.2`. The immutable `0.1.0` candidate remains an
+  experimental surface and is excluded from the v1 stable-promotion target set.
 - The `npm-stable` environment now limits deployments to `main`, requires the
   `mineclover` reviewer, permits the documented owner-authorized self-review
   exception, and disallows administrator bypass. It is the protected
@@ -71,11 +71,10 @@ and the latter under `currentRegistryState`.
 On 2026-08-10, read-only npm and GitHub API checks confirmed the recorded
 external state:
 
-- `@context-action/webmcp`: `latest` is `0.1.1`, while `next` is `0.1.0` and
-  `rc` is `0.1.0-rc.0`; registry tag hygiene is cleared. Protected workflow
-  run `31341251251` also passed the `latest` external-consumer check; its
-  captured evidence is
-  `release-evidence/webmcp-hygiene-patch-0.1.1-31341251251/registry-evidence.json`.
+- `@context-action/webmcp`: `latest` is `0.1.2`, while `next` is `0.1.0` and
+  `rc` is `0.1.0-rc.0`. Protected maintenance run `31364068737` passed the
+  reverse-dependency consumer matrix and captured registry evidence at
+  `release-evidence/webmcp-maintenance-patch-0.1.2-31364068737/`.
 - `npm-stable` allows only `main`, requires review by `mineclover`, permits the
   owner-authorized self-review exception, and disallows administrator bypass.
 
@@ -89,12 +88,11 @@ checks remain mandatory.
 
 The protected WebMCP hygiene rehearsals `31328409822` and `31328975435`
 confirmed that direct `dist-tag rm` is not a viable repair path (OIDC failed
-with `E401`; the configured token failed with `E403`). The repair is now the
-versioned `@context-action/webmcp@0.1.1` hygiene patch, published through a
-separate protected workflow. Run `31340779674` published it, and rerun
-`31341251251` completed the deferred tag, consumer, and registry-evidence
-checks without republishing. Its token preflight and exact-version validation
-remain fail-closed before any publication attempt.
+with `E401`; the configured token failed with `E403`). The versioned `0.1.1`
+hygiene patch replaced the accidental RC tag; protected maintenance run
+`31364068737` then published `@context-action/webmcp@0.1.2` with the corrected
+bundled changelog. Its token preflight and exact-version validation remain
+fail-closed before any publication attempt.
 
 ## Post-release maintenance
 

--- a/release-evidence/webmcp-maintenance-patch-0.1.2-31364068737/maintenance-patch-registry-evidence.json
+++ b/release-evidence/webmcp-maintenance-patch-0.1.2-31364068737/maintenance-patch-registry-evidence.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "context-action-published-release-evidence.v1",
+  "capturedAt": "2026-08-10T07:01:09.337Z",
+  "distTag": "latest",
+  "packages": {
+    "@context-action/webmcp": {
+      "version": "0.1.2",
+      "integrity": "sha512-KeIolf0REeRVDJFg/AAy6D6emZJ9h3rojdT0MKAght8IBw8cT8igeOyHna2huWoV6BWsOrq51VMWb/OXjkSe6g==",
+      "tarball": "https://registry.npmjs.org/@context-action/webmcp/-/webmcp-0.1.2.tgz",
+      "sha256": "b27f3d7e88390d590d83eac26b0f61ccdd51c5d3dd245804ed3ee7232d947b65",
+      "publishedAt": "2026-08-10T07:00:43.494Z",
+      "distTags": {
+        "rc": "0.1.0-rc.0",
+        "next": "0.1.0",
+        "latest": "0.1.2"
+      },
+      "provenance": {
+        "status": "pending-verification",
+        "sourceCommit": null
+      },
+      "externalConsumer": {
+        "status": "passed"
+      }
+    }
+  },
+  "notes": [
+    "Tarball SHA-256 and registry metadata were read after publication.",
+    "Provenance status remains pending until the npm attestation source commit is independently verified."
+  ]
+}

--- a/release-evidence/webmcp-maintenance-patch-0.1.2-31364068737/maintenance-patch-summary.json
+++ b/release-evidence/webmcp-maintenance-patch-0.1.2-31364068737/maintenance-patch-summary.json
@@ -1,0 +1,7 @@
+[
+  {
+    "packageName": "@context-action/webmcp",
+    "version": "0.1.2",
+    "status": "published"
+  }
+]


### PR DESCRIPTION
## Summary
- record protected maintenance run 31364068737 registry evidence
- set @context-action/webmcp latest to 0.1.2 in the release manifest
- close the distributed WebMCP changelog correction item

## Validation
- pnpm verify:v1-release-manifest
- pnpm verify:v1-release-state-alignment
- pnpm release:roadmap:check
- pnpm lint
- pnpm docs:build
- pnpm llms:check