### PR TITLE
fix: resume candidates before version validation

### DIFF
--- a/.github/workflows/publish-maintenance-patch.yml
+++ b/.github/workflows/publish-maintenance-patch.yml
@@ -139,14 +139,6 @@ jobs:
           pnpm --filter "$PACKAGE_NAME" type-check
           pnpm --filter "$PACKAGE_NAME" test
 
-      - name: Verify patch-only semantic version increment
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          command=(node scripts/verify-maintenance-patch-version.mjs --package "$PACKAGE_NAME" --version "$PACKAGE_VERSION")
-          if [ "$ALLOW_INITIAL_RELEASE" = true ]; then command+=(--allow-initial); fi
-          "${command[@]}"
-
       - name: Resume an existing verified candidate when safe
         env:
           RELEASE_COMMIT: ${{ inputs.release_commit }}
@@ -165,6 +157,15 @@ jobs:
             --output reports/maintenance-patch-provenance-evidence.json
           echo 'PUBLISH_REQUIRED=false' >> "$GITHUB_ENV"
           echo "Resuming verified maintenance candidate $PACKAGE_NAME@$PACKAGE_VERSION."
+
+      - name: Verify patch-only semantic version increment
+        if: env.PUBLISH_REQUIRED != 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          command=(node scripts/verify-maintenance-patch-version.mjs --package "$PACKAGE_NAME" --version "$PACKAGE_VERSION")
+          if [ "$ALLOW_INITIAL_RELEASE" = true ]; then command+=(--allow-initial); fi
+          "${command[@]}"
 
       - name: Verify local tarball reverse dependency closure
         run: pnpm verify:published-tool-consumers -- --local --packages "$PATCH_CONSUMER_CLOSURE"

--- a/scripts/verify-v1-release-workflows.mjs
+++ b/scripts/verify-v1-release-workflows.mjs
@@ -107,6 +107,7 @@ requireOrder(errors, maintenancePatch, 'Verify source and packed changelog', 'Pu
 requireOrder(errors, maintenancePatch, 'Build and test the maintenance closure', 'Publish the new patch candidate', 'Maintenance package validation must occur before candidate publication');
 requireOrder(errors, maintenancePatch, 'Verify local tarball reverse dependency closure', 'Publish the new patch candidate', 'Maintenance local consumer closure must run before candidate publication');
 requireOrder(errors, maintenancePatch, 'Resume an existing verified candidate when safe', 'Publish the new patch candidate', 'Maintenance candidate resume decision must occur before publication');
+requireOrder(errors, maintenancePatch, 'Resume an existing verified candidate when safe', 'Verify patch-only semantic version increment', 'Maintenance candidate resume decision must precede patch version validation');
 requireOrder(errors, maintenancePatch, 'Verify published candidate reverse dependency closure', 'Promote verified candidate to latest', 'Candidate consumer closure must pass before latest mutation');
 requireOrder(errors, maintenancePatch, 'Verify published candidate changelog and provenance', 'Promote verified candidate to latest', 'Candidate provenance must pass before latest mutation');
 requireOrder(errors, maintenancePatch, 'Record previous latest tag', 'Promote verified candidate to latest', 'Maintenance workflow must record the rollback target before latest mutation');


### PR DESCRIPTION
Follow-up to #78 and CA-1X-ARTIFACT-001. Existing verified maintenance candidates are now detected before patch-increment validation, so an initial artifact that npm already tags latest can complete its registry evidence path.