### PR TITLE
fix: validate coordinated core react promotion

### DIFF
--- a/.github/workflows/promote-coordinated-stable.yml
+++ b/.github/workflows/promote-coordinated-stable.yml
@@ -34,9 +34,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          ref: ${{ inputs.release_commit }}
+          # Promotion changes only registry tags. Run its reviewed control code from
+          # the current protected main tip; RELEASE_COMMIT remains the separately
+          # verified source commit of the immutable next candidate.
+          ref: ${{ github.sha }}
 
-      - name: Verify approved main release commit
+      - name: Verify approved candidate source and current main governance
         env:
           RELEASE_COMMIT: ${{ inputs.release_commit }}
           CONFIRMATION: ${{ inputs.confirmation }}
@@ -44,9 +47,11 @@ jobs:
           [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           test "$CONFIRMATION" = "PROMOTE_COORDINATED_STABLE"
           test "$GITHUB_REF" = "refs/heads/main"
-          test "$RELEASE_COMMIT" = "$GITHUB_SHA"
-          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
-          git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+          git merge-base --is-ancestor "$RELEASE_COMMIT" HEAD
+          git diff --exit-code
+          git diff --cached --exit-code
 
       - name: Clear npm config before registry setup
         run: |

--- a/releases/COORDINATED_STABLE_2026_08.md
+++ b/releases/COORDINATED_STABLE_2026_08.md
@@ -22,10 +22,12 @@ artifact에서는 `./tools` subpath를 제외하므로, 상태 관리 릴리즈�
 2. 후보 workflow는 `release:check`, release plan, packed cohort closure를 통과한
    뒤 두 immutable tarball을 `next`에만 게시한다. provenance, 외부 consumer,
    registry evidence를 모두 업로드한다.
-3. evidence 승인 후 동일 SHA와 명시적 confirmation으로
-   `promote-coordinated-stable.yml`을 실행한다. 이 경로는 `next`의 provenance와
-   consumer를 다시 확인한 다음, package별 predecessor journal을 기록하고
-   `latest`를 승격한다.
+3. evidence 승인 후 candidate를 만든 SHA와 명시적 confirmation으로
+   `promote-coordinated-stable.yml`을 실행한다. 이 workflow는 현재 보호된 main
+   tip의 제어 코드를 checkout하고, candidate SHA가 그 main의 조상인지 및 `next`의
+   provenance와 consumer를 다시 확인한 다음, package별 predecessor journal을
+   기록하고 `latest`를 승격한다. 후보를 게시하는 workflow만 source SHA와 event
+   SHA의 동일성을 요구한다.
 4. 승격 후 consumer/provenance/evidence가 실패하면 workflow가 현재 `latest`가
    자기 candidate를 가리킬 때만 journal의 predecessor로 복구한다. 다른 release가
    tag를 바꾼 경우에는 fail closed 한다.

--- a/scripts/coordinated-stable-release.test.mjs
+++ b/scripts/coordinated-stable-release.test.mjs
@@ -20,6 +20,9 @@ test('promotion uses durable registry journal markers and refuses local executio
   const source = read('scripts/promote-coordinated-stable.mjs');
   for (const required of [
     "process.env.GITHUB_ACTIONS !== 'true'",
+    "new Set(['@context-action/core', '@context-action/react'])",
+    'packages.length !== expectedPackages.size',
+    'packages.some(([name]) => !expectedPackages.has(name))',
     'stable-previous-',
     'stable-previous-absent-',
     'stable-ready-',
@@ -31,6 +34,16 @@ test('promotion uses durable registry journal markers and refuses local executio
   ]) assert.ok(source.includes(required), `missing coordinated promotion safeguard: ${required}`);
 });
 
+test('provenance verification is bound to the approved Core and React cohort', () => {
+  const source = read('scripts/verify-coordinated-stable-provenance.mjs');
+  for (const required of [
+    "new Set(['@context-action/core', '@context-action/react'])",
+    'packages.length !== expectedPackages.size',
+    'packages.some(([name]) => !expectedPackages.has(name))',
+    'exact Core and React cohort',
+  ]) assert.ok(source.includes(required), `missing coordinated provenance cohort guard: ${required}`);
+});
+
 test('candidate and promotion workflows bind the exact coordinated cohort', () => {
   const candidate = read('.github/workflows/publish-coordinated-stable-candidate.yml');
   const promotion = read('.github/workflows/promote-coordinated-stable.yml');
@@ -39,6 +52,9 @@ test('candidate and promotion workflows bind the exact coordinated cohort', () =
   assert.ok(promotion.includes(`--packages "${cohort}"`));
   assert.ok(candidate.includes('test "$RELEASE_COMMIT" = "$GITHUB_SHA"'));
   assert.ok(promotion.includes('test "$CONFIRMATION" = "PROMOTE_COORDINATED_STABLE"'));
+  assert.ok(promotion.includes('ref: ${{ github.sha }}'));
+  assert.ok(promotion.includes('git merge-base --is-ancestor "$RELEASE_COMMIT" HEAD'));
+  assert.ok(!promotion.includes('test "$RELEASE_COMMIT" = "$GITHUB_SHA"'));
 });
 
 test('the React state-management artifact excludes the Durable-backed tools entry', () => {

--- a/scripts/promote-coordinated-stable.mjs
+++ b/scripts/promote-coordinated-stable.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const planPath = path.join(repositoryRoot, 'releases', 'coordinated-stable-2026-08.json');
+const expectedPackages = new Set(['@context-action/core', '@context-action/react']);
 const outputIndex = process.argv.indexOf('--output');
 const output = outputIndex === -1 ? undefined : process.argv[outputIndex + 1];
 if (!output || output.startsWith('--')) throw new Error('Usage: node scripts/promote-coordinated-stable.mjs --output <repository-relative JSON path>');
@@ -19,7 +20,12 @@ if (resolvedOutput !== repositoryRoot && !resolvedOutput.startsWith(`${repositor
 const plan = JSON.parse(await readFile(planPath, 'utf8'));
 const releaseId = String(plan.release ?? '').replace(/[^a-z0-9-]/giu, '-');
 const packages = Object.entries(plan.packages ?? {});
-if (packages.length !== 4 || plan.candidateDistTag !== 'next' || plan.promotionDistTag !== 'latest') throw new Error('Invalid coordinated stable release plan');
+if (
+  packages.length !== expectedPackages.size
+  || packages.some(([name]) => !expectedPackages.has(name))
+  || plan.candidateDistTag !== 'next'
+  || plan.promotionDistTag !== 'latest'
+) throw new Error('Invalid coordinated stable release plan');
 
 function npm(argumentsList) {
   return execFileSync('npm', argumentsList, { cwd: repositoryRoot, encoding: 'utf8', env: { ...process.env, npm_config_loglevel: 'error' } }).trim();

--- a/scripts/verify-coordinated-stable-provenance.mjs
+++ b/scripts/verify-coordinated-stable-provenance.mjs
@@ -10,6 +10,7 @@ const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url))
 const planPath = path.join(repositoryRoot, 'releases', 'coordinated-stable-2026-08.json');
 const expectedRepository = 'https://github.com/mineclover/context-action';
 const expectedWorkflowPath = '.github/workflows/publish-coordinated-stable-candidate.yml';
+const expectedPackages = new Set(['@context-action/core', '@context-action/react']);
 
 function option(name) {
   const index = process.argv.indexOf(name);
@@ -42,7 +43,9 @@ if (!['next', 'latest'].includes(tag) || !/^[a-f0-9]{40}$/u.test(commit ?? '')) 
 
 const plan = JSON.parse(await readFile(planPath, 'utf8'));
 const packages = Object.entries(plan.packages ?? {});
-if (packages.length !== 4) throw new Error('Coordinated stable release plan must contain the exact four-package cohort');
+if (packages.length !== expectedPackages.size || packages.some(([name]) => !expectedPackages.has(name))) {
+  throw new Error('Coordinated stable release plan must contain the exact Core and React cohort');
+}
 const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), 'context-action-coordinated-provenance-'));
 try {
   await writeFile(path.join(temporaryDirectory, 'package.json'), `${JSON.stringify({

--- a/scripts/verify-v1-release-workflows.mjs
+++ b/scripts/verify-v1-release-workflows.mjs
@@ -17,6 +17,7 @@ const manifestPath = path.join(repositoryRoot, 'docs', 'releases', 'v1.0.0', 're
 const failureOrCancellationCondition = '$' + '{{ failure() || cancelled() }}';
 const foreignJournalErrorTemplate = 'foreign maintenance journal $' + '{candidate} is unresolved';
 const releaseCommitInputExpression = '$' + '{{ inputs.release_commit }}';
+const workflowEventShaExpression = '$' + '{{ github.sha }}';
 const maintenanceBuildStepName = 'Build workspace dependencies and test the maintenance target';
 const maintenanceBuildStatements = [
   'pnpm build',
@@ -228,7 +229,11 @@ export function validateReleaseWorkflowSources({
     }
     for (const required of [
       'test "$CONFIRMATION" = "PROMOTE_COORDINATED_STABLE"',
-      'test "$RELEASE_COMMIT" = "$GITHUB_SHA"',
+      'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"',
+      'test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"',
+      'git merge-base --is-ancestor "$RELEASE_COMMIT" HEAD',
+      'git diff --exit-code',
+      'git diff --cached --exit-code',
       'pnpm verify:coordinated-stable-release-plan',
       'node scripts/verify-coordinated-stable-provenance.mjs --tag next --commit "$RELEASE_COMMIT" --output reports/npm-coordinated-stable-promotion-preflight-provenance.json',
       'pnpm verify:published-tool-consumers -- --tag next --packages "@context-action/core,@context-action/react"',
@@ -238,6 +243,14 @@ export function validateReleaseWorkflowSources({
       'pnpm capture:published-release -- --tag latest --packages "@context-action/core,@context-action/react" --consumer-status passed --output reports/npm-coordinated-stable-promotion-registry-evidence.json',
     ]) {
       if (!promotionStatements.includes(required)) errors.push(`Coordinated stable promotion workflow must include ${required}`);
+    }
+    const promotionCheckout = promotionJob.steps.find(step =>
+      typeof step.definition.uses === 'string'
+      && step.definition.uses.startsWith('actions/checkout@')
+      && step.definition.with?.ref === workflowEventShaExpression
+      && isUnconditionalFailClosedStep(step));
+    if (!promotionCheckout) {
+      errors.push('Coordinated stable promotion workflow must check out the immutable current main event SHA');
     }
     if (!coordinatedPromotionInspection.steps.some(step =>
       step.definition.name === 'Upload coordinated stable promotion evidence'


### PR DESCRIPTION
CA-COORDINATED-STABLE-2026-08\n\nRepairs the coordinated Core 1.1.0 / React 2.0.0 candidate verifier to use its approved two-package cohort. Promotion now runs reviewed control code from the current protected main SHA while requiring the attested candidate source SHA to be a main ancestor; candidate publication retains strict source/event SHA equality. Includes release-contract regressions and roadmap clarification.