### PR TITLE
fix: resume initial latest promotion

### DIFF
--- a/.github/workflows/publish-maintenance-patch.yml
+++ b/.github/workflows/publish-maintenance-patch.yml
@@ -200,11 +200,16 @@ jobs:
           previous_latest="$(npm view "$PACKAGE_NAME" dist-tags.latest --registry=https://registry.npmjs.org 2>/dev/null || true)"
           if [ -n "$previous_latest" ]; then
             [[ "$previous_latest" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-            test "$previous_latest" != "$PACKAGE_VERSION"
+            if [ "$previous_latest" = "$PACKAGE_VERSION" ]; then
+              echo 'LATEST_ALREADY_PROMOTED=true' >> "$GITHUB_ENV"
+              echo "Latest already resolves to verified candidate $PACKAGE_NAME@$PACKAGE_VERSION."
+              exit 0
+            fi
           fi
           echo "PREVIOUS_LATEST=$previous_latest" >> "$GITHUB_ENV"
 
       - name: Promote verified candidate to latest
+        if: env.LATEST_ALREADY_PROMOTED != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |

--- a/scripts/verify-v1-release-workflows.mjs
+++ b/scripts/verify-v1-release-workflows.mjs
@@ -95,6 +95,7 @@ for (const required of [
   'verify-ai-sdk-tool-protocol-contract.mjs --published --version "$PACKAGE_VERSION"',
   'verify-maintenance-patch-provenance.mjs',
   'Record previous latest tag',
+  'LATEST_ALREADY_PROMOTED=true',
   'Promote verified candidate to latest',
   'verify:published-tool-consumers -- --tag latest --packages "$PATCH_CONSUMER_CLOSURE"',
   'capture:published-release -- --tag latest --packages "$PACKAGE_NAME"',


### PR DESCRIPTION
Follow-up to #77 and CA-1X-ARTIFACT-001.

Handles npm automatic latest tagging on an initial publish as an already-promoted verified candidate, then continues the final registry-closure evidence checks.