### PR TITLE
docs: support Interface Intent integration profile

### DIFF
--- a/catalog/integration-profiles/interface-intent-runtime.v1.json
+++ b/catalog/integration-profiles/interface-intent-runtime.v1.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": "context-action.integration-profile/v1",
   "id": "interface-intent-runtime",
-  "status": "verified",
+  "status": "supported",
   "lifecycle": {
     "states": ["draft", "registered", "verified", "supported", "deprecated"],
-    "current": "verified"
+    "current": "supported"
   },
   "compatibility": {
     "core": "^1.1.0",
@@ -36,7 +36,12 @@
     {
       "id": "macrostructure-first-reference-v0.4.0",
       "role": "runtime adapter",
-      "status": "verified"
+      "status": "supported"
     }
-  ]
+  ],
+  "supportEvidence": {
+    "consumerRepository": "https://github.com/mineclover/macrostructure-first-reference",
+    "release": "https://github.com/mineclover/macrostructure-first-reference/releases/tag/v0.4.0",
+    "hostedCi": "https://github.com/mineclover/macrostructure-first-reference/actions/runs/32627435068"
+  }
 }

--- a/docs/en/context-layered/integration-profiles.md
+++ b/docs/en/context-layered/integration-profiles.md
@@ -18,7 +18,7 @@ compatibility, and evidence requirements.
 ## Interface Intent runtime profile
 
 [`interface-intent-runtime`](../../../catalog/integration-profiles/interface-intent-runtime.v1.json)
-is currently **verified**. It supplies four typed actions (`scope.select`,
+is currently **supported**. It supplies four typed actions (`scope.select`,
 `scene.select`, `compile.run`, `evaluate.run`) and requires document refs,
 revision cancellation, and a pure compiler/evaluator boundary. The canonical
 Interface Intent documents remain external authorities; runtime state may hold

--- a/docs/ko/context-layered/integration-profiles.md
+++ b/docs/ko/context-layered/integration-profiles.md
@@ -17,7 +17,7 @@ lifecycle·상태 소유권·호환성·증빙 조건을 catalog로 공급합니
 ## Interface Intent runtime profile
 
 [`interface-intent-runtime`](../../../catalog/integration-profiles/interface-intent-runtime.v1.json)은
-현재 **verified** 상태입니다. `scope.select`, `scene.select`, `compile.run`,
+현재 **supported** 상태입니다. `scope.select`, `scene.select`, `compile.run`,
 `evaluate.run` 네 typed action을 공급하며, document ref·revision cancellation·순수
 compiler/evaluator 경계를 요구합니다. 원본 Interface Intent 문서는 외부 authority로
 남고 runtime에는 ref·선택·실행 상태·파생 evidence만 둡니다.

--- a/llmsData/en/context-layered--integration-profiles/priority.json
+++ b/llmsData/en/context-layered--integration-profiles/priority.json
@@ -190,7 +190,7 @@
     "version": "1.0.0",
     "original_size": 1700,
     "created_at": "2026-08-23T04:57:44.424Z",
-    "source_last_modified": "2026-08-23T05:11:06.142Z",
+    "source_last_modified": "2026-08-23T09:40:47.113Z",
     "keywords": {
       "primary": [
         "context-layered",
@@ -209,6 +209,6 @@
         "framework"
       ]
     },
-    "last_updated": "2026-08-23T05:11:14.578Z"
+    "last_updated": "2026-08-23T09:42:00.303Z"
   }
 }

--- a/llmsData/ko/context-layered--integration-profiles/priority.json
+++ b/llmsData/ko/context-layered--integration-profiles/priority.json
@@ -190,7 +190,7 @@
     "version": "1.0.0",
     "original_size": 1725,
     "created_at": "2026-08-23T04:57:50.657Z",
-    "source_last_modified": "2026-08-23T05:11:06.143Z",
+    "source_last_modified": "2026-08-23T09:40:47.114Z",
     "keywords": {
       "primary": [
         "context-layered",
@@ -209,6 +209,6 @@
         "framework"
       ]
     },
-    "last_updated": "2026-08-23T05:11:14.808Z"
+    "last_updated": "2026-08-23T09:42:00.562Z"
   }
 }

--- a/scripts/verify-integration-profile-catalog.mjs
+++ b/scripts/verify-integration-profile-catalog.mjs
@@ -25,6 +25,13 @@ for (const file of profiles) {
   if (!profile.ownership?.forbiddenRuntimeState?.includes('canonicalDocumentCopies')) fail(`${file} must forbid canonical document copies`);
   if (!Array.isArray(profile.requiredEvidence) || profile.requiredEvidence.length < 4) fail(`${file} must require lifecycle evidence`);
   if (!Array.isArray(profile.registeredConsumers) || profile.registeredConsumers.length === 0) fail(`${file} must register at least one consumer`);
+  if (profile.status === 'supported') {
+    const evidence = profile.supportEvidence;
+    if (!evidence || !/^https:\/\/github\.com\/[^/]+\/[^/]+\/releases\/tag\/v\d+\.\d+\.\d+$/u.test(evidence.release)
+      || !/^https:\/\/github\.com\/[^/]+\/[^/]+\/actions\/runs\/\d+$/u.test(evidence.hostedCi)) {
+      fail(`${file} must bind supported state to immutable consumer release and hosted CI evidence`);
+    }
+  }
 }
 
 console.log(JSON.stringify({ status: 'ok', profiles }));


### PR DESCRIPTION
## Summary\n- promote the Interface Intent runtime integration profile to supported\n- require immutable consumer release and hosted CI evidence in the profile catalog\n\n## Evidence\n- consumer release: https://github.com/mineclover/macrostructure-first-reference/releases/tag/v0.4.0\n- consumer hosted CI: https://github.com/mineclover/macrostructure-first-reference/actions/runs/32627435068\n\n## Verification\n- pnpm integration-profile:check\n- node scripts/verify-context-action-conventions.mjs\n- pnpm llms:check