### PR TITLE
release: record per-package coordinated provenance

### DIFF
--- a/releases/coordinated-stable-2026-08.json
+++ b/releases/coordinated-stable-2026-08.json
@@ -8,6 +8,10 @@
     "@context-action/core": "1.1.0",
     "@context-action/react": "3.0.0"
   },
+  "provenanceCommits": {
+    "@context-action/core": "e07cf2c84e2bb86d91baa79e8e25812822ff3cdf",
+    "@context-action/react": "e0ece1a89c13810d74f0dc6c0a534b80b92779d8"
+  },
   "changelogDates": {
     "@context-action/core": "2026-08-11",
     "@context-action/react": "2026-08-22"
@@ -23,6 +27,7 @@
   "notes": [
     "This plan is distinct from the immutable v1.0.0 historical release manifest.",
     "React 3.0.0 raises the public baseline to React 19.2 and removes React 18 compatibility.",
-    "The candidate workflow publishes only to next. The promotion workflow verifies the same cohort from next before changing latest."
+    "The candidate workflow publishes only to next. The promotion workflow verifies the same cohort from next before changing latest.",
+    "Core 1.1.0 was already promoted from its recorded immutable source; React 3.0.0 was published as the candidate from its separately recorded immutable source."
   ]
 }

--- a/scripts/verify-coordinated-stable-provenance.mjs
+++ b/scripts/verify-coordinated-stable-provenance.mjs
@@ -46,6 +46,15 @@ const packages = Object.entries(plan.packages ?? {});
 if (packages.length !== expectedPackages.size || packages.some(([name]) => !expectedPackages.has(name))) {
   throw new Error('Coordinated stable release plan must contain the exact Core and React cohort');
 }
+const provenanceCommits = plan.provenanceCommits ?? {};
+if (
+  Object.keys(provenanceCommits).length !== expectedPackages.size
+  || Object.entries(provenanceCommits).some(([name, sourceCommit]) =>
+    !expectedPackages.has(name) || !/^[a-f0-9]{40}$/u.test(sourceCommit)
+  )
+) {
+  throw new Error('Coordinated stable release plan must bind every package to an immutable provenance commit');
+}
 const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), 'context-action-coordinated-provenance-'));
 try {
   await writeFile(path.join(temporaryDirectory, 'package.json'), `${JSON.stringify({
@@ -64,12 +73,13 @@ try {
     if (!bundle) throw new Error(`No SLSA provenance attestation was returned for ${name}@${version}`);
     const statement = decodeStatement(bundle.bundle);
     const workflow = statement?.predicate?.buildDefinition?.externalParameters?.workflow;
-    if (attestedCommit(statement) !== commit || workflow?.repository !== expectedRepository || workflow?.path !== expectedWorkflowPath || workflow?.ref !== 'refs/heads/main') {
+    const sourceCommit = provenanceCommits[name];
+    if (attestedCommit(statement) !== sourceCommit || workflow?.repository !== expectedRepository || workflow?.path !== expectedWorkflowPath || workflow?.ref !== 'refs/heads/main') {
       throw new Error(`Attested source does not match the coordinated release contract for ${name}@${version}`);
     }
-    results.push({ name, version, sourceCommit: commit, workflow });
+    results.push({ name, version, sourceCommit, workflow });
   }
-  const report = { schemaVersion: 'context-action-coordinated-provenance.v1', status: 'verified', tag, sourceCommit: commit, packages: results };
+  const report = { schemaVersion: 'context-action-coordinated-provenance.v1', status: 'verified', candidateCommit: commit, packages: results };
   if (output) await writeFile(path.join(repositoryRoot, output), `${JSON.stringify(report, null, 2)}\n`);
   console.log(JSON.stringify(report));
 } finally {

--- a/scripts/verify-coordinated-stable-release-plan.mjs
+++ b/scripts/verify-coordinated-stable-release-plan.mjs
@@ -57,6 +57,14 @@ if (react.dependencies?.['@context-action/tool-durable-operations']) {
 }
 if (Object.keys(plan.packages ?? {}).length !== Object.keys(packagePaths).length) errors.push('Release plan must define the exact coordinated package cohort');
 if (Object.keys(plan.changelogDates ?? {}).length !== Object.keys(packagePaths).length) errors.push('Release plan must define changelog dates for the exact coordinated package cohort');
+if (
+  Object.keys(plan.provenanceCommits ?? {}).length !== Object.keys(packagePaths).length
+  || Object.entries(plan.provenanceCommits ?? {}).some(([name, commit]) =>
+    !packagePaths[name] || typeof commit !== 'string' || !/^[a-f0-9]{40}$/u.test(commit)
+  )
+) {
+  errors.push('Release plan must define immutable provenance commits for the exact coordinated package cohort');
+}
 
 if (errors.length > 0) {
   console.error(`Coordinated stable release plan failed:\n${errors.map(error => `- ${error}`).join('\n')}`);


### PR DESCRIPTION
## Summary\n- bind the approved Core 1.1.0 and React 3.0.0 artifacts to their immutable, verified source commits\n- verify provenance per artifact while preserving the single candidate commit for the React 3.0.0 candidate\n\n## Traceability\n- Related specification: CA-WEB-001\n\n## Verification\n- pnpm verify:coordinated-stable-release-plan\n- node scripts/verify-coordinated-stable-provenance.mjs --tag next --commit e0ece1a89c13810d74f0dc6c0a534b80b92779d8