### PR TITLE
docs: clarify React 18 compatibility entrypoint

### DIFF
--- a/docs/en/context-layered/migration-guide.md
+++ b/docs/en/context-layered/migration-guide.md
@@ -50,8 +50,11 @@ options cannot be confused:
 await register.actions.reset(undefined, { debounce: 100 });
 ```
 
-`@context-action/react` supports React 18 and 19 through the same runtime and
-the `react18` entry point is a compatibility path, not a separate runtime.
+`@context-action/react` supports React 18 and 19 through the same runtime.
+Import Store and Action APIs from `@context-action/react` for either version.
+The `@context-action/react/react18` entry point remains for compatibility with
+existing type imports (`React18Options`); it is not a separate runtime and
+does not provide a second Store or Action API.
 The maintained `@context-action/mutative-core` / `@context-action/mutative`
 fork remains the immutable runtime contract; synchronize upstream changes via
 its [`UPSTREAM.md`](../../../packages/mutative-core/UPSTREAM.md) record.

--- a/docs/en/llms/library-specs.md
+++ b/docs/en/llms/library-specs.md
@@ -35,8 +35,8 @@
 
 #### @context-action/react
 - **Purpose**: React integration with Context API and hooks
-- **Dependencies**: React 18 or 19, @context-action/core, @context-action/tool-protocol, @context-action/tool-durable-operations, and @context-action/webmcp; durable execution and WebMCP registration remain opt-in at runtime
-- **Key Features**: Store management, action contexts, hooks, and `useWebMCPToolScope` lifecycle integration
+- **Dependencies**: React 18 or 19 (peer), `@context-action/core`, `@context-action/mutative`, `@context-action/tool-protocol`, and `@context-action/webmcp`; it does not depend on Durable Operations in the published React 2 artifact
+- **Key Features**: Store management, action contexts, hooks, and React 18/19 SSR support. Import these APIs from `@context-action/react`; the `react18` subpath is a type-compatibility entry point, not a second runtime.
 
 ### Release and Security Baseline
 

--- a/docs/ko/context-layered/migration-guide.md
+++ b/docs/ko/context-layered/migration-guide.md
@@ -70,8 +70,11 @@ void action의 dispatch option은 payload와 혼동되지 않도록 두 번째 �
 await register.actions.reset(undefined, { debounce: 100 });
 ```
 
-`@context-action/react`는 동일 runtime으로 React 18과 19를 지원하며,
-`react18` entry point는 별도 runtime이 아니라 호환성 경로입니다.
+`@context-action/react`는 동일 runtime으로 React 18과 19를 지원합니다.
+두 버전 모두 Store·Action API는 `@context-action/react`에서 import합니다.
+`@context-action/react/react18` entry point는 기존 타입 import
+(`React18Options`) 호환성을 위한 경로이며, 별도 runtime이나 두 번째 Store·Action
+API가 아닙니다.
 `@context-action/mutative-core` / `@context-action/mutative` fork는 계속
 유지 관리하고 upstream 동기화는 해당 package의 `UPSTREAM.md`에 기록합니다.
 

--- a/docs/ko/llms/library-specs.md
+++ b/docs/ko/llms/library-specs.md
@@ -35,8 +35,8 @@
 
 #### @context-action/react
 - **목적**: Context API 및 훅을 통한 React 통합
-- **의존성**: React 18 또는 19, @context-action/core, @context-action/tool-protocol, @context-action/tool-durable-operations, @context-action/webmcp. durable 실행과 WebMCP 등록은 런타임에서 opt-in
-- **주요 기능**: 스토어 관리, 액션 컨텍스트, 훅, `useWebMCPToolScope` 수명 주기 통합
+- **의존성**: React 18 또는 19(peer), `@context-action/core`, `@context-action/mutative`, `@context-action/tool-protocol`, `@context-action/webmcp`. 배포된 React 2 artifact는 Durable Operations에 의존하지 않음
+- **주요 기능**: 스토어 관리, 액션 컨텍스트, 훅, React 18/19 SSR 지원. Store·Action API는 `@context-action/react`에서 import하며, `react18` subpath는 두 번째 runtime이 아닌 타입 호환성 entry point임
 
 ### 릴리스 및 보안 기준
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -108,6 +108,24 @@ stores for owned application state and `useStoreValue()` for reactive reads.
 This keeps rendering, state transitions, and infrastructure concerns
 independently testable.
 
+### React 18 and React 19 imports
+
+Use the main entry point for both supported React versions:
+
+```ts
+import {
+  createActionContext,
+  createStoreContext,
+  useStoreValue,
+} from '@context-action/react';
+```
+
+The package has one shared runtime and declares React 18 and React 19 as peer
+dependencies. `@context-action/react/react18` remains only as a compatibility
+entry point for existing type imports; it exports `React18Options` and is not
+a React-18-specific runtime or an alternative place to import the Store and
+Action APIs.
+
 ### Development-only tool runtime
 
 The repository retains ToolContext and Durable Operations source while their

--- a/packages/react/bundle-analysis.md
+++ b/packages/react/bundle-analysis.md
@@ -9,10 +9,10 @@ fixed byte claims. Generate a current report with `pnpm --filter
 - `@context-action/react` is the default action, store, ref, and React helper
   entry point. It does not load tool-protocol or durable-operation runtimes.
 - `@context-action/react/advanced` exposes optional store features.
-- `@context-action/react/react18` exposes React 18/19 compatibility helpers.
-- `@context-action/react/tools` is the explicit ToolContext entry point. It
-  requires `@context-action/tool-protocol` and may use the optional durable
-  operations peer.
+- `@context-action/react/react18` is a type-compatibility entry point for
+  existing `React18Options` imports; it does not contain a separate runtime.
+- ToolContext and Durable integration are development-track source and are not
+  exported by the published React 2 artifact.
 
 ## Optimization Achievements
 
@@ -43,11 +43,11 @@ import { StoreRegistry, useComputedStore, deepCloneWithImmer } from '@context-ac
 // Includes all advanced features, loads Immer dynamically only when deepCloneWithImmer is called
 ```
 
-### Tool calling (explicit opt-in)
-```typescript
-import { createToolContext } from '@context-action/react/tools';
-// Install @context-action/tool-protocol and zod when this entry is used.
-```
+### Tool calling
+
+ToolContext and Durable integration are intentionally excluded from the public
+React 2 package while their protocol and recovery contract remain in active
+development. They do not contribute to the Store/Action consumer bundle.
 
 ## Verification
 


### PR DESCRIPTION
## Summary\n- document the main React import path for React 18 and 19\n- clarify that the react18 subpath is type compatibility, not a second runtime\n- align library and bundle documentation with the React 2 public artifact boundary\n\nSpecification: CA-COORDINATED-STABLE-2026-08\n\n## Validation\n- pnpm change:traceability\n- pnpm docs:build\n- pnpm example:build\n- git diff --check