### PR TITLE
fix: retry npm dist-tag propagation

### DIFF
--- a/scripts/publish-packages.cjs
+++ b/scripts/publish-packages.cjs
@@ -81,7 +81,8 @@ function publishScopedPackages() {
 
   function ensureDistTag(manifest, packageDirectory) {
     let tags;
-    for (let attempt = 1; attempt <= 6; attempt += 1) {
+    const attempts = 12;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
       const tagsResult = commandSucceeded(
         'npm',
         ['view', manifest.name, 'dist-tags', '--json', '--registry=https://registry.npmjs.org'],
@@ -90,7 +91,10 @@ function publishScopedPackages() {
         tags = JSON.parse(tagsResult.stdout);
         break;
       }
-      if (attempt < 6) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10_000);
+      if (attempt < attempts) {
+        process.stdout.write(`Waiting for npm dist-tags (${attempt}/${attempts - 1})...\n`);
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10_000);
+      }
     }
     if (!tags) throw new Error(`Could not read dist-tags for ${manifest.name}`);
     if (tags[distTag] === manifest.version) return;


### PR DESCRIPTION
Follow-up to #76 and CA-1X-ARTIFACT-001.\n\nExtends protected publisher dist-tag visibility retries to 12 attempts at 10-second intervals so a successful npm publish is not reported as failed during registry propagation.